### PR TITLE
Ensure ASVS mapping can be processed programaticly.

### DIFF
--- a/source/ecommerce-mappings-1.3.yaml
+++ b/source/ecommerce-mappings-1.3.yaml
@@ -18,7 +18,7 @@ suits:
   -
     value: "3"
     owasp_scp: [ ]
-    owasp_asvs: [ 1.5.3, 5.1.1-5.1.4, 13.2.1, 14.1.2, 14.4.1 ]
+    owasp_asvs: [ 1.5.3, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 13.2.1, 14.1.2, 14.4.1 ]
     owasp_appsensor: [ RE7-8, AE4-7, IE2-3, CIE1, CIE3-4, HT1-3 ]
     capec: [ 28, 48, 126, 165, 213, 220, 221, 261, 262, 271, 272 ]
     safecode: [ 3, 16, 24, 35 ]
@@ -67,7 +67,7 @@ suits:
   -
     value: "10"
     owasp_scp: [ 2, 19, 92, 95, 180 ]
-    owasp_asvs: [ 1.12.2, 5.1.3, 9.2.3, 12.2.1, 12.3.1-12.3.3, 12.4.2, 12.5.2, 14.5.3 ]
+    owasp_asvs: [ 1.12.2, 5.1.3, 9.2.3, 12.2.1, 12.3.1, 12.3.2, 12.3.3, 12.4.2, 12.5.2, 14.5.3 ]
     owasp_appsensor: [ IE4, IE5 ]
     capec: [ 12, 51, 57, 90, 111, 145, 194, 195, 202, 218, 463 ]
     safecode: [ 14 ]
@@ -88,7 +88,7 @@ suits:
   -
     value: "K"
     owasp_scp: [ 15, 19, 20, 21, 22, 167, 180, 204, 211, 212 ]
-    owasp_asvs: [ 5.2.1, 5.2.2, 5.3.4, 5.3.7-5.3.10, ]
+    owasp_asvs: [ 5.2.1, 5.2.2, 5.3.4, 5.3.7, 5.3.8, 5.3.9, 5.3.10 ]
     owasp_appsensor: [ CIE1, CIE2 ]
     capec: [ 23, 28, 76, 152, 160, 261 ]
     safecode: [ 2, 19, 20 ]
@@ -98,7 +98,7 @@ suits:
   -
     value: "2"
     owasp_scp: [ 47, 52 ]
-    owasp_asvs: [ 2.5.2, 7.1.2, 7.1.4, 7.2.1, 8.2.1-8.2.3, 8.3.6 ]
+    owasp_asvs: [ 2.5.2, 7.1.2, 7.1.4, 7.2.1, 8.2.1, 8.2.2, 8.2.3, 8.3.6 ]
     owasp_appsensor: [ UT1 ]
     capec: [ ]
     safecode: [ 28 ]
@@ -175,7 +175,7 @@ suits:
   -
     value: "K"
     owasp_scp: [ 24 ]
-    owasp_asvs: [ 4.1.1, 10.2.3-10.2.6 ]
+    owasp_asvs: [ 4.1.1, 10.2.3, 10.2.4, 10.2.5, 10.2.6 ]
     owasp_appsensor: [ ]
     capec: [ 115, 207, 554 ]
     safecode: [ 14, 28 ]
@@ -199,7 +199,7 @@ suits:
   -
     value: "4"
     owasp_scp: [ 59, 61 ]
-    owasp_asvs: [ 3.4.1-3.4.5 ]
+    owasp_asvs: [ 3.4.1, 3.4.2, 3.4.3, 3.4.4, 3.4.5 ]
     owasp_appsensor: [ SE2 ]
     capec: [ 31, 61 ]
     safecode: [ 28 ]
@@ -213,7 +213,7 @@ suits:
   -
     value: "6"
     owasp_scp: [ 64, 65 ]
-    owasp_asvs: [ 3.3.2-3.3.4 ]
+    owasp_asvs: [ 3.3.2, 3.3.3, 3.3.4 ]
     owasp_appsensor: [ SE5, SE6 ]
     capec: [ 21 ]
     safecode: [ 28 ]
@@ -227,7 +227,7 @@ suits:
   -
     value: "8"
     owasp_scp: [ 96 ]
-    owasp_asvs: [3.6.1, 3.3.2 ]
+    owasp_asvs: [ 3.6.1, 3.3.2 ]
     owasp_appsensor: [ ]
     capec: [ 21 ]
     safecode: [ 28 ]
@@ -248,7 +248,7 @@ suits:
   -
     value: "J"
     owasp_scp: [ ]
-    owasp_asvs: [ 11.1.1-11.1.3 ]
+    owasp_asvs: [ 11.1.1, 11.1.2, 11.1.3 ]
     owasp_appsensor: [ IE5 ]
     capec: [ 60 ]
     safecode: [ 12, 14 ]
@@ -335,7 +335,7 @@ suits:
   -
     value: "J"
     owasp_scp: [ 89, 90 ]
-    owasp_asvs: [ 4.1.2, 10.2.3, 10.2.3-10.2.6 ]
+    owasp_asvs: [ 4.1.2, 10.2.3, 10.2.3, 10.2.4, 10.2.5, 10.2.6 ]
     owasp_appsensor: [ ]
     capec: [ 75, 133, 203 ]
     safecode: [ 8, 10, 11 ]
@@ -349,7 +349,7 @@ suits:
   -
     value: "K"
     owasp_scp: [ 77, 89, 91 ]
-    owasp_asvs: [ 4.1.1, 4.1.2, 10.2.3-10.2.6 ]
+    owasp_asvs: [ 4.1.1, 4.1.2, 10.2.3, 10.2.4, 10.2.5, 10.2.6 ]
     owasp_appsensor: [ ]
     capec: [ 207, 554 ]
     safecode: [ 8, 10, 11 ]
@@ -366,7 +366,7 @@ suits:
   -
     value: "3"
     owasp_scp: [ 92, 205, 212 ]
-    owasp_asvs: [ 14.1.1, 14.1.4, 14.1.5, 10.2.3-10.2.6, 10.3.1, 10.3.2 ]
+    owasp_asvs: [ 14.1.1, 14.1.4, 14.1.5, 10.2.3, 10.2.4, 10.2.5, 10.2.6, 10.3.1, 10.3.2 ]
     owasp_appsensor: [ SE1, IE4 ]
     capec: [ 31, 39, 68, 75, 133, 145, 162, 203, 438, 439, 442 ]
     safecode: [ 12, 14 ]
@@ -502,7 +502,7 @@ suits:
   -
     value: "10"
     owasp_scp: [ 57, 151, 152, 204, 205, 213, 214 ]
-    owasp_asvs: [ 1.14.3, 10.1.1, 10.2.3-10.2.6, 14.2.1 ]
+    owasp_asvs: [ 1.14.3, 10.1.1, 10.2.3, 10.2.4, 10.2.5, 10.2.6, 14.2.1 ]
     owasp_appsensor: [ ]
     capec: [ 68, 438, 439, 442, 524, 538 ]
     safecode: [ 15 ]
@@ -516,7 +516,7 @@ suits:
   -
     value: "Q"
     owasp_scp: [ ]
-    owasp_asvs: [ 8.1.4, 11.1.1-11.1.4 ]
+    owasp_asvs: [ 8.1.4, 11.1.1, 11.1.2, 11.1.3, 11.1.4 ]
     owasp_appsensor: [ (All) ]
     capec: [ ]
     safecode: [ 1, 27 ]


### PR DESCRIPTION
In order to be able to create proper links, and process the mapping codes individually, we need to specify each code separately explicitly and not implicitly with an n-dash.