### PR TITLE
Revert "Bump hexpm/elixir from 1.18.4-erlang-27.3.4-debian-bullseye-20250520-slim to 1.18.4-erlang-27.3.4-debian-bullseye-20250610-slim in /copi.owasp.org"

### DIFF
--- a/copi.owasp.org/Dockerfile
+++ b/copi.owasp.org/Dockerfile
@@ -12,7 +12,7 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.14.2-erlang-25.1.1-debian-bullseye-20220801-slim
 #
-FROM hexpm/elixir:1.18.4-erlang-27.3.4-debian-bullseye-20250610-slim@sha256:cb36bd08b46163e600594c2218b18a44364b7a8d2f0a776e8bd1289bb81be5e7 as builder
+FROM --platform=linux/amd64 hexpm/elixir:1.18.4-erlang-27.3.4-debian-bullseye-20250610@sha256:d93975b5e78b29fd62d6e7f74f4eaa7e1df165cc95d3525eaa2e333e1449bc2c as builder
 
 # install build dependencies
 RUN apt-get update -y && apt-get install -y build-essential git nodejs npm \

--- a/copi.owasp.org/Dockerfile
+++ b/copi.owasp.org/Dockerfile
@@ -12,7 +12,7 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.14.2-erlang-25.1.1-debian-bullseye-20220801-slim
 #
-FROM hexpm/elixir:1.18.4-erlang-27.3.4-debian-bullseye-20250520-slim@sha256:d93975b5e78b29fd62d6e7f74f4eaa7e1df165cc95d3525eaa2e333e1449bc2c as builder
+FROM hexpm/elixir:1.18.4-erlang-27.3.4-debian-bullseye-20250610-slim@sha256:cb36bd08b46163e600594c2218b18a44364b7a8d2f0a776e8bd1289bb81be5e7 as builder
 
 # install build dependencies
 RUN apt-get update -y && apt-get install -y build-essential git nodejs npm \

--- a/copi.owasp.org/Dockerfile
+++ b/copi.owasp.org/Dockerfile
@@ -12,7 +12,7 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.14.2-erlang-25.1.1-debian-bullseye-20220801-slim
 #
-FROM hexpm/elixir:1.18.4-erlang-27.3.4-debian-bullseye-20250610-slim@sha256:cb36bd08b46163e600594c2218b18a44364b7a8d2f0a776e8bd1289bb81be5e7 as builder
+FROM hexpm/elixir:1.18.4-erlang-27.3.4-debian-bullseye-20250520-slim@sha256:d93975b5e78b29fd62d6e7f74f4eaa7e1df165cc95d3525eaa2e333e1449bc2c as builder
 
 # install build dependencies
 RUN apt-get update -y && apt-get install -y build-essential git nodejs npm \


### PR DESCRIPTION
Reverts OWASP/cornucopia#1354

Crashes the build. Something is wrong with the image.