### PR TITLE
Add STRIDE corrections. Add code as text when displayed in the mapping table

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/mappingsList.svelte
+++ b/cornucopia.owasp.org/src/lib/components/mappingsList.svelte
@@ -3,17 +3,20 @@
     title: string;
     mappings: number[] | string[];
     linkFunction?: any;
+    textFunction?: any;
   }
 
-  let { title, mappings, linkFunction = undefined }: Props = $props();
+  let { title, mappings, linkFunction = undefined, textFunction = undefined }: Props = $props();
 </script>
 
 <p>
-  {title}
+  <span class="title">{title}</span>
   {#each mappings as m, index}
     {#if linkFunction == undefined}
       <span>{m}</span>{#if index != mappings.length - 1}<span class="spacer">, </span>{/if}
-    {:else if String(m).trim() != '-' && linkFunction(m).includes('cornucopia')}
+    {:else if String(m).trim() != '-' && linkFunction(m).startsWith('/') && textFunction != undefined }
+      <a title="{title} {textFunction(m)}" href={linkFunction(m)}>{textFunction(m)}</a>{#if index != mappings.length - 1}<span class="spacer">, </span>{/if}
+    {:else if String(m).trim() != '-' && linkFunction(m).startsWith('/')}
       <a title="{title} {m}" href={linkFunction(m)}>{m}</a>{#if index != mappings.length - 1}<span class="spacer">, </span>{/if}
     {:else if String(m).trim() != '-'}
       <a title="{title} {m}" target="_blank" rel="noopener nofollow" class="link-with-external-indicator" href={linkFunction(m)}>{m}</a>{#if index != mappings.length - 1}<span class="spacer">, </span>{/if}
@@ -40,5 +43,9 @@
 
   .spacer {
     padding-right: 0.2rem;
+  }
+
+  .title {
+    font-weight: 600;
   }
 </style>

--- a/cornucopia.owasp.org/src/lib/components/webAppCardTaxonomy.svelte
+++ b/cornucopia.owasp.org/src/lib/components/webAppCardTaxonomy.svelte
@@ -33,6 +33,17 @@
     function linkSTRIDE(input: string) {
       return  "/taxonomy/stride/" + input.toLowerCase();
     }
+
+    function textSTRIDE(input: string) {
+      return {
+        "S": 'Spoofing',
+        "T": 'Tampering',
+        "R": 'Repudiation',
+        "I": 'Information Disclosure',
+        "D": 'Denial of Service',
+        "E": 'Elevation of Privilege',
+      }[input] || input;
+    }
   
     function FormatToDoubleDigitSearchstring(input: string) {
       input = String(input)
@@ -63,6 +74,7 @@
         title="STRIDE:" 
         mappings={mappings.stride}
         linkFunction={linkSTRIDE}
+        textFunction={textSTRIDE}
       />
       <MappingsList
         title="OWASP ASVS (4.0):"

--- a/source/webapp-mappings-2.2.yaml
+++ b/source/webapp-mappings-2.2.yaml
@@ -19,6 +19,7 @@ suits:
     stride: [ I ]
     owasp_scp: [ 69, 107, 108, 109, 136, 137, 153, 156, 158, 162 ]
     owasp_scp_print: [ 69, 107, 107-109, 136, 137, 153, 156, 158, 162 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC1, SC2, SC3, SC4, SC8, SC9, SC10, SC11, SC12, SC13, FM1, FM2, FM5, EE6, EE7, EE8 ]
     owasp_dev_guide_print: [ SC1-4, SC8-13, FM1-2, FM5, EE6-8 ]
     owasp_asvs: [ 1.6.4, 2.10.4, 4.3.2, 7.1.1, 10.2.3, 14.1.1, 14.2.2, 14.3.3 ]
@@ -36,6 +37,7 @@ suits:
     stride: [ T ]
     owasp_scp: [ 8, 9, 11, 12, 13, 14, 16, 159, 190, 191 ]
     owasp_scp_print: [ 8, 9, 11-14, 16, 159, 190, 191 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ CEC5, CEC8, SSV2, SSV6, SSV7, SSV8, SSV9, SSV10, LF3, LF4, LF5, FV7, FV8 ]
     owasp_dev_guide_print: [ CEC5, CEC8, SSV2, SSV6-10, LF3-5, FV7-8 ]
     owasp_asvs: [ 1.5.3, 5.1.1, 5.1.2, 5.1.3, 13.2.1, 14.1.2, 14.4.1 ]
@@ -50,8 +52,9 @@ suits:
     id: "VE4"
     value: "4"
     url: "https://cornucopia.owasp.org/cards/VE4"
-    stride: [ T, E ]
+    stride: [ T ]
     owasp_scp: [ 8, 10, 183 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SSV2, SSV7, FV2, AC14, AC15 ]
     owasp_dev_guide_print: [ SSV2, SSV7, FV2, AC14-15 ]
     owasp_asvs: [ 4.2.1, 5.1.1, 5.1.2, 11.1.1, 11.1.2 ]
@@ -69,6 +72,7 @@ suits:
     stride: [ T, I ]
     owasp_scp: [ 3, 15, 18, 19, 20, 21, 22, 168 ]
     owasp_scp_print: [ 3, 15, 18-22, 168 ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ SQ3, SQ4, CEC3, CEC4, CEC5, CEC6, COE1, COE2 ]
     owasp_dev_guide_print: [ SQ3-4, CEC3-6, COE1-2 ]
     owasp_asvs: [ 1.1.6, 5.3.3, 5.2.1, 5.2.2, 5.2.5 ]
@@ -84,6 +88,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VE6"
     stride: [ T ]
     owasp_scp: [ 3, 168 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SQ3, SQ4, SSV1, SSV2, SSV9, SSV10, LF2 ]
     owasp_dev_guide_print: [ SQ3-4, SSV1-2, SSV9-10, LF2 ]
     owasp_asvs: [ 1.1.6, 1.5.3, 5.1.3, 13.2.2, 13.2.5 ]
@@ -99,6 +104,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VE7"
     stride: [ T ]
     owasp_scp: [ 4, 5, 7, 150 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SSV3, SSV4, SSV5, VSD2, DP7 ]
     owasp_dev_guide_print: [ SSV3-5, VSD2, DP7 ]
     owasp_asvs: [ 1.5.3, 13.2.2, 13.2.5 ]
@@ -114,6 +120,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VE8"
     stride: [ T ]
     owasp_scp: [ 15, 169 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ LF4, VSD2 ]
     owasp_dev_guide_print: [ LF4, VSD2 ]
     owasp_asvs: [ 1.1.6, 5.2.2, 5.2.5 ]
@@ -129,6 +136,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VE9"
     stride: [ T ]
     owasp_scp: [ 6, 21, 22, 168 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SQ3, SQ4, CEC7, CEC8, COE2, SSV9 ]
     owasp_dev_guide_print: [ SQ3, SQ4, CEC7-8, COE2, SSV9 ]
     owasp_asvs: [ 7.1.3 ]
@@ -144,6 +152,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VEX"
     stride: [ S ]
     owasp_scp: [ 2, 19, 92, 95, 180 ]
+    stride_print: [ Spoofing]
     owasp_dev_guide: [ COE1, SSV1, VSD1, FV1, SM22 ]
     owasp_dev_guide_print: [ COE1, SSV1, VSD1, FV1, SM22 ]
     owasp_asvs: [ 1.12.2, 5.1.3, 9.2.3, 12.2.1, 12.3.1, 12.3.2, 12.3.3, 12.4.2, 12.5.2, 14.5.3 ]
@@ -159,6 +168,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VEJ"
     stride: [ T ]
     owasp_scp: [ 1, 17 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ CEC2, LF1 ]
     owasp_dev_guide_print: [ CEC2, LF1 ]
     owasp_asvs: [ 1.5.3 ]
@@ -174,6 +184,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VEQ"
     stride: [ T ]
     owasp_scp: [ 10, 15, 16, 19, 20 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ CEC5, CEC6, COE1, SSV7, LF3, LF4 ]
     owasp_dev_guide_print: [ CEC5-6, COE1, SSV7, LF3-4 ]
     owasp_asvs: [ 5.2.1, 5.2.5, 5.3.3, 5.5.4 ]
@@ -190,6 +201,7 @@ suits:
     stride: [ T ]
     owasp_scp: [ 15, 19, 20, 21, 22, 167, 180, 204, 211, 212 ]
     owasp_scp_print: [ 15, 19-22, 167, 180, 204, 211, 212 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SFL4, SFL9, SFL10, SFL11, SQ2, CEC6, CEC7, COE1, COE2, LF4, LF5, LF6, FV1 ]
     owasp_dev_guide_print: [ SFL4, SFL9-11, SQ2, CEC6-7, COE1-2, LF4-6, FV1 ]
     owasp_asvs: [ 5.2.1, 5.2.2, 5.3.4, 5.3.7, 5.3.8, 5.3.9, 5.3.10 ]
@@ -205,6 +217,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/VEA"
     stride: [ ]
     owasp_scp: [ "-" ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_scp_print: [ "-" ]
@@ -225,6 +238,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT2"
     stride: [ R ]
     owasp_scp: [ 47, 52 ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ A3, A11, A12, A17, A18, A19, A20, A21, P10, P11, P12, SL6, SL8, SLD9, M1, M2 ]
     owasp_dev_guide_print: [ A3, A17-21, P10-12, SL6, SL8, SLD9, M1-2 ]
     owasp_asvs: [ 2.5.2, 7.1.2, 7.1.4, 7.2.1, 8.2.1, 8.2.2, 8.2.3, 8.3.6 ]
@@ -240,6 +254,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT3"
     stride: [ I ]
     owasp_scp: [ 36, 37, 40, 43, 48, 51, 119, 139, 140, 146 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ A14, P14, P15, DP6, PDR3, SL6 ]
     owasp_dev_guide_print: [ A14, P14-15, DP6, PDR3, SL6 ]
     owasp_asvs: [ 2.5.2, 2.5.3 ]
@@ -255,6 +270,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT4"
     stride: [ I ]
     owasp_scp: [ 33, 53 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ A4, A18, A19, A20, A21 ]
     owasp_dev_guide_print: [ A4, A18-21 ]
     owasp_asvs: [ 2.2.1, 4.1.5 ]
@@ -270,6 +286,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT5"
     stride: [ S ]
     owasp_scp: [ 54, 175, 178 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SDC6, SDA1, P13 ]
     owasp_dev_guide_print: [ SDC6, SDA1, P13 ]
     owasp_asvs: [ 4.1.5 ]
@@ -285,6 +302,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT6"
     stride: [ S ]
     owasp_scp: [ 37, 45, 46, 178 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A14, A15, P8, P9 ]
     owasp_dev_guide_print: [ A14-15, P8-9 ]
     owasp_asvs: [ 2.5.6 ]
@@ -300,6 +318,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT7"
     stride: [ S ]
     owasp_scp: [ 33, 38, 39, 41, 50, 53 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A4, A12, A18, A19, A20, A21, P4, ACM1 ]
     owasp_dev_guide_print: [ A4, A12, A18-21, P4, ACM1 ]
     owasp_asvs: [ 2.1.2, 2.1.7, '2.1.10', 2.2.1 ]
@@ -315,6 +334,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT8"
     stride: [ S ]
     owasp_scp: [ 28 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A4 ]
     owasp_dev_guide_print: [ A4 ]
     owasp_asvs: [ 4.1.5 ]
@@ -330,6 +350,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AT9"
     stride: [ S ]
     owasp_scp: [ 55, 56 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A10, A11, A13 ]
     owasp_dev_guide_print: [ A10-11, A13 ]
     owasp_asvs: [ 1.4.5, 2.1.6, 2.2.4, 4.1.3, 4.3.3 ]
@@ -345,6 +366,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/ATX"
     stride: [ S ]
     owasp_scp: [ 25, 26, 27 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A5, A6, A7, A8 ]
     owasp_dev_guide_print: [ A5-8 ]
     owasp_asvs: [ 1.1.6, 1.4.4 ]
@@ -360,6 +382,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/ATJ"
     stride: [ S ]
     owasp_scp: [ 23, 32, 34 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SC1, A1, A2, AC1, AC2, AC3 ]
     owasp_dev_guide_print: [ SC1, A1-2, AC1-3 ]
     owasp_asvs: [ 1.4.5, 4.3.1 ]
@@ -375,6 +398,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/ATQ"
     stride: [ S ]
     owasp_scp: [ 23, 29, 42, 49 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A1, A2, A9, A10, A11, P5, AC6, AC7 ]
     owasp_dev_guide_print: [ A1-2, A9-11, P5, AC6-7 ]
     owasp_asvs: [ 1.4.5, 2.5.6, 2.5.7, 4.3.1 ]
@@ -390,6 +414,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/ATK"
     stride: [ T ]
     owasp_scp: [ 24 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ A3 ]
     owasp_dev_guide_print: [ A3 ]
     owasp_asvs: [ 4.1.1, 10.2.3, 10.2.4, 10.2.5, 10.2.6 ]
@@ -405,6 +430,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/ATA"
     stride: [ ]
     owasp_scp: [ "-" ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_scp_print: [ "-" ]
@@ -423,6 +449,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM2"
     stride: [ S ]
     owasp_scp: [ 58, 59 ]
+    stride_print: [ Spoofing]
     owasp_dev_guide: [ SM1, SM2 ]
     owasp_dev_guide_print: [ SM1-2 ]
     owasp_asvs: [ 3.7.1 ]
@@ -438,6 +465,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM3"
     stride: [ R ]
     owasp_scp: [ 68 ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ SM25 ]
     owasp_dev_guide_print: [ SM25 ]
     owasp_asvs: [ 3.3.3, 3.3.4 ]
@@ -453,6 +481,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM4"
     stride: [ T ]
     owasp_scp: [ 59, 61 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SM2, SM4 ]
     owasp_dev_guide_print: [ SM2, SM4 ]
     owasp_asvs: [ 3.4.1, 3.4.2, 3.4.3, 3.4.4, 3.4.5 ]
@@ -468,6 +497,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM5"
     stride: [ S ]
     owasp_scp: [ 60, 62, 66, 67, 71, 72 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM2, SM3, SM5, SM8, SM9, SM10, SM11, SM12, SM13, SM14, SM15 ]
     owasp_dev_guide_print: [ SM2-3, SM5, SM8-15 ]
     owasp_asvs: [ 3.2.1, 3.2.2, 3.2.4, 3.3.1 ]
@@ -484,6 +514,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM6"
     stride: [ S ]
     owasp_scp: [ 64, 65 ]
+    stride_print: [ Spoofing]
     owasp_dev_guide: [ SM7, SM8 ]
     owasp_dev_guide_print: [ SM7-8 ]
     owasp_asvs: [ 3.3.2, 3.3.3, 3.3.4 ]
@@ -499,6 +530,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM7"
     stride: [ S ]
     owasp_scp: [ 62, 63 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM5, SM6, SM20 ]
     owasp_dev_guide_print: [ SM5-6, SM20 ]
     owasp_asvs: [ 3.3.1, 3.3.4 ]
@@ -514,6 +546,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM8"
     stride: [ E ]
     owasp_scp: [ 96 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ SM19, SM21, SM23, SM24 ]
     owasp_dev_guide_print: [ SM19, SM21, SM23-24 ]
     owasp_asvs: [ 3.3.2, 3.6.1 ]
@@ -529,6 +562,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SM9"
     stride: [ S ]
     owasp_scp: [ 69, 75, 76, 119, 138 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM11, SM12, SM15, SM16, DP5, SL5, EE6 ]
     owasp_dev_guide_print: [ SM11-12, SM15-16, DP5, SL5, EE6 ]
     owasp_asvs: [ 1.9.1, 3.1.1, 7.1.1, 7.1.2, 7.2.1, 9.1.3, 9.2.2 ]
@@ -545,6 +579,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SMX"
     stride: [ S ]
     owasp_scp: [ 73, 74 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM22 ]
     owasp_dev_guide_print: [ SM22 ]
     owasp_asvs: [ 4.2.2 ]
@@ -560,6 +595,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SMJ"
     stride: [ T ]
     owasp_scp: [ "-" ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SM22 ]
     owasp_dev_guide_print: [ SM22 ]
     owasp_asvs: [ 11.1.1, 11.1.2, 11.1.3 ]
@@ -575,6 +611,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SMQ"
     stride: [ S ]
     owasp_scp: [ 58 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM1 ]
     owasp_dev_guide_print: [ SM1 ]
     owasp_asvs: [ 1.1.6, 3.7.1 ]
@@ -590,6 +627,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/SMK"
     stride: [ S ]
     owasp_scp: [ 58, 60 ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM1, SM2, SM3 ]
     owasp_dev_guide_print: [ SM1-3 ]
     owasp_asvs: [ 1.1.6 ]
@@ -606,6 +644,7 @@ suits:
     stride: []
     owasp_scp: [ "-" ]
     owasp_scp_print: [ "-" ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -623,6 +662,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ2"
     stride: [ T ]
     owasp_scp: [ 44 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ P7 ]
     owasp_dev_guide_print: [ P7 ]
     owasp_asvs: [ 4.1.3, 4.2.1, 5.1.5 ]
@@ -638,6 +678,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ3"
     stride: [ I ]
     owasp_scp: [ 51, 100, 135, 139, 140, 141, 150 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ AC1, AC6, AC7, DP6, DP7, SCM6, PDR1, PDR2, PDR3, PDR4 ]
     owasp_dev_guide_print: [ AC1, AC6-7, DP6-7, SCM6, PDR1-4 ]
     owasp_asvs: [ 4.1.3, 4.1.5, 8.1.2, 8.2.1, 8.3.1, 8.3.4, 8.3.6, 8.3.8, 12.4.1 ]
@@ -653,6 +694,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ4"
     stride: [ E ]
     owasp_scp: [ 79, 80 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC3, AC10, AC11 ]
     owasp_dev_guide_print: [ AC3, AC10-11 ]
     owasp_asvs: [ 4.1.5 ]
@@ -669,6 +711,7 @@ suits:
     stride: [ E ]
     owasp_scp: [ 70, 81, 83, 84, 87, 88, 89, 99, 117, 131, 132, 142, 154, 170, 179 ]
     owasp_scp_print: [ 70, 81, 83, 84, 87-9, 99, 117, 131, 132, 142, 154, 170, 179 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ SC1, SC2, SDC1, SDA2, SM2, SM12, AC2, AC3, AC4, ACM4, ACM5, ACM6, ACM7, ACM8, ACM9, SCM2, SCM4, PDR3, PDR4, SLD3 ]
     owasp_dev_guide_print: [ SC1-2, SDC1, SDA2, SDA2, SM2, SM12, AC2-4, ACM4-9, SCM2, SCM4, PDR3-4, SLD3 ]
     owasp_asvs: [ 1.2.2, 4.1.1, 4.1.3, 4.2.1 ]
@@ -685,6 +728,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ6"
     stride: [ E ]
     owasp_scp: [ 81, 88, 131 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC2, AC4, ACM6, ACM7, ACM8, DP4 ]
     owasp_dev_guide_print: [ AC2, AC4, ACM6-8, DP4  ]
     owasp_asvs: [ 4.1.3, 4.2.1 ]
@@ -701,6 +745,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ7"
     stride: [ E ]
     owasp_scp: [ 81, 85, 86, 131 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC2, AC4, ACM5, ACM6, ACM7, ACM8, DP4 ]
     owasp_dev_guide_print: [ AC2, AC4, ACM5-8, DP4 ]
     owasp_asvs: [ 4.1.3, 4.2.1 ]
@@ -717,6 +762,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ8"
     stride: [ T, E ]
     owasp_scp: [ 10, 32, 93, 94, 189 ]
+    stride_print: [ Tampering, 'Elevation of Privilege' ]
     owasp_dev_guide: [ SSV7, FV6, A18, AC14, AC15, ACM1 ]
     owasp_dev_guide_print: [ SSV7, FV6, A18, AC14-15, ACM1 ]
     owasp_asvs: [ 4.1.2, 4.2.1, 4.3.3, 7.3.4, 11.1.1, 11.1.2 ]
@@ -732,6 +778,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZ9"
     stride: [ D ]
     owasp_scp: [ 94 ]
+    stride_print: [ 'Denial of Service' ]
     owasp_dev_guide: [ ACM1 ]
     owasp_dev_guide_print: [ ACM1 ]
     owasp_asvs: [ 11.1.3, 11.1.4 ]
@@ -748,6 +795,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZX"
     stride: [ E ]
     owasp_scp: [ 78, 91 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC9, AC15 ]
     owasp_dev_guide_print: [ AC9, AC15 ]
     owasp_asvs: [ 1.1.6, 4.1.1 ]
@@ -764,6 +812,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZJ"
     stride: [ I, E ]
     owasp_scp: [ 89, 90 ]
+    stride_print: [ 'Information Disclosure', 'Elevation of Privilege' ]
     owasp_dev_guide: [ ACM8 ]
     owasp_dev_guide_print: [ ACM8 ]
     owasp_asvs: [ 4.1.2, 10.2.3, 10.2.4, 10.2.5, 10.2.6 ]
@@ -779,6 +828,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZQ"
     stride: [ E ]
     owasp_scp: [ 209 ]
+    stride_print: ['Elevation of Privilege' ]
     owasp_dev_guide: [ SFL9, CEC7, LF6 ]
     owasp_dev_guide_print: [ SFL9, CEC7, LF6 ]
     owasp_asvs: [ 5.3.8 ]
@@ -794,6 +844,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/AZK"
     stride: [ E ]
     owasp_scp: [ 77, 89, 91 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC8, AC15, ACM8 ]
     owasp_dev_guide_print: [ AC8, AC15, ACM8 ]
     owasp_asvs: [ 4.1.1, 4.1.2, 10.2.3, 10.2.4, 10.2.5, 10.2.6 ]
@@ -810,6 +861,7 @@ suits:
     stride: [ ]
     owasp_scp: [ "-" ]
     owasp_scp_print: [ "-" ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -827,6 +879,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR2"
     stride: [ I ]
     owasp_scp: [ 105, 133, 135 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ P15, CP6, SCM6, SCM7, PDR1, PDR3 ]
     owasp_dev_guide_print: [ P15, CP6, SCM6-7, PDR1, PDR3 ]
     owasp_asvs: [ 6.2.2 ]
@@ -842,6 +895,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR3"
     stride: [ T ]
     owasp_scp: [ 92, 205, 212 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SFL3, SFL4, VSD1 ]
     owasp_dev_guide_print: [ SFL3-4, VSD1 ]
     owasp_asvs: [ 10.2.3, 10.2.4, 10.2.5, 10.2.6, 10.3.1, 10.3.2, 14.1.1, 14.1.4, 14.1.5 ]
@@ -857,6 +911,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR4"
     stride: [ I ]
     owasp_scp: [ 37, 88, 143, 214 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ P15, PDT1, PDT2, PDT3, PDT4, PDT5 ]
     owasp_dev_guide_print: [ P15, PDT1-5 ]
     owasp_asvs: [ 8.3.4, 9.1.1 ]
@@ -872,6 +927,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR5"
     stride: [ T, I ]
     owasp_scp: [ 103, 145 ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ CP3, PDT4 ]
     owasp_dev_guide_print: [ CP3, PDT4 ]
     owasp_asvs: [ 1.9.1, 6.2.1, 9.1.3, 9.2.2 ]
@@ -887,6 +943,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR6"
     stride: [ T, I ]
     owasp_scp: [ 36, 37, 143, 146, 147 ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ A14, A15, PDR2, PDR3, PDR4, PDT1, PDT2, PDT3, PDT4, PDT5, PDT6, PDT7, PDT8, PDT9, PDT10, PDT11 ]
     owasp_dev_guide_print: [ A14-15, PDR2-4, PDT1-11 ]
     owasp_asvs: [ 1.9.1, 2.2.5, 2.5.1, 8.3.4, 8.3.6, 9.1.3, 9.2.2 ]
@@ -902,6 +959,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR7"
     stride: [ T, I ]
     owasp_scp: [ 75, 144, 145, 148 ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ SM15, PDT4, PDT5, PDT6, PDT7, PDT8 ]
     owasp_dev_guide_print: [ SM15, PDT4-8 ]
     owasp_asvs: [ 1.9.2, 6.2.7, 9.1.1, 9.2.1, 9.2.4, 14.4.5 ]
@@ -917,6 +975,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR8"
     stride: [ I ]
     owasp_scp: [ 30, 31, 70, 133, 135 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ P1, P2, SM12, SCM6, PDR1, PDR2, PDR3, PDR4 ]
     owasp_dev_guide_print: [ P1-2, SM12, SCM6, PDR1-4 ]
     owasp_asvs: [ 2.4.1, 6.2.2, 6.2.3, 8.3.4 ]
@@ -932,6 +991,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CR9"
     stride: [ T, I ]
     owasp_scp: [ 60, 104, 105 ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ SM3, CP4, CP5, CP6 ]
     owasp_dev_guide_print: [ SM3, CP4-6 ]
     owasp_asvs: [ 6.2.2, 6.2.3, 6.3.1, 6.3.3 ]
@@ -947,6 +1007,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CRX"
     stride: [ T, I ]
     owasp_scp: [ 104, 105 ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ CP4, CP5, CP6 ]
     owasp_dev_guide_print: [ CP4-6 ]
     owasp_asvs: [ 6.3.3 ]
@@ -962,6 +1023,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CRJ"
     stride: [ I ]
     owasp_scp: [ 35, 90, 171, 172 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC12, SQ6, SQ7, SDA3, ACM8, SCM6, SCM7, PDR1 ]
     owasp_dev_guide_print: [ SC12, SQ6-7, SDA3, ACM8, SCM6-7, PDR1 ]
     owasp_asvs: [ 1.6.1, 1.6.2, 1.6.4, 2.10.4, 6.4.1, 6.4.2 ]
@@ -975,8 +1037,9 @@ suits:
     id: "CRQ"
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/CRQ"
-    stride: [ T, I ]
+    stride: [ I ]
     owasp_scp: [ 35, 102 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC12, SCM2, SCM6, SCM7 ]
     owasp_dev_guide_print: [ SC12, SCM2, SCM6-7 ]
     owasp_asvs: [ 1.6.1, 1.6.2, 1.6.3, 6.2.3, 8.3.6 ]
@@ -992,6 +1055,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CRK"
     stride: [ T ]
     owasp_scp: [ 31, 101 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ CP2, P2 ]
     owasp_dev_guide_print: [ CP2, P2 ]
     owasp_asvs: [ 1.6.2, 6.2.5, 6.2.6, 6.2.7, 6.2.8 ]
@@ -1008,6 +1072,7 @@ suits:
     stride: []
     owasp_scp: [ "-" ]
     owasp_scp_print: [ "-" ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -1026,6 +1091,7 @@ suits:
     stride: [ T ]
     owasp_scp: [ 194, 195, 196, 197, 198, 199, 200, 201, 202, 205, 206, 207, 208, 209 ]
     owasp_scp_print: [ 194-202, 205-209 ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SFL8, SFL10, ACM9, MM1, MM2, MM3, MM4, MM5, MM6, MM8, MM9 ]
     owasp_dev_guide_print: [ SFL8, SFL10, ACM9, MM1-6, MM8-9 ]
     owasp_asvs: [ 14.1.2 ]
@@ -1041,6 +1107,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/C3"
     stride: [ I ]
     owasp_scp: [ 134 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC2, SC4, SC9, SC11 ]
     owasp_dev_guide_print: [ SC2, SC4, SC9, SC11 ]
     owasp_asvs: [ 14.1.1 ]
@@ -1056,6 +1123,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/C4"
     stride: [ R ]
     owasp_scp: [ 23, 32, 34, 42, 51, 181 ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ A1, A2, A13, A18, P5 ]
     owasp_dev_guide_print: [ A1-2, A13, A18, P5 ]
     owasp_asvs: [ 7.2.1, 7.2.2 ]
@@ -1071,6 +1139,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/C5"
     stride: [ R ]
     owasp_scp: [ "-" ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ 1.9.2, 5.1.5, 9.1.1, 9.2.1, 9.2.4 ]
@@ -1084,9 +1153,10 @@ suits:
     id: "C6"
     value: "6"
     url: "https://cornucopia.owasp.org/cards/C6"
-    stride: [ S, T, E ]
+    stride: [ T ]
     owasp_scp: [ 109, 110, 111, 112, 155 ]
     owasp_scp_print: [ 109-112, 155 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ A4, AC10, CP3, EE1, EE8, EE9, EE10, EE11 ]
     owasp_dev_guide_print: [ A4, AC10, CP3, EE1, EE8-11 ]
     owasp_asvs: [ 4.1.5, 7.1.4 ]
@@ -1103,6 +1173,7 @@ suits:
     stride: [ R ]
     owasp_scp: [ 113, 114, 115, 117, 118, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130 ]
     owasp_scp_print: [ 113, 114, 115, 117, 118, 121-130 ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ A4 SL1, SL2, SL3, SL6, SL7, SL8, SL9, SL10, SL11, SL12, SL13, SLD3, SLD4, SLD8, SLD9, SLD10 ]
     owasp_dev_guide_print: [ A4 SL1-3, SL6-13, SLD3-4, SLD8-10 ]
     owasp_asvs: [ 7.1.2, 7.1.4, 7.2.1, 7.2.2, 7.3.1, 7.3.3, 8.3.5, 9.2.5 ]
@@ -1119,6 +1190,7 @@ suits:
     stride: [ I ]
     owasp_scp: [ 151, 152, 156, 160, 161, 173, 174, 175, 176, 177 ]
     owasp_scp_print: [ 151, 152, 156, 160, 161, 173-177 ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC1, SC2, SC3, SC4, SC5, SC6, SC7, SC8, SC9, SC10, SC11, SC12, SC13, SFL1, SFL2, SFL14, SFL15, SDC2, SDC3, SDC4, SDC5, SDC6, SDA1, PDT1, PDT2, PDT3, PDT4, PDT5, PDT6, PDT7, PDT8, PDT9, PDT10, PDT11 ]
     owasp_dev_guide_print: [ SC1-13, SFL1-2, SFL14-15, SDC2-6, SDA1, PDT1-11 ]
     owasp_asvs: [ 1.4.5, 10.3.1, 10.3.2, 14.1.4, 14.1.5, 14.2.1, 14.2.2 ]
@@ -1132,9 +1204,10 @@ suits:
     id: "C9"
     value: "9"
     url: "https://cornucopia.owasp.org/cards/C9"
-    stride: [ I, E ]
+    stride: [ E ]
     owasp_scp: [ 23, 29, 56, 81, 82, 84, 85, 86, 87, 88, 89, 90 ]
     owasp_scp_print: [ 23, 29, 56, 81, 82, 84-90 ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ A1, A3, A9, A10, AC2, AC12, ACM4, ACM5, ACM6, ACM7, ACM8 ]
     owasp_dev_guide_print: [ A1, A3, A9-10, AC2, AC12, 7.2-8 ]
     owasp_asvs: [ 1.4.5, 4.3.1 ]
@@ -1148,8 +1221,9 @@ suits:
     id: "CX"
     value: "10"
     url: "https://cornucopia.owasp.org/cards/CX"
-    stride: [ T, E ]
+    stride: [ T ]
     owasp_scp: [ 57, 151, 152, 204, 205, 213, 214 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SC4, SFL1, SFL2, SFL10, SFL11, SFL12, SFL13, SFL14, SFL15 ]
     owasp_dev_guide_print: [ SC4, SFL1-2, SFL10-15 ]
     owasp_asvs: [ 1.14.3, 10.1.1, 10.2.3, 10.2.4, 10.2.5, 10.2.6, 14.2.1 ]
@@ -1163,9 +1237,10 @@ suits:
     id: "CJ"
     value: "J"
     url: "https://cornucopia.owasp.org/cards/CJ"
-    stride: [ T, I, E ]
+    stride: [ T ]
     owasp_scp: [ 90, 137, 148, 151, 152, 153, 154, 175, 176, 177, 178, 179, 186, 192 ]
     owasp_scp_print: [ 90, 137, 148, 151-154, 175-179, 186, 192 ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SC1, SC12, SC13, FM1, FM2, FM3, FM4, FM5, SFL1, SFL2, SFL3, SFL4, SFL5, SFL6, SDC4, SDC5, SDC6, SDA1, SDA2, AC6, AC7, ACM8, PDT2, PDT8 ]
     owasp_dev_guide_print: [ SC1, SC12-13, FM1-5, SFL1-6, SDC4-6, SDA1-2, AC6-7, ACM8, PDT2, PDT8 ]
     owasp_asvs: [ 1.14.3, 14.1.1, 14.1.2, 14.1.3, 14.1.4, 14.1.5, 14.2.1 ]
@@ -1181,6 +1256,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CQ"
     stride: [ R ]
     owasp_scp: [ "-" ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ M1, M2 ]
     owasp_dev_guide_print: [ M1-2 ]
     owasp_asvs: [ 8.1.4, 11.1.1-4 ]
@@ -1196,6 +1272,7 @@ suits:
     url: "https://cornucopia.owasp.org/cards/CK"
     stride: [ D ]
     owasp_scp: [ 41, 55 ]
+    stride_print: [ 'Denial of Service' ]
     owasp_dev_guide: [ A12, ACM1 ]
     owasp_dev_guide_print: [ A12, ACM1 ]
     owasp_asvs: [ 2.2.1, 11.1.3, 11.1.4 ]
@@ -1213,6 +1290,7 @@ suits:
     stride: []
     owasp_scp: [ "-" ]
     owasp_scp_print: [ "-" ]
+    stride_print: [ ]
     owasp_dev_guide: [ "-" ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]

--- a/source/webapp-mappings-3.0.yaml
+++ b/source/webapp-mappings-3.0.yaml
@@ -17,6 +17,7 @@ suits:
     value: "2"
     url: "https://cornucopia.owasp.org/cards/VE2"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC1, SC2, SC3, SC4, SC8, SC9, SC10, SC11, SC12, SC13, FM1, FM2, FM5, EE6, EE7, EE8 ]
     owasp_dev_guide_print: [ SC1-4, SC8-13, FM1-2, FM5, EE6-8 ]
     owasp_asvs: [ 2.4.1, 4.3.2, 13.2.2, 13.4.1, 13.4.2, 13.4.3, 13.4.4, 13.4.5, 13.4.6, 13.4.7, 15.2.3, 16.2.5, 16.4.2, 16.5.1, 17.1.1 ]
@@ -55,6 +56,7 @@ suits:
     value: "3"
     url: "https://cornucopia.owasp.org/cards/VE3"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ CEC5, CEC8, SSV2, SSV6, SSV7, SSV8, SSV9, SSV10, LF3, LF4, LF5, FV7, FV8 ]
     owasp_dev_guide_print: [ CEC5, CEC8, SSV2, SSV6-10, LF3-5, FV7-8 ]
     owasp_asvs: [ 1.1.1, 1.2.2, 1.2.3, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.6, 1.3.7, 1.3.8, 1.3.9, '1.3.10', 1.3.11, 1.3.12, 1.4.2, 1.5.3, 2.1.1, 2.2.1, 2.2.2, 3.2.3, 4.1.1, 4.1.4, 4.2.1, 4.2.2, 4.2.3, 4.2.4, 4.2.5, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.3.2, 5.3.3, 5.4.1, 5.4.2, 15.3.3, 15.3.4, 15.3.5, 15.3.6, 15.3.7, 16.5.1 ]
@@ -98,7 +100,8 @@ suits:
     id: "VE4"
     value: "4"
     url: "https://cornucopia.owasp.org/cards/VE4"
-    stride: [ T, E ]
+    stride: [ T ]
+    stride_print: [ Tampering]
     owasp_dev_guide: [ SSV2, SSV7, FV2, AC14, AC15 ]
     owasp_dev_guide_print: [ SSV2, SSV7, FV2, AC14-15 ]
     owasp_asvs: [ 2.1.1, 2.1.2, 2.1.3, 2.2.1, 2.2.2, 2.2.3, 2.3.1, 2.3.2, 2.3.3, 15.3.3, 15.3.4, 15.3.5, 15.3.6, 15.3.7, 16.5.1 ] 
@@ -129,6 +132,7 @@ suits:
     value: "5"
     url: "https://cornucopia.owasp.org/cards/VE5"
     stride: [ T, I ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ SQ3, SQ4, CEC3, CEC4, CEC5, CEC6, COE1, COE2 ]
     owasp_dev_guide_print: [ SQ3-4, CEC3-6, COE1-2 ]
     owasp_asvs: [ 1.1.1, 1.1.2, 1.2.1, 1.2.2, 1.2.3, 1.3.3, 1.3.7, 3.2.2, 5.4.2, 16.4.1, 16.5.1 ]
@@ -157,6 +161,7 @@ suits:
     value: "6"
     url: "https://cornucopia.owasp.org/cards/VE6"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SQ3, SQ4, SSV1, SSV2, SSV9, SSV10, LF2 ]
     owasp_dev_guide_print: [ SQ3-4, SSV1-2, SSV9-10, LF2 ]
     owasp_asvs: [ 1.4.2, 2.1.1, 2.1.2, 2.1.3, 2.2.1, 2.2.2, 2.2.3, 2.3.1, 2.3.2, 2.3.3, 16.5.1 ]
@@ -183,6 +188,7 @@ suits:
     value: "7"
     url: "https://cornucopia.owasp.org/cards/VE7"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SSV3, SSV4, SSV5, VSD2, DP7 ]
     owasp_dev_guide_print: [ SSV3-5, VSD2, DP7 ]
     owasp_asvs: [ 1.1.1, 1.1.2, 1.2.1, 1.2.2, 1.2.3, 1.2.9, '1.2.10', 2.1.1, 2.2.1, 3.2.2, 3.2.3, 4.1.1, 5.4.2, 15.3.5, 15.3.6, 16.5.1 ]
@@ -225,6 +231,7 @@ suits:
     value: "8"
     url: "https://cornucopia.owasp.org/cards/VE8"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ LF4, VSD2 ]
     owasp_dev_guide_print: [ LF4, VSD2 ]
     owasp_asvs: [ 1.1.1, 1.1.2, 1.2.3, 1.2.3, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.6, 1.3.7, 1.3.8, 1.3.9, '1.3.10', 1.3.11, 1.3.12, 16.5.1 ]
@@ -267,6 +274,7 @@ suits:
     value: "9"
     url: "https://cornucopia.owasp.org/cards/VE9"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SQ3, SQ4, CEC7, CEC8, COE2, SSV9 ]
     owasp_dev_guide_print: [ SQ3, SQ4, CEC7-8, COE2, SSV9 ]
     owasp_asvs: [ 16.5.1, 16.5.2, 16.5.3, 16.5.4 ]
@@ -291,6 +299,7 @@ suits:
     value: "10"
     url: "https://cornucopia.owasp.org/cards/VEX"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ COE1, SSV1, VSD1, FV1, SM22 ]
     owasp_dev_guide_print: [ COE1, SSV1, VSD1, FV1, SM22 ]
     owasp_asvs: [ 1.3.6, 2.2.2, 3.2.1, 3.3.1, 3.3.2, 3.3.3, 3.3.4, 3.3.5, 3.4.1, 3.4.2, 3.4.3, 3.4.4, 3.4.5, 3.4.6, 3.4.7, 3.4.8, 3.5.1, 3.5.2, 3.5.3, 3.5.4, 3.5.5, 4.1.3, 9.1.3, 9.2.2, 9.2.3, 9.2.4, 10.4.1, 15.3.4 ]
@@ -319,6 +328,7 @@ suits:
     value: "J"
     url: "https://cornucopia.owasp.org/cards/VEJ"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ CEC2, LF1 ]
     owasp_dev_guide_print: [ CEC2, LF1 ]
     owasp_asvs: [ 2.2.2, 3.1.1, 3.4.3, 3.4.6, 3.4.7, 3.5.3, 3.5.4, 3.5.5, 3.5.6, 3.5.7, 3.6.1, 3.7.5 ]
@@ -347,6 +357,7 @@ suits:
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/VEQ"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ CEC5, CEC6, COE1, SSV7, LF3, LF4 ]
     owasp_dev_guide_print: [ CEC5-6, COE1, SSV7, LF3-4 ]
     owasp_asvs: [ 1.1.1, 1.2.1, 1.2.2, 1.2.3, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.6, 1.3.7, 2.1.1, 3.1.1, 3.2.1, 3.2.2, 3.2.3, 3.4.2, 3.4.3, 3.4.6, 3.4.7, 3.4.8, 3.5.4, 3.5.5, 3.5.6, 3.5.7, 3.5.8, 3.6.1, 3.7.1, 3.7.5, 4.1.1, 15.3.5, 15.3.6 ]
@@ -375,6 +386,7 @@ suits:
     value: "K"
     url: "https://cornucopia.owasp.org/cards/VEK"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SFL4, SFL9, SFL10, SFL11, SQ2, CEC6, CEC7, COE1, COE2, LF4, LF5, LF6, FV1 ]
     owasp_dev_guide_print: [ SFL4, SFL9-11, SQ2, CEC6-7, COE1-2, LF4-6, FV1 ]
     owasp_asvs: [ 1.1.1, 1.1.2, 1.2.2, 1.2.4, 1.2.5, 1.2.6, 1.2.7, 1.2.8, 1.2.9, '1.2.10', 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.8, 1.3.9, '1.3.10', 1.3.11, 1.5.1, 1.5.2, 1.5.3, 2.1.1, 2.1.2, 2.1.3, 2.2.1, 2.2.2, 2.2.3, 5.1.1, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.3.1, 5.3.2, 5.3.3, 5.4.1, 5.4.2, 5.4.3, 15.3.1, 15.3.2, 15.3.3, 15.3.5, 15.3.6, 15.3.7, 16.4.1, 16.5.1 ]
@@ -425,6 +437,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/VEA"
     stride: [ ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -443,6 +456,7 @@ suits:
     value: "2"
     url: "https://cornucopia.owasp.org/cards/AT2"
     stride: [ R ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ A3, A11, A12, A17, A18, A19, A20, A21, P10, P11, P12, SL6, SL8, SLD9, M1, M2 ]
     owasp_dev_guide_print: [ A3, A17-21, P10-12, SL6, SL8, SLD9, M1-2 ]
     owasp_asvs: [ 6.3.1, 6.3.3, 6.3.5, 6.3.7, 6.3.8, 6.4.3, 6.4.4, 6.4.6, 7.2.1, 7.5.1, 7.5.2, 7.6.2, 14.3.1, 16.2.1, 16.3.1 ]
@@ -457,6 +471,7 @@ suits:
     value: "3"
     url: "https://cornucopia.owasp.org/cards/AT3"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ A14, P14, P15, DP6, PDR3, SL6 ]
     owasp_dev_guide_print: [ A14, P14-15, DP6, PDR3, SL6 ]
     owasp_asvs: [ 6.2.6, 6.2.10, 6.2.11, 6.2.12, 6.3.2, 6.4.2, 6.5.7, 11.4.2, 12.2.1, 12.3.1, 12.3.3, 13.3.1, 14.2.1, 14.2.2, 14.3.1 ]
@@ -471,6 +486,7 @@ suits:
     value: "4"
     url: "https://cornucopia.owasp.org/cards/AT4"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ A4, A18, A19, A20, A21 ]
     owasp_dev_guide_print: [ A4, A18-21 ]
     owasp_asvs: [ 6.1.1, 6.3.1, 6.3.2, 6.3.8, 16.5.3 ]
@@ -485,6 +501,7 @@ suits:
     value: "5"
     url: "https://cornucopia.owasp.org/cards/AT5"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SDC6, SDA1, P13 ]
     owasp_dev_guide_print: [ SDC6, SDA1, P13 ]
     owasp_asvs: [ 6.2.2, 6.2.4, 6.2.11, 6.2.12, 6.3.2, 6.4.2, 7.2.2, 13.2.3 ]
@@ -499,6 +516,7 @@ suits:
     value: "6"
     url: "https://cornucopia.owasp.org/cards/AT6"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A14, A15, P8, P9 ]
     owasp_dev_guide_print: [ A14-15, P8-9 ]
     owasp_asvs: [ 6.3.6, 6.4.1, 6.4.6, 6.5.1, 6.5.5, 6.5.6, 6.5.8, 6.6.1, 6.6.2, 6.8.3, 9.2.1, 10.4.2, 10.4.3, 10.4.5, 10.4.9, 13.3.4 ]
@@ -513,6 +531,7 @@ suits:
     value: "7"
     url: "https://cornucopia.owasp.org/cards/AT7"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A4, A12, A18, A19, A20, A21, P4, ACM1 ]
     owasp_dev_guide_print: [ A4, A12, A18-21, P4, ACM1 ]
     owasp_asvs: [ 6.1.1, 6.2.1, 6.2.2, 6.2.3, 6.2.4, 6.2.5, 6.2.8, 6.2.9, '6.2.10', 6.2.11, 6.2.12, 6.1.1, 6.3.1, 6.3.2, 6.3.3, 6.3.5, 6.3.8, 6.4.1, 6.4.2, 6.4.3, 6.5.1, 6.5.2, 6.5.3, 6.5.4, 6.5.5, 6.6.3, 6.6.4 ]
@@ -527,6 +546,7 @@ suits:
     value: "8"
     url: "https://cornucopia.owasp.org/cards/AT8"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A4 ]
     owasp_dev_guide_print: [ A4 ]
     owasp_asvs: [ 16.5.3 ]
@@ -541,6 +561,7 @@ suits:
     value: "9"
     url: "https://cornucopia.owasp.org/cards/AT9"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A10, A11, A13 ]
     owasp_dev_guide_print: [ A10-11, A13 ]
     owasp_asvs: [ 6.1.1, 6.1.2, 6.1.3, 6.2.3, 6.3.3, 6.3.4, 6.3.6, 6.4.1, 6.4.2, 6.4.3, 6.4.4, 6.5.3, 6.5.4, 6.6.1, 6.6.2, 6.6.3, 6.7.2, 7.5.1, 7.5.3, 8.1.3, 8.1.4, 8.4.2, 10.4.4, 13.2.3 ]
@@ -555,6 +576,7 @@ suits:
     value: "10"
     url: "https://cornucopia.owasp.org/cards/ATX"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A5, A6, A7, A8 ]
     owasp_dev_guide_print: [ A5-8 ]
     owasp_asvs: [ 6.1.1, 6.1.2, 6.1.3, 6.3.1, 6.3.2, 6.3.3, 6.3.4, 6.3.6, 6.4.2, 6.6.1, 6.7.1, 6.8.1, 6.8.2, 6.8.3, 6.8.4, 10.1.1, 10.1.2, 10.3.1, 10.3.2, 10.3.3, 10.3.4, 10.3.5, 10.5.1, 10.5.2, 10.5.3, 10.5.4, 10.5.5 ]
@@ -569,6 +591,7 @@ suits:
     value: "J"
     url: "https://cornucopia.owasp.org/cards/ATJ"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SC1, A1, A2, AC1, AC2, AC3 ]
     owasp_dev_guide_print: [ SC1, A1-2, AC1-3 ]
     owasp_asvs: [ 4.4.4, 6.1.3, 6.3.3, 6.3.4, 6.4.3, 6.4.4, 7.5.1, 7.5.3, 8.4.2, 12.3.5, 13.2.1, 13.2.3 ]
@@ -583,6 +606,7 @@ suits:
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/ATQ"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ A1, A2, A9, A10, A11, P5, AC6, AC7 ]
     owasp_dev_guide_print: [ A1-2, A9-11, P5, AC6-7 ]
     owasp_asvs: [ 6.1.3, 6.4.3, 6.4.4, 6.8.4, 7.5.1, 7.5.3, 13.2.1 ]
@@ -597,6 +621,7 @@ suits:
     value: "K"
     url: "https://cornucopia.owasp.org/cards/ATK"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ A3 ]
     owasp_dev_guide_print: [ A3 ]
     owasp_asvs: [ 7.2.1, 10.1.1, 10.1.2, 10.2.1, 13.2.1, 13.2.3, 16.5.3 ]
@@ -611,6 +636,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/ATA"
     stride: [ ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -627,6 +653,7 @@ suits:
     value: "2"
     url: "https://cornucopia.owasp.org/cards/SM2"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM1, SM2 ]
     owasp_dev_guide_print: [ SM1-2 ]
     owasp_asvs: [ 10.1.1, 10.1.2, 10.2.1, 10.2.2, 10.3.5, 14.2.1, 16.5.3 ]
@@ -641,6 +668,7 @@ suits:
     value: "3"
     url: "https://cornucopia.owasp.org/cards/SM3"
     stride: [ R ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ SM25 ]
     owasp_dev_guide_print: [ SM25 ]
     owasp_asvs: [ 7.1.2, 7.4.5, 7.5.2, 10.4.6 ]
@@ -655,6 +683,7 @@ suits:
     value: "4"
     url: "https://cornucopia.owasp.org/cards/SM4"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SM2, SM4 ]
     owasp_dev_guide_print: [ SM2, SM4 ]
     owasp_asvs: [ 3.3.1, 3.3.2, 3.3.3, 3.3.4, 3.5.4 ]
@@ -669,6 +698,7 @@ suits:
     value: "5"
     url: "https://cornucopia.owasp.org/cards/SM5"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM2, SM3, SM5, SM8, SM9, SM10, SM11, SM12, SM13, SM14, SM15 ]
     owasp_dev_guide_print: [ SM2-3, SM5, SM8-15 ]
     owasp_asvs: [ 7.2.1, 7.2.2, 7.2.3, 7.2.4 ]
@@ -683,6 +713,7 @@ suits:
     value: "6"
     url: "https://cornucopia.owasp.org/cards/SM6"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM7, SM8 ]
     owasp_dev_guide_print: [ SM7-8 ]
     owasp_asvs: [ 7.1.1, 7.1.3, 7.3.1, 7.3.2, 7.4.1, 7.6.1, 10.4.8 ]
@@ -697,6 +728,7 @@ suits:
     value: "7"
     url: "https://cornucopia.owasp.org/cards/SM7"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM5, SM6, SM20 ]
     owasp_dev_guide_print: [ SM5-6, SM20 ]
     owasp_asvs: [ 7.4.1, 7.4.3, 7.4.4, 7.4.5, 7.5.2 ]
@@ -711,6 +743,7 @@ suits:
     value: "8"
     url: "https://cornucopia.owasp.org/cards/SM8"
     stride: [ E ]
+    stride_print: [ ]
     owasp_dev_guide: [ SM19, SM21, SM23, SM24 ]
     owasp_dev_guide_print: [ SM19, SM21, SM23-24 ]
     owasp_asvs: [ 7.3.1, 7.3.2, 7.4.1, 7.4.2, 7.6.1, 8.2.4 ]
@@ -725,6 +758,7 @@ suits:
     value: "9"
     url: "https://cornucopia.owasp.org/cards/SM9"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM11, SM12, SM15, SM16, DP5, SL5, EE6 ]
     owasp_dev_guide_print: [ SM11-12, SM15-16, DP5, SL5, EE6 ]
     owasp_asvs: [ 10.1.1, 12.1.1, 12.2.1, 12.3.1, 12.3.3, 14.2.1, 14.2.2, 16.2.5, 16.5.1 ]
@@ -739,6 +773,7 @@ suits:
     value: "10"
     url: "https://cornucopia.owasp.org/cards/SMX"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM22 ]
     owasp_dev_guide_print: [ SM22 ]
     owasp_asvs: [ 3.5.1, 3.5.2, 3.5.3, 3.5.4, 4.4.2, 10.2.1 ]
@@ -753,6 +788,7 @@ suits:
     value: "J"
     url: "https://cornucopia.owasp.org/cards/SMJ"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SM22 ]
     owasp_dev_guide_print: [ SM22 ]
     owasp_asvs: [ 2.3.1, 2.3.2, 2.3.4, 2.4.2 ]
@@ -767,6 +803,7 @@ suits:
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/SMQ"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM1 ]
     owasp_dev_guide_print: [ SM1 ]
     owasp_asvs: [ 4.4.3, 7.2.1, 7.5.1, 7.5.3, 10.1.1 ]
@@ -781,6 +818,7 @@ suits:
     value: "K"
     url: "https://cornucopia.owasp.org/cards/SMK"
     stride: [ S ]
+    stride_print: [ Spoofing ]
     owasp_dev_guide: [ SM1, SM2, SM3 ]
     owasp_dev_guide_print: [ SM1-3 ]
     owasp_asvs: [ 7.2.1, 7.2.2, 10.1.1, 13.2.1 ]
@@ -795,6 +833,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/SMA"
     stride: []
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -811,6 +850,7 @@ suits:
     value: "2"
     url: "https://cornucopia.owasp.org/cards/AZ2"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ P7 ]
     owasp_dev_guide_print: [ P7 ]
     owasp_asvs: [ 3.4.5, 3.4.8, 3.7.2, 3.7.3, 8.3.1, 8.4.1, 13.1.1, 13.2.4, 13.2.5, 15.3.2 ]
@@ -825,6 +865,7 @@ suits:
     value: "3"
     url: "https://cornucopia.owasp.org/cards/AZ3"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ AC1, AC6, AC7, DP6, DP7, SCM6, PDR1, PDR2, PDR3, PDR4 ]
     owasp_dev_guide_print: [ AC1, AC6-7, DP6-7, SCM6, PDR1-4 ]
     owasp_asvs: [ 8.3.3, 8.4.2, 13.4.5, 14.2.2, 14.2.5, 14.2.7, 14.3.1, 14.3.2, 16.3.3 ]
@@ -839,6 +880,7 @@ suits:
     value: "4"
     url: "https://cornucopia.owasp.org/cards/AZ4"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC3, AC10, AC11 ]
     owasp_dev_guide_print: [ AC3, AC10-11 ]
     owasp_asvs: [ 8.3.1, 16.5.3 ]
@@ -853,6 +895,7 @@ suits:
     value: "5"
     url: "https://cornucopia.owasp.org/cards/AZ5"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ SC1, SC2, SDC1, SDA2, SM2, SM12, AC2, AC3, AC4, ACM4, ACM5, ACM6, ACM7, ACM8, ACM9, SCM2, SCM4, PDR3, PDR4, SLD3 ]
     owasp_dev_guide_print: [ SC1-2, SDC1, SDA2, SDA2, SM2, SM12, AC2-4, ACM4-9, SCM2, SCM4, PDR3-4, SLD3 ]
     owasp_asvs: [ 8.1.1, 10.2.3, 13.2.2, 13.3.2, 16.4.2 ]
@@ -867,6 +910,7 @@ suits:
     value: "6"
     url: "https://cornucopia.owasp.org/cards/AZ6"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC2, AC4, ACM6, ACM7, ACM8, DP4 ]
     owasp_dev_guide_print: [ AC2, AC4, ACM6-8, DP4  ]
     owasp_asvs: [ 8.1.1, 8.1.2, 8.2.2, 8.2.3 ]
@@ -881,6 +925,7 @@ suits:
     value: "7"
     url: "https://cornucopia.owasp.org/cards/AZ7"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC2, AC4, ACM5, ACM6, ACM7, ACM8, DP4 ]
     owasp_dev_guide_print: [ AC2, AC4, ACM5-8, DP4 ]
     owasp_asvs: [ 8.1.1, 8.1.2, 8.2.1, 8.2.2, 8.2.3, 15.3.1 ]
@@ -895,6 +940,7 @@ suits:
     value: "8"
     url: "https://cornucopia.owasp.org/cards/AZ8"
     stride: [ T, E ]
+    stride_print: [ Tampering, 'Elevation of Privilege' ]
     owasp_dev_guide: [ SSV7, FV6, A18, AC14, AC15, ACM1 ]
     owasp_dev_guide_print: [ SSV7, FV6, A18, AC14-15, ACM1 ]
     owasp_asvs: [ 2.1.3, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.3.5, 3.5.7, 16.3.3 ]
@@ -909,6 +955,7 @@ suits:
     value: "9"
     url: "https://cornucopia.owasp.org/cards/AZ9"
     stride: [ D ]
+    stride_print: [ 'Denial of Service' ]
     owasp_dev_guide: [ ACM1 ]
     owasp_dev_guide_print: [ ACM1 ]
     owasp_asvs: [ 2.3.2, 2.4.1 ]
@@ -923,6 +970,7 @@ suits:
     value: "10"
     url: "https://cornucopia.owasp.org/cards/AZX"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC9, AC15 ]
     owasp_dev_guide_print: [ AC9, AC15 ]
     owasp_asvs: [ 8.3.1, 8.3.2, 8.4.1, 13.2.1, 10.4.1, 10.4.2, 10.4.3, 10.4.4, 10.4.5, 10.4.6, 10.4.7, 10.4.8, 10.4.9, 10.4.10, 10.4.11, 10.4.12, 10.4.13, 10.4.14, 10.4.15, 10.4.16, 10.6.1, 10.6.2, 16.3.3 ]
@@ -937,6 +985,7 @@ suits:
     value: "J"
     url: "https://cornucopia.owasp.org/cards/AZJ"
     stride: [ I, E ]
+    stride_print: [ 'Information Disclosure', 'Elevation of Privilege' ]
     owasp_dev_guide: [ ACM8 ]
     owasp_dev_guide_print: [ ACM8 ]
     owasp_asvs: [ 8.1.4, 8.2.1, 8.3.1, 8.4.2, 14.2.4 ]
@@ -951,6 +1000,7 @@ suits:
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/AZQ"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ SFL9, CEC7, LF6 ]
     owasp_dev_guide_print: [ SFL9, CEC7, LF6 ]
     owasp_asvs: [ 1.2.3, 1.2.4, 1.2.5, 1.2.6, 1.2.7, 1.2.8, 1.2.9, '1.2.10', 5.4.2, 5.4.3, 16.4.1 ]
@@ -965,6 +1015,7 @@ suits:
     value: "K"
     url: "https://cornucopia.owasp.org/cards/AZK"
     stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ AC8, AC15, ACM8 ]
     owasp_dev_guide_print: [ AC8, AC15, ACM8 ]
     owasp_asvs: [ 7.2.1, 8.2.1, 8.3.1, 8.4.2, 13.2.3, 14.2.4 ]
@@ -979,6 +1030,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/AZA"
     stride: [ ]
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -995,6 +1047,7 @@ suits:
     value: "2"
     url: "https://cornucopia.owasp.org/cards/CR2"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ P15, CP6, SCM6, SCM7, PDR1, PDR3 ]
     owasp_dev_guide_print: [ P15, CP6, SCM6-7, PDR1, PDR3 ]
     owasp_asvs: [ 11.2.1, 11.3.2, 11.3.3, 11.4.1 ]
@@ -1009,6 +1062,7 @@ suits:
     value: "3"
     url: "https://cornucopia.owasp.org/cards/CR3"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SFL3, SFL4, VSD1 ]
     owasp_dev_guide_print: [ SFL3-4, VSD1 ]
     owasp_asvs: [ 4.1.5, 6.7.1, 9.1.1, 9.1.2, 9.1.2, 11.3.3, 11.4.3, 14.2.4 ]
@@ -1023,6 +1077,7 @@ suits:
     value: "4"
     url: "https://cornucopia.owasp.org/cards/CR4"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ P15, PDT1, PDT2, PDT3, PDT4, PDT5 ]
     owasp_dev_guide_print: [ P15, PDT1-5 ]
     owasp_asvs: [ 12.2.1, 14.2.1, 14.2.6 ]
@@ -1037,6 +1092,7 @@ suits:
     value: "5"
     url: "https://cornucopia.owasp.org/cards/CR5"
     stride: [ T, I ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ CP3, PDT4 ]
     owasp_dev_guide_print: [ CP3, PDT4 ]
     owasp_asvs: [ 11.2.5, 12.2.1, 12.3.1, 12.3.3 ]
@@ -1051,6 +1107,7 @@ suits:
     value: "6"
     url: "https://cornucopia.owasp.org/cards/CR6"
     stride: [ T, I ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ A14, A15, PDR2, PDR3, PDR4, PDT1, PDT2, PDT3, PDT4, PDT5, PDT6, PDT7, PDT8, PDT9, PDT10, PDT11 ]
     owasp_dev_guide_print: [ A14-15, PDR2-4, PDT1-11 ]
     owasp_asvs: [ 4.4.1, 11.7.1, 11.7.2, 12.1.1, 12.1.2, 12.1.3, 12.1.4, 12.1.5, 12.2.1, 12.2.2, 12.3.1, 12.3.2, 12.3.3, 12.3.4, 12.3.5, 13.4.2, 14.2.1, 14.2.2, 14.2.3, 14.2.4, 14.2.5, 14.2.6, 14.3.1, 14.3.2, 14.3.3 ]
@@ -1065,6 +1122,7 @@ suits:
     value: "7"
     url: "https://cornucopia.owasp.org/cards/CR7"
     stride: [ T, I ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ SM15, PDT4, PDT5, PDT6, PDT7, PDT8 ]
     owasp_dev_guide_print: [ SM15, PDT4-8 ]
     owasp_asvs: [ 3.4.1, 3.7.4, 4.1.2, 11.3.3, 11.3.4, 11.3.5, 12.1.1, 12.1.2, 12.1.3, 12.1.4, 12.2.1, 12.2.2, 12.3.1, 12.3.2, 12.3.3, 12.3.4, 12.3.5 ]
@@ -1079,6 +1137,7 @@ suits:
     value: "8"
     url: "https://cornucopia.owasp.org/cards/CR8"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ P1, P2, SM12, SCM6, PDR1, PDR2, PDR3, PDR4 ]
     owasp_dev_guide_print: [ P1-2, SM12, SCM6, PDR1-4 ]
     owasp_asvs: [ 11.2.1, 11.3.1, 11.3.2, 11.3.3, 11.3.4, 11.3.5, 11.4.1, 11.4.2, 11.6.1, 11.6.2, 13.3.1, 14.1.1, 14.1.2 ]
@@ -1093,6 +1152,7 @@ suits:
     value: "9"
     url: "https://cornucopia.owasp.org/cards/CR9"
     stride: [ T, I ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ SM3, CP4, CP5, CP6 ]
     owasp_dev_guide_print: [ SM3, CP4-6 ]
     owasp_asvs: [ 11.2.1, 11.2.2, 11.2.3, 11.2.4, 11.2.5, 11.3.1, 11.3.2, 11.3.3, 11.3.4, 11.3.5, 11.4.1, 11.4.2, 11.4.3, 11.4.4, 11.5.1, 11.5.2, 11.6.1, 11.6.2 ]
@@ -1107,6 +1167,7 @@ suits:
     value: "10"
     url: "https://cornucopia.owasp.org/cards/CRX"
     stride: [ T, I ]
+    stride_print: [ Tampering, 'Information Disclosure' ]
     owasp_dev_guide: [ CP4, CP5, CP6 ]
     owasp_dev_guide_print: [ CP4-6 ]
     owasp_asvs: [ 11.2.3, 11.4.2, 11.4.3, 11.4.4, 11.5.1, 11.5.2 ]
@@ -1121,6 +1182,7 @@ suits:
     value: "J"
     url: "https://cornucopia.owasp.org/cards/CRJ"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC12, SQ6, SQ7, SDA3, ACM8, SCM6, SCM7, PDR1 ]
     owasp_dev_guide_print: [ SC12, SQ6-7, SDA3, ACM8, SCM6-7, PDR1 ]
     owasp_asvs: [ 11.1.1, 11.1.2, 11.1.4, 13.1.4, 13.3.1, 13.3.3, 14.2.2, 16.2.5, 17.2.1 ]
@@ -1134,7 +1196,8 @@ suits:
     id: "CRQ"
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/CRQ"
-    stride: [ T, I ]
+    stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC12, SCM2, SCM6, SCM7 ]
     owasp_dev_guide_print: [ SC12, SCM2, SCM6-7 ]
     owasp_asvs: [ 11.2.3, 11.2.4, 11.2.5, 11.3.1, 11.3.2, 11.3.4, 11.4.1, 11.4.2, 11.4.3, 11.4.4, 11.5.1, 11.5.2, 11.6.1, 11.6.2, 13.3.1 ]
@@ -1149,6 +1212,7 @@ suits:
     value: "K"
     url: "https://cornucopia.owasp.org/cards/CRK"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ CP2, P2 ]
     owasp_dev_guide_print: [ CP2, P2 ]
     owasp_asvs: [ 11.2.4, 11.2.5, 11.3.1, 11.3.2, 11.3.3, 11.3.4, 11.3.5, 11.4.1, 11.5.1, 11.6.1, 11.6.2 ]
@@ -1163,6 +1227,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/CRA"
     stride: []
+    stride_print: [ ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -1179,6 +1244,7 @@ suits:
     value: "2"
     url: "https://cornucopia.owasp.org/cards/C2"
     stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SFL8, SFL10, ACM9, MM1, MM2, MM3, MM4, MM5, MM6, MM8, MM9 ]
     owasp_dev_guide_print: [ SFL8, SFL10, ACM9, MM1-6, MM8-9 ]
     owasp_asvs: [ 1.4.1, 1.4.2, 1.4.3, 3.7.1, 11.2.5, 15.1.1, 15.1.2, 15.1.4, 15.1.5, 15.2.1, 15.2.2, 15.2.5, 15.4.1, 15.4.2, 15.4.3, 15.4.4, 16.5.2, 16.5.3 ]
@@ -1193,6 +1259,7 @@ suits:
     value: "3"
     url: "https://cornucopia.owasp.org/cards/C3"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC2, SC4, SC9, SC11 ]
     owasp_dev_guide_print: [ SC2, SC4, SC9, SC11 ]
     owasp_asvs: [ 13.4.1, 13.4.2, 13.4.5, 13.4.6, 13.4.7, 15.2.3 ]
@@ -1207,6 +1274,7 @@ suits:
     value: "4"
     url: "https://cornucopia.owasp.org/cards/C4"
     stride: [ R ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ A1, A2, A13, A18, P5 ]
     owasp_dev_guide_print: [ A1-2, A13, A18, P5 ]
     owasp_asvs: [ 6.3.2, 6.7.1, 6.8.2, 16.3.1, 16.3.2, 16.3.3, 16.3.4 ]
@@ -1221,6 +1289,7 @@ suits:
     value: "5"
     url: "https://cornucopia.owasp.org/cards/C5"
     stride: [ R ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ 3.4.3, 3.4.6, 3.4.7, 3.4.8, 3.7.2, 3.7.3, 12.1.4, 12.2.1, 12.2.2, 12.3.1, 12.3.4 ]
@@ -1234,7 +1303,8 @@ suits:
     id: "C6"
     value: "6"
     url: "https://cornucopia.owasp.org/cards/C6"
-    stride: [ S, T, E ]
+    stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ A4, AC10, CP3, EE1, EE8, EE9, EE10, EE11 ]
     owasp_dev_guide_print: [ A4, AC10, CP3, EE1, EE8-11 ]
     owasp_asvs: [ 11.2.5, 12.2.1, 12.3.1, 12.3.3, 16.5.3 ]
@@ -1249,6 +1319,7 @@ suits:
     value: "7"
     url: "https://cornucopia.owasp.org/cards/C7"
     stride: [ R ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ A4 SL1, SL2, SL3, SL6, SL7, SL8, SL9, SL10, SL11, SL12, SL13, SLD3, SLD4, SLD8, SLD9, SLD10 ]
     owasp_dev_guide_print: [ A4 SL1-3, SL6-13, SLD3-4, SLD8-10 ]
     owasp_asvs: [ 16.1.1, 16.2.1, 16.2.2, 16.2.3, 16.2.4, 16.3.1, 16.3.2, 16.3.3, 16.3.4, 16.4.1, 16.4.2, 16.4.3 ]
@@ -1263,6 +1334,7 @@ suits:
     value: "8"
     url: "https://cornucopia.owasp.org/cards/C8"
     stride: [ I ]
+    stride_print: [ 'Information Disclosure' ]
     owasp_dev_guide: [ SC1, SC2, SC3, SC4, SC5, SC6, SC7, SC8, SC9, SC10, SC11, SC12, SC13, SFL1, SFL2, SFL14, SFL15, SDC2, SDC3, SDC4, SDC5, SDC6, SDA1, PDT1, PDT2, PDT3, PDT4, PDT5, PDT6, PDT7, PDT8, PDT9, PDT10, PDT11 ]
     owasp_dev_guide_print: [ SC1-13, SFL1-2, SFL14-15, SDC2-6, SDA1, PDT1-11 ]
     owasp_asvs: [ 13.2.1, 13.2.2, 13.2.3, 15.1.1, 15.1.2, 15.2.1, 15.2.4 ]
@@ -1276,7 +1348,8 @@ suits:
     id: "C9"
     value: "9"
     url: "https://cornucopia.owasp.org/cards/C9"
-    stride: [ I, E ]
+    stride: [ E ]
+    stride_print: [ 'Elevation of Privilege' ]
     owasp_dev_guide: [ A1, A3, A9, A10, AC2, AC12, ACM4, ACM5, ACM6, ACM7, ACM8 ]
     owasp_dev_guide_print: [ A1, A3, A9-10, AC2, AC12, 7.2-8 ]
     owasp_asvs: [ 7.5.3, 8.4.2, 13.2.1, 13.2.2, 13.2.3 ]
@@ -1290,7 +1363,8 @@ suits:
     id: "CX"
     value: "10"
     url: "https://cornucopia.owasp.org/cards/CX"
-    stride: [ T, E ]
+    stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SC4, SFL1, SFL2, SFL10, SFL11, SFL12, SFL13, SFL14, SFL15 ]
     owasp_dev_guide_print: [ SC4, SFL1-2, SFL10-15 ]
     owasp_asvs: [ 15.1.1, 15.1.2, 15.2.1, 15.2.2, 15.2.3, 15.2.4, 15.2.5 ]
@@ -1304,7 +1378,8 @@ suits:
     id: "CJ"
     value: "J"
     url: "https://cornucopia.owasp.org/cards/CJ"
-    stride: [ T, I, E ]
+    stride: [ T ]
+    stride_print: [ Tampering ]
     owasp_dev_guide: [ SC1, SC12, SC13, FM1, FM2, FM3, FM4, FM5, SFL1, SFL2, SFL3, SFL4, SFL5, SFL6, SDC4, SDC5, SDC6, SDA1, SDA2, AC6, AC7, ACM8, PDT2, PDT8 ]
     owasp_dev_guide_print: [ SC1, SC12-13, FM1-5, SFL1-6, SDC4-6, SDA1-2, AC6-7, ACM8, PDT2, PDT8 ]
     owasp_asvs: [ 3.7.5, 15.1.1, 15.1.2, 15.2.1, 15.2.2, 15.2.3, 15.2.4, 15.2.5 ]
@@ -1319,6 +1394,7 @@ suits:
     value: "Q"
     url: "https://cornucopia.owasp.org/cards/CQ"
     stride: [ R ]
+    stride_print: [ Repudiation ]
     owasp_dev_guide: [ M1, M2 ]
     owasp_dev_guide_print: [ M1-2 ]
     owasp_asvs: [ 2.3.2, 2.4.1, 2.4.2, 6.3.1, 6.3.5, 6.3.7, 7.4.5, 7.5.1, 7.5.2, 7.5.3, 8.1.3, 8.1.4, 8.3.2, 8.4.2, 16.3.1, 16.3.2, 16.3.3, 16.3.4 ]
@@ -1333,6 +1409,7 @@ suits:
     value: "K"
     url: "https://cornucopia.owasp.org/cards/CK"
     stride: [ D ]
+    stride_print: [ 'Denial of Service' ]
     owasp_dev_guide: [ A12, ACM1 ]
     owasp_dev_guide_print: [ A12, ACM1 ]
     owasp_asvs: [ 1.3.12, 2.3.2, 2.4.1, 2.4.2, 4.2.5, 4.3.1, 5.2.1, 5.2.6, 6.1.1, 6.3.1, 10.5.5, 10.6.2, 13.1.2, 13.1.3, 13.2.6, 15.1.3, 17.1.2, 17.3.1, 17.3.2 ]
@@ -1347,6 +1424,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/CA"
     stride: []
+    stride_print: [ ]
     owasp_dev_guide: [ "-" ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ "-" ]
@@ -1363,6 +1441,7 @@ suits:
     value: "A"
     url: "https://cornucopia.owasp.org/cards/JOA"
     stride: []
+    stride_print: [ ]
     owasp_dev_guide: [ "-" ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ 3.1.1, 5.1.1, 5.4.3, 10.4.7 ]
@@ -1375,6 +1454,7 @@ suits:
     value: "B"
     url: "https://cornucopia.owasp.org/cards/JOB"
     stride: []
+    stride_print: [ ]
     owasp_dev_guide: [ "-" ]
     owasp_dev_guide_print: [ "-" ]
     owasp_asvs: [ 3.1.1, 5.1.1, 6.4.5-6, 10.7.1, 10.7.2, 10.7.3, 11.1.3, 11.1.4, 13.1.4, 14.2.8 ]


### PR DESCRIPTION
In this pull-request:

- More STRIDE code corrections. Secondary impact removed.
- Add STRIDE print tags for printing
- Make sure the STRIDE category is displayed in the mapping table on the website in full when shown as a link.