### PR TITLE
Add id for each document

### DIFF
--- a/cornucopia.owasp.org/src/domain/cre/creController.ts
+++ b/cornucopia.owasp.org/src/domain/cre/creController.ts
@@ -46,7 +46,7 @@ export class CreController {
         if (!CreController.editions.has(edition)) return {"meta": {}, "standards": []};
         let standards: Cre[] = [];
         (this.deck || []).forEach(
-                (card: Card) => (card.edition == edition) && standards.push(this.generateDoc(card))
+                async (card: Card) => (card.edition == edition) && standards.push(this.generateDoc(card))
             );
         return {
             "meta": {
@@ -75,6 +75,7 @@ export class CreController {
         }));
         return {
             "doctype": "Tool",
+            "id": 'https://cornucopia.owasp.org' + card.url,
             "name": CreController.editions.get(card.edition),
             "section": card.suitNameLocal,
             "description": card.desc,
@@ -84,5 +85,16 @@ export class CreController {
             "tags": [],
             "tooltype": "Defensive"
         };
+    }
+
+    private static hash(id: string): Promise<string> {
+        const utf8 = new TextEncoder().encode(id);
+        return crypto.subtle.digest('SHA-256', utf8).then((hashBuffer) => {
+          const hashArray = Array.from(new Uint8Array(hashBuffer));
+          const hashHex = hashArray
+            .map((bytes) => bytes.toString(16).padStart(2, '0'))
+            .join('');
+          return hashHex;
+        });
     }
 }

--- a/cornucopia.owasp.org/src/domain/cre/creController.ts
+++ b/cornucopia.owasp.org/src/domain/cre/creController.ts
@@ -46,7 +46,7 @@ export class CreController {
         if (!CreController.editions.has(edition)) return {"meta": {}, "standards": []};
         let standards: Cre[] = [];
         (this.deck || []).forEach(
-                async (card: Card) => (card.edition == edition) && standards.push(this.generateDoc(card))
+                (card: Card) => (card.edition == edition) && standards.push(this.generateDoc(card))
             );
         return {
             "meta": {
@@ -85,16 +85,5 @@ export class CreController {
             "tags": [],
             "tooltype": "Defensive"
         };
-    }
-
-    private static hash(id: string): Promise<string> {
-        const utf8 = new TextEncoder().encode(id);
-        return crypto.subtle.digest('SHA-256', utf8).then((hashBuffer) => {
-          const hashArray = Array.from(new Uint8Array(hashBuffer));
-          const hashHex = hashArray
-            .map((bytes) => bytes.toString(16).padStart(2, '0'))
-            .join('');
-          return hashHex;
-        });
     }
 }


### PR DESCRIPTION
Adding a CRE id for each document. This can be anything, really, OWASP Juice Shop has chosen this format:

"OWASP Juice Shop:restfulXssChallenge:API-only XSS:https://demo.owasp-juice.shop//#/score-board?searchQuery=API-only%20XSS"

I thought just using the urls for each card probably is sufficient. Doesn't look like there is any need of creating a hash.

```
{
            "description": "Perform a <i>persisted</i> XSS attack with <code>&lt;iframe src=\"javascript:alert(`xss`)\"&gt;</code> without using the frontend application at all.",
            "doctype": "Tool",
            "hyperlink": "https://demo.owasp-juice.shop//#/score-board?searchQuery=API-only%20XSS",
            "id": "OWASP Juice Shop:restfulXssChallenge:API-only XSS:https://demo.owasp-juice.shop//#/score-board?searchQuery=API-only%20XSS",
            "links": [
                {
                    "document": {
                        "doctype": "CRE",
                        "id": "760-765",
                        "name": "XSS protection",
                        "tags": [
                            "Injection protection"
                        ]
                    },
                    "ltype": "Automatically linked to"
                }
            ],
            "name": "OWASP Juice Shop",
            "section": "API-only XSS",
            "sectionID": "restfulXssChallenge",
            "tags": [
                "XSS"
            ],
            "tooltype": "Training"
```