### PR TITLE
Ensure whitespace doesn't get trimmed when the text placeholders are replaced inside the paragraph.

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -863,7 +863,6 @@ def replace_text_in_xml_file(filename: str, replacement_dict: Dict[str, str]) ->
             continue
         el.text = get_replacement_value_from_dict(el.text, replacement_values)
         with open(filename, "bw") as f:
-            tree.write("output/test_leaflet.xml")
             f.write(ElTree.tostring(tree.getroot(), encoding="utf-8"))
 
 

--- a/tests/scripts/convert_utest.py
+++ b/tests/scripts/convert_utest.py
@@ -1488,7 +1488,6 @@ class Test1(unittest.TestCase):
         self.replacement_values = [
             ("${VE_suit}", "Validation & Encoding"),
             ("${VE_VE2_desc}", "You have invented a new attack against Data Validation and Encoding"),
-            ("${VE_VE2_misc'}", "Read more about this topic in OWASP's free Cheat Sheets"),
             ("${WC_suit}", "Wild Card"),
             ("${WC_JokerA_desc}", "Alice can utilize the application to attack users' systems and data"),
         ]
@@ -1506,21 +1505,7 @@ class Test1(unittest.TestCase):
 
     def test_get_replacement_value_from_dict_spaced(self) -> None:
         input_text = " ${VE_VE2_desc} "
-        want_data = "You have invented a new attack against Data Validation and Encoding"
-
-        got_data = c.get_replacement_value_from_dict(input_text, self.replacement_values)
-        self.assertEqual(want_data, got_data)
-
-    def test_get_replacement_value_from_dict_inverts(self) -> None:
-        input_text = "${VE_VE2_misc’}"
-        want_data = "Read more about this topic in OWASP's free Cheat Sheets"
-
-        got_data = c.get_replacement_value_from_dict(input_text, self.replacement_values)
-        self.assertEqual(want_data, got_data)
-
-    def test_get_replacement_value_from_dict_lowers(self) -> None:
-        input_text = "${ve_ve2_misc’}"
-        want_data = "Read more about this topic in OWASP's free Cheat Sheets"
+        want_data = " You have invented a new attack against Data Validation and Encoding "
 
         got_data = c.get_replacement_value_from_dict(input_text, self.replacement_values)
         self.assertEqual(want_data, got_data)


### PR DESCRIPTION
In this pull-request:
- Improve the consistency and readability for the asvs, capec, scp and appsensor code tables 
- Support for having multiple text placeholders within the same paragraph without getting tabs, space and other whitespace characters stripped. Needed for correctly being able to build the leaflet.

I found some complicated code related to the replacing the text placeholders correctly even if the case was wrong. Very considerate, but it added a lot of complexity that didn't really take away the need for doing QA so I removed it. (only used for the idml files btw.)

[owasp_cornucopia_ecommerce_cards_en_1.30_leaflet.pdf](https://github.com/OWASP/cornucopia/files/15123285/owasp_cornucopia_ecommerce_cards_en_1.30_leaflet.pdf)

[owasp_cornucopia_ecommerce_cards_en_1.30_static.pdf](https://github.com/OWASP/cornucopia/files/15123287/owasp_cornucopia_ecommerce_cards_en_1.30_static.pdf)
