### PR TITLE
Cw owasp patch 1

### DIFF
--- a/source/ecommerce-cards-1.30-en.yaml
+++ b/source/ecommerce-cards-1.30-en.yaml
@@ -35,7 +35,7 @@ suits:
   -
     id: "DV8"
     value: "8"
-    desc: "Sarah can bypass the centralized sanitization routines since they are not being used comprehensively"
+    desc: "Oana can bypass the centralized sanitization routines since they are not being used comprehensively"
   -
     id: "DV9"
     value: "9"
@@ -47,7 +47,7 @@ suits:
   -
     id: "DVJ"
     value: "J"
-    desc: "Dennis has control over input validation, output validation or output encoding code or routines so they can be bypassed"
+    desc: "Toby has control over input validation, output validation or output encoding code or routines so they can be bypassed"
   -
     id: "DVQ"
     value: "Q"
@@ -143,7 +143,7 @@ suits:
   -
     id: "SM7"
     value: "7"
-    desc: "Casey can utilize Adam's session after he has finished, because there is no log out function, or he cannot easily log out, or log out does not properly terminate the session"
+    desc: "Graham can utilize Adam's session after he has finished, because there is no log out function, or he cannot easily log out, or log out does not properly terminate the session"
   -
     id: "SM8"
     value: "8"
@@ -275,7 +275,7 @@ suits:
   -
     id: "CRQ"
     value: "Q"
-    desc: "Randolph can access or predict the master cryptographic secrets"
+    desc: "Artim can access or predict the master cryptographic secrets"
   -
     id: "CRK"
     value: "K"
@@ -323,7 +323,7 @@ suits:
   -
     id: "COX"
     value: "10"
-    desc: "Xavier can circumvent the application's controls because code frameworks, libraries and components contain malicious code or vulnerabilities (e.g. in-house, commercial off the shelf, outsourced, open source, externally-located)"
+    desc: "Spyros can circumvent the application's controls because code frameworks, libraries and components contain malicious code or vulnerabilities (e.g. in-house, commercial off the shelf, outsourced, open source, externally-located)"
   -
     id: "COJ"
     value: "J"
@@ -335,7 +335,7 @@ suits:
   -
     id: "COK"
     value: "K"
-    desc: "Gareth can utilize the application to deny service to some or all of its users"
+    desc: "Grant can utilize the application to deny service to some or all of its users"
   -
     id: "COA"
     value: "A"

--- a/source/ecommerce-cards-1.30-es.yaml
+++ b/source/ecommerce-cards-1.30-es.yaml
@@ -35,7 +35,7 @@ suits:
   -
     id: "DV8"
     value: "8"
-    desc: "Sarah puede pasar por alto las rutinas de sanitización centralizadas ya que no están siendo utilizadas exhaustivamente"
+    desc: "Oana puede pasar por alto las rutinas de sanitización centralizadas ya que no están siendo utilizadas exhaustivamente"
   -
     id: "DV9"
     value: "9"
@@ -47,7 +47,7 @@ suits:
   -
     id: "DVJ"
     value: "J"
-    desc: "Dennis tiene control sobre la validación de entrada, la validación de salida o código de codificación de salida o rutinas para que puedan ser evitados"
+    desc: "Toby tiene control sobre la validación de entrada, la validación de salida o código de codificación de salida o rutinas para que puedan ser evitados"
   -
     id: "DVQ"
     value: "Q"
@@ -143,7 +143,7 @@ suits:
   -
     id: "SM7"
     value: "7"
-    desc: "Casey puede utilizar la sesión de Adam después de que haya terminado, porque no hay una función de cierre de sesión, o no puede cerrar sesión fácilmente, o el cierre de sesión no termina la sesión correctamente"
+    desc: "Graham puede utilizar la sesión de Adam después de que haya terminado, porque no hay una función de cierre de sesión, o no puede cerrar sesión fácilmente, o el cierre de sesión no termina la sesión correctamente"
   -
     id: "SM8"
     value: "8"
@@ -275,7 +275,7 @@ suits:
   -
     id: "CRQ"
     value: "Q"
-    desc: "Randolph puede acceder o predecir los algoritmos o llaves de los secretos criptográficos"
+    desc: "Artim puede acceder o predecir los algoritmos o llaves de los secretos criptográficos"
   -
     id: "CRK"
     value: "K"
@@ -323,7 +323,7 @@ suits:
   -
     id: "COX"
     value: "10"
-    desc: "Xavier puede eludir los controles de la aplicación porque los frameworks de código, librerías y componentes contienen código malicioso o vulnerabilidades (por ejemplo, inhouse, software comercial, servicio tercerizado, de código abierto, ubicado externamente)"
+    desc: "Spyros puede eludir los controles de la aplicación porque los frameworks de código, librerías y componentes contienen código malicioso o vulnerabilidades (por ejemplo, inhouse, software comercial, servicio tercerizado, de código abierto, ubicado externamente)"
   -
     id: "COJ"
     value: "J"
@@ -335,7 +335,7 @@ suits:
   -
     id: "COK"
     value: "K"
-    desc: "Gareth puede utilizar la aplicación para negar el servicio a algunos o todos sus usuarios"
+    desc: "Grant puede utilizar la aplicación para negar el servicio a algunos o todos sus usuarios"
   -
     id: "COA"
     value: "A"

--- a/source/ecommerce-cards-1.30-fr.yaml
+++ b/source/ecommerce-cards-1.30-fr.yaml
@@ -35,7 +35,7 @@ suits:
   -
     id: "DV8"
     value: "8"
-    desc: "Sarah peut contourner les routines de sanitisation centralisées, car celles-ci ne sont pas pleinement utilisées"
+    desc: "Oana peut contourner les routines de sanitisation centralisées, car celles-ci ne sont pas pleinement utilisées"
   -
     id: "DV9"
     value: "9"
@@ -47,7 +47,7 @@ suits:
   -
     id: "DVJ"
     value: "J"
-    desc: "Dennis a le contrôle sur la validation des saisies, la validation des sorties, ou le code d'encodage des sorties, ou les routines, de telle manière que celles-ci peuvent être contournées"
+    desc: "Toby a le contrôle sur la validation des saisies, la validation des sorties, ou le code d'encodage des sorties, ou les routines, de telle manière que celles-ci peuvent être contournées"
   -
     id: "DVQ"
     value: "Q"
@@ -143,7 +143,7 @@ suits:
   -
     id: "SM7"
     value: "7"
-    desc: "Casey peut utiliser la session d'Adam après qu'il ait terminé, car il n'existe pas de fonction de déconnexion, ou il ne peut pas se déconnecter facilement, ou la déconnexion ne clôt pas proprement la session"
+    desc: "Graham peut utiliser la session d'Adam après qu'il ait terminé, car il n'existe pas de fonction de déconnexion, ou il ne peut pas se déconnecter facilement, ou la déconnexion ne clôt pas proprement la session"
   -
     id: "SM8"
     value: "8"
@@ -275,7 +275,7 @@ suits:
   -
     id: "CRQ"
     value: "Q"
-    desc: "Randolph peut accéder ou prédire les secrets cryptographiques maîtres"
+    desc: "Artim peut accéder ou prédire les secrets cryptographiques maîtres"
   -
     id: "CRK"
     value: "K"
@@ -323,7 +323,7 @@ suits:
   -
     id: "COX"
     value: "10"
-    desc: "Xavier peut contourner les contrôles de l'application car les frameworks, les bibliothèques et les composants applicatifs contiennent du code malveillant ou des vulnérabilités (par exemple: interne, sur étagère, externalisé, open source, externe)"
+    desc: "Spyros peut contourner les contrôles de l'application car les frameworks, les bibliothèques et les composants applicatifs contiennent du code malveillant ou des vulnérabilités (par exemple: interne, sur étagère, externalisé, open source, externe)"
   -
     id: "COJ"
     value: "J"
@@ -335,7 +335,7 @@ suits:
   -
     id: "COK"
     value: "K"
-    desc: "Gareth peut utiliser l'application pour refuser le service à certains ou à tous ses utilisateurs"
+    desc: "Grant peut utiliser l'application pour refuser le service à certains ou à tous ses utilisateurs"
   -
     id: "COA"
     value: "A"

--- a/source/ecommerce-cards-1.30-nl.yaml
+++ b/source/ecommerce-cards-1.30-nl.yaml
@@ -35,7 +35,7 @@ suits:
   -
     id: "DV8"
     value: "8"
-    desc: "Sarah kan de gecentraliseerde reinigingsroutines omzeilen omdat ze niet volledig worden gebruikt"
+    desc: "Oana kan de gecentraliseerde reinigingsroutines omzeilen omdat ze niet volledig worden gebruikt"
   -
     id: "DV9"
     value: "9"
@@ -47,7 +47,7 @@ suits:
   -
     id: "DVJ"
     value: "J"
-    desc: "Dennis heeft controle over invoervalidatie, uitvoervalidatie of uitvoercoderingscode of routines zodat ze kunnen worden omzeild"
+    desc: "Toby heeft controle over invoervalidatie, uitvoervalidatie of uitvoercoderingscode of routines zodat ze kunnen worden omzeild"
   -
     id: "DVQ"
     value: "Q"
@@ -143,7 +143,7 @@ suits:
   -
     id: "SM7"
     value: "7"
-    desc: "Casey kan de sessie van Adam gebruiken nadat hij klaar is, omdat er geen uitlogfunctie is, of hij kan niet gemakkelijk uitloggen, of uitloggen beëindigt de sessie niet correct"
+    desc: "Graham kan de sessie van Adam gebruiken nadat hij klaar is, omdat er geen uitlogfunctie is, of hij kan niet gemakkelijk uitloggen, of uitloggen beëindigt de sessie niet correct"
   -
     id: "SM8"
     value: "8"
@@ -275,7 +275,7 @@ suits:
   -
     id: "CRQ"
     value: "Q"
-    desc: "Randolph kan de hoofdcryptografische geheimen openen of voorspellen"
+    desc: "Artim kan de hoofdcryptografische geheimen openen of voorspellen"
   -
     id: "CRK"
     value: "K"
@@ -323,7 +323,7 @@ suits:
   -
     id: "COX"
     value: "10"
-    desc: "Xavier kan de controles van de applicatie omzeilen omdat codeframeworks, bibliotheken en componenten kwaadaardige code of kwetsbaarheden bevatten (bijv. intern, commercieel kant-en-klaar, uitbesteed, open source, extern gelokaliseerd)"
+    desc: "Spyros kan de controles van de applicatie omzeilen omdat codeframeworks, bibliotheken en componenten kwaadaardige code of kwetsbaarheden bevatten (bijv. intern, commercieel kant-en-klaar, uitbesteed, open source, extern gelokaliseerd)"
   -
     id: "COJ"
     value: "J"
@@ -335,7 +335,7 @@ suits:
   -
     id: "COK"
     value: "K"
-    desc: "Gareth kan de applicatie gebruiken om service aan sommige of alle gebruikers te weigeren"
+    desc: "Grant kan de applicatie gebruiken om service aan sommige of alle gebruikers te weigeren"
   -
     id: "COA"
     value: "A"

--- a/source/ecommerce-cards-1.30-no_nb.yaml
+++ b/source/ecommerce-cards-1.30-no_nb.yaml
@@ -35,7 +35,7 @@ suits:
   -
     id: "DV8"
     value: "8"
-    desc: "Sarah kan omgå de sentraliserte datarensingsrutinene siden de ikke brukes fullt ut"
+    desc: "Oana kan omgå de sentraliserte datarensingsrutinene siden de ikke brukes fullt ut"
   -
     id: "DV9"
     value: "9"
@@ -47,7 +47,7 @@ suits:
   -
     id: "DVJ"
     value: "J"
-    desc: "Dennis has control over input validation, output validation or output encoding code or routines so they can be bypassed"
+    desc: "Toby has control over input validation, output validation or output encoding code or routines so they can be bypassed"
   -
     id: "DVQ"
     value: "Q"
@@ -143,7 +143,7 @@ suits:
   -
     id: "SM7"
     value: "7"
-    desc: "Casey kan benytte Adams økt etter at han er ferdig, fordi det ikke er noen utloggingsfunksjon, fordi han ikke enkelt kan logge ut, eller fordi utlogging ikke avslutter økten på riktig måte"
+    desc: "Graham kan benytte Adams økt etter at han er ferdig, fordi det ikke er noen utloggingsfunksjon, fordi han ikke enkelt kan logge ut, eller fordi utlogging ikke avslutter økten på riktig måte"
   -
     id: "SM8"
     value: "8"
@@ -275,7 +275,7 @@ suits:
   -
     id: "CRQ"
     value: "Q"
-    desc: "Randolph kan få tilgang til eller forutsi kryptografiske hovednøkler"
+    desc: "Artim kan få tilgang til eller forutsi kryptografiske hovednøkler"
   -
     id: "CRK"
     value: "K"
@@ -323,7 +323,7 @@ suits:
   -
     id: "COX"
     value: "10"
-    desc: "Xavier kan omgå applikasjonens kontroller fordi koderammeverk, biblioteker og komponenter inneholder ondsinnet kode eller sårbarheter i (f.eks. internt utviklede-, kommersielt ikke-standardiserte- eller tjenesteutsatte systemer , eller i systemer som benytter åpen kildekode eller er eksternt plassert)"
+    desc: "Spyros kan omgå applikasjonens kontroller fordi koderammeverk, biblioteker og komponenter inneholder ondsinnet kode eller sårbarheter i (f.eks. internt utviklede-, kommersielt ikke-standardiserte- eller tjenesteutsatte systemer , eller i systemer som benytter åpen kildekode eller er eksternt plassert)"
   -
     id: "COJ"
     value: "J"
@@ -335,7 +335,7 @@ suits:
   -
     id: "COK"
     value: "K"
-    desc: "Gareth kan bruke applikasjonen til å nekte noen eller alle brukerne tjenesten"
+    desc: "Grant kan bruke applikasjonen til å nekte noen eller alle brukerne tjenesten"
   -
     id: "COA"
     value: "A"

--- a/source/ecommerce-cards-1.30-pt_br.yaml
+++ b/source/ecommerce-cards-1.30-pt_br.yaml
@@ -35,7 +35,7 @@ suits:
   -
     id: "DV8"
     value: "8"
-    desc: "Sarah consegue ignorar as rotinas centralizadas de tratamento (sanitização) pois elas não estão sendo usadas de forma abrangente"
+    desc: "Oana consegue ignorar as rotinas centralizadas de tratamento (sanitização) pois elas não estão sendo usadas de forma abrangente"
   -
     id: "DV9"
     value: "9"
@@ -47,7 +47,7 @@ suits:
   -
     id: "DVJ"
     value: "J"
-    desc: "Dennis tem o controle sobre validações de entrada de dados, validações de saída de dados ou codificação de saída ou rotinas que ele consegue ignorar/burlar"
+    desc: "Toby tem o controle sobre validações de entrada de dados, validações de saída de dados ou codificação de saída ou rotinas que ele consegue ignorar/burlar"
   -
     id: "DVQ"
     value: "Q"
@@ -143,7 +143,7 @@ suits:
   -
     id: "SM7"
     value: "7"
-    desc: "Casey consegue utilizar a sessão de Adam depois dele ter finalizado o uso da aplicação, porque a função de logout inexiste, ou Adam não fez logout, ou a função de logout não termina a sessão de forma adequada"
+    desc: "Graham consegue utilizar a sessão de Adam depois dele ter finalizado o uso da aplicação, porque a função de logout inexiste, ou Adam não fez logout, ou a função de logout não termina a sessão de forma adequada"
   -
     id: "SM8"
     value: "8"
@@ -275,7 +275,7 @@ suits:
   -
     id: "CRQ"
     value: "Q"
-    desc: "Randolph consegue acessar ou prever os dados mestres de criptografia"
+    desc: "Artim consegue acessar ou prever os dados mestres de criptografia"
   -
     id: "CRK"
     value: "K"
@@ -323,7 +323,7 @@ suits:
   -
     id: "COX"
     value: "10"
-    desc: "Xavier consegue contornar os controles do aplicativo porque os códigos fontes tanto dos frameworks, como de bibliotecas e componentes utilizados contêm código malicioso ou vulnerabilidades"
+    desc: "Spyros consegue contornar os controles do aplicativo porque os códigos fontes tanto dos frameworks, como de bibliotecas e componentes utilizados contêm código malicioso ou vulnerabilidades"
   -
     id: "COJ"
     value: "J"
@@ -335,7 +335,7 @@ suits:
   -
     id: "COK"
     value: "K"
-    desc: "Gareth pode utilizar o aplicativo para negar o serviço a alguns ou a todos os usuários"
+    desc: "Grant pode utilizar o aplicativo para negar o serviço a alguns ou a todos os usuários"
   -
     id: "COA"
     value: "A"


### PR DESCRIPTION
Updated six attacker names (cards DV8, DVJ, SM7, CRQ, COX and COX) in the six v1.30 yaml language data files (but not in the v1.20, v1.21 yaml files). These assign some 2021-2023 project contributor names to existing cards.