### PR TITLE
Remove links to secure delivery

### DIFF
--- a/copi.owasp.org/FLY.md
+++ b/copi.owasp.org/FLY.md
@@ -8,7 +8,7 @@ Fly.io support clustering Elixir apps which means that you can scale horizontall
 
 Make a note of the host and name of the app.
 
-Then deploy the app from copi.owas.org
+Then deploy the app from copi.owasp.org
 
     fly deploy --app <app name> --env PHX_HOST=<app hostname without 'https://'> --env DNS_CLUSTER_QUERY="<app name>.internal"
     fly scale count 2 --app <app name>

--- a/copi.owasp.org/README.md
+++ b/copi.owasp.org/README.md
@@ -95,7 +95,7 @@ Fly.io support clustering Elixir apps which means that you can scale horizontall
 
 Make a note of the host and name of the app.
 
-Then deploy the app from copi.owas.org
+Then deploy the app from copi.owasp.org
 
     fly deploy --app <app name> --env PHX_HOST=<app hostname without 'https://'> --env DNS_CLUSTER_QUERY="<app name>.internal"
     fly scale count 2 --app <app name>

--- a/copi.owasp.org/lib/copi_web/controllers/error_html/404.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/error_html/404.html.heex
@@ -56,16 +56,11 @@
       <div class="border-t border-white/10 pt-8 md:flex md:items-center md:justify-between">
         <div class="flex space-x-6 md:order-2">
 
-          <a href="https://github.com/secure-delivery/copi" class="text-gray-500 hover:text-gray-400">
+          <a href="https://github.com/OWASP/cornucopia/tree/master/copi.owasp.org" class="text-gray-500 hover:text-gray-400">
             <span class="sr-only">GitHub</span>
             <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
             </svg>
-          </a>
-
-           <a href="https://securedelivery.io/" class="opacity-50 hover:opacity-70">
-            <span class="sr-only">Secure Delivery</span>
-            <img src="/images/sd-logomark.png" class="h-6"  aria-hidden="true" />
           </a>
         </div>
         <div>

--- a/copi.owasp.org/lib/copi_web/controllers/error_html/500.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/error_html/500.html.heex
@@ -59,16 +59,11 @@
       <div class="border-t border-white/10 pt-8 md:flex md:items-center md:justify-between">
         <div class="flex space-x-6 md:order-2">
 
-          <a href="https://github.com/secure-delivery/copi" class="text-gray-500 hover:text-gray-400">
+          <a href="https://github.com/OWASP/cornucopia/tree/master/copi.owasp.org" class="text-gray-500 hover:text-gray-400">
             <span class="sr-only">GitHub</span>
             <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
             </svg>
-          </a>
-
-           <a href="https://securedelivery.io/" class="opacity-50 hover:opacity-70">
-            <span class="sr-only">Secure Delivery</span>
-            <img src="/images/sd-logomark.png" class="h-6"  aria-hidden="true" />
           </a>
         </div>
         <div>

--- a/copi.owasp.org/lib/copi_web/controllers/page_html/home.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/page_html/home.html.heex
@@ -59,16 +59,11 @@
       <div class="border-t border-white/10 pt-8 md:flex md:items-center md:justify-between">
         <div class="flex space-x-6 md:order-2">
           
-          <a href="https://github.com/secure-delivery/copi" class="text-gray-500 hover:text-gray-400">
+          <a href="https://github.com/OWASP/cornucopia/tree/master/copi.owasp.org" class="text-gray-500 hover:text-gray-400">
             <span class="sr-only">GitHub</span>
             <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
             </svg>
-          </a>
-
-           <a href="https://securedelivery.io/" class="opacity-50 hover:opacity-70">
-            <span class="sr-only">Secure Delivery</span>
-            <img src="/images/sd-logomark.png" class="h-6"  aria-hidden="true" />
           </a>
         </div>
         <div>

--- a/cornucopia.owasp.org/data/website/pages/copi/en/index.md
+++ b/cornucopia.owasp.org/data/website/pages/copi/en/index.md
@@ -109,7 +109,7 @@ Fly.io support clustering Elixir apps which means that you can scale horizontall
 
 Make a note of the host and name of the app.
 
-Then deploy the app from copi.owas.org
+Then deploy the app from copi.owasp.org
 
 ```bash
     fly deploy --app <app name> --env PHX_HOST=<app hostname without 'https://'> --env DNS_CLUSTER_QUERY="<app name>.internal"


### PR DESCRIPTION
In this pull-request:

- @rewtd If for some reason links to Secure Delivery should stay, please just close this pull-request.