### PR TITLE
Run tests when bumping the dependencies or changing the pipeline in order to get confirmation that everything is ok

### DIFF
--- a/.github/workflows/run-tests-generate-output.yaml
+++ b/.github/workflows/run-tests-generate-output.yaml
@@ -18,22 +18,6 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    steps:
-    permission:
-      pull-requests: read
-    outputs:
-      uploadoutputfiles: ${{ steps.filter.outputs.uploadoutputfiles }}
-    steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            uploadoutputfiles:
-              - 'sources/**'
-              - 'scripts/convert**'
-              - 'resources/templates/**'
   runtests:
     name: Run Tests
     runs-on: ubuntu-latest
@@ -90,7 +74,22 @@ jobs:
         run: pipenv run flake8 --max-line-length=120 --max-complexity=10 --ignore=E203,W503
       - name: Check formatting of files for correct spelling and namespace names
         run: pipenv run mypy --namespace-packages --strict ./scripts/
-
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+    permission:
+      pull-requests: read
+    outputs:
+      uploadoutputfiles: ${{ steps.filter.outputs.uploadoutputfiles }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            uploadoutputfiles:
+              - 'sources/**'
+              - 'scripts/convert**'
+              - 'resources/templates/**'
   # If Tests pass, generate new output files
   uploadoutputfiles:
     name: Upload Output Files

--- a/.github/workflows/run-tests-generate-output.yaml
+++ b/.github/workflows/run-tests-generate-output.yaml
@@ -9,6 +9,8 @@ on:
       - 'sources/**'
       - 'scripts/convert**'
       - 'resources/templates/**'
+      - 'Pipfile'
+      - '.github/workflows/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/run-tests-generate-output.yaml
+++ b/.github/workflows/run-tests-generate-output.yaml
@@ -18,6 +18,22 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+    permission:
+      pull-requests: read
+    outputs:
+      uploadoutputfiles: ${{ steps.filter.outputs.uploadoutputfiles }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            uploadoutputfiles:
+              - 'sources/**'
+              - 'scripts/convert**'
+              - 'resources/templates/**'
   runtests:
     name: Run Tests
     runs-on: ubuntu-latest
@@ -78,6 +94,8 @@ jobs:
   # If Tests pass, generate new output files
   uploadoutputfiles:
     name: Upload Output Files
+    needs: changes
+    if: ${{ needs.changes.outputs.uploadoutputfiles == 'true' }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
It's a "good" practice to run the tests and generate artifacts when patching the dependencies or the pipeline as well. It should make it safer to merge in dependencies and pipeline updates.