### PR TITLE
Style fixes

### DIFF
--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA2/explanation.md
@@ -18,7 +18,7 @@ Choi really wanted to pay his student loan, but he also really needed to go to t
 
 ### STRIDE
 
-### What can go Wrong? 
+### What can go wrong? 
  
 If the unlock key is not used or it's not confirmed that the unlocked key has been used, then the mobile application may be vulnerable to local authentication bypass. This type of vulnerability can be exploited by a controlling partner, a spy or a thief to get access to sensitive information. Effectively resulting in a data breach. 
  

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA3/explanation.md
@@ -13,7 +13,7 @@ Little does she know that this app, in particular, will look for capabilities, o
 
 ### STRIDE
 
-### What can go Wrong? 
+### What can go wrong? 
  
 - Custom Permission Typos: A custom permission may be declared in the Manifest of one of the apps installed on Vandana's phone, but a different custom permission is used to protect exported Android components, due to a typo, Choi's malicious application can capitalize on the misspelling by either: 
   - Registering that permission first 

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA4/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA5/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA6/explanation.md
@@ -6,7 +6,7 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?
 

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA7/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA8/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA9/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAA/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAJ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAK/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAQ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AAX/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM2/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM3/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM4/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM5/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM6/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM7/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM8/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CM9/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMA/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMJ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMK/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMQ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cornucopia/CMX/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM2/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM3/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM4/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM5/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM6/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM7/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM8/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRM9/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMA/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMJ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMK/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?s

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMQ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMQ/technical-note.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMQ/technical-note.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/cryptography/CRMX/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS2/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS3/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS4/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS5/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS6/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS7/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS8/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NS9/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSA/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSJ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSK/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSQ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/network-&-storage/NSX/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC2/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC3/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC4/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC5/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC6/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC7/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC8/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PC9/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCA/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCJ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCK/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCQ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/platform-&-code/PCX/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS2/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS3/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS4/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS5/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS6/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS7/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS8/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RS9/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSA/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSJ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSK/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSQ/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/resilience/RSX/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/wild-card/JOAM/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/wild-card/JOAM/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/wild-card/JOBM/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/wild-card/JOBM/explanation.md
@@ -6,6 +6,6 @@
 
 ### STRIDE
 
-### What can go Wrong?
+### What can go wrong?
 
 ### What are you going to do about it?

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT2/explanation.md
@@ -22,7 +22,7 @@ James is able to perform authentication-related actions without the legitimate u
 STRIDE’s **Repudiation** threat category is about the ability to perform actions that cannot be traced or denied — essentially a lack of sufficient logging, auditing, or notification.
 The absence of alerts/notifications means the legitimate user cannot detect or contest the malicious activity. That is classic repudiation risk. Depending on the context, any of the other categories could be a secondary or related impact.
 
-### What can go Wrong?
+### What can go wrong?
 
 This kind of vulnerability can lead to unnoticed account takeovers, prolonged unauthorized access, and potentially significant data breaches or identity theft.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT3/explanation.md
@@ -32,7 +32,7 @@ Muhammad gains access to confidential information (passwords, secrets) that shou
 STRIDE’s **Information Disclosure** category is specifically about unauthorized exposure of sensitive data.
 The example (plaintext password interception) is a textbook case of information disclosure due to lack of encryption in transit.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to widespread unauthorized access, data breaches, identity theft, and compromise of sensitive information.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT4/explanation.md
@@ -21,7 +21,7 @@ The scenario maps directly to STRIDE: **Information Disclosure**.
 Sebastien is learning something the system should treat as sensitive: the set of valid usernames.
 In STRIDE, **Information Disclosure** is about exposing data to unauthorized parties. Usernames are part of authentication secrets, and leaking or allowing enumeration discloses information attackers can weaponize.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to targeted attacks, including phishing, social engineering, and brute-force attacks, as attackers gain knowledge about valid user accounts.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT5/explanation.md
@@ -26,7 +26,7 @@ Spoofing is about pretending to be someone or something you’re not.
 By logging in with default, test, old, or unnecessary accounts, Javier spoofs a legitimate user (or admin), but
 if the default/test account has higher-than-normal rights (e.g., admin), Javier also escalates privileges making **Elevation of Privilege** a secondary impact.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities allow for unauthorized access and control, leading to potential data breaches, system manipulations, and other security risks.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT6/explanation.md
@@ -22,7 +22,7 @@ This scenario is a clear case of STRIDE: **Spoofing**.
 Sven takes advantage of weakly managed temporary credentials to log in as a legitimate user.
 The system fails to enforce proper lifecycle rules (expiry, one-time use, out-of-band delivery), which makes impersonation possible.
 
-### What can go Wrong?
+### What can go wrong?
 
 This oversight can lead to unauthorized account access, data breaches, and potential exploitation of system vulnerabilities.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT7/explanation.md
@@ -22,7 +22,7 @@ The scenario falls under STRIDE: **Spoofing**.
 In brute force, dictionary, or credential stuffing attacks, the attacker’s entire goal is to gain access by impersonating a valid user with guessed or stolen credentials.
 The root weakness here is inadequate authentication protections (no lockouts, weak password policy), which makes spoofing identities feasible.
 
-### What can go Wrong?
+### What can go wrong?
 
 This type of vulnerability exposes users to account takeover, data breaches, and potentially, the compromise of the entire system.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT8/explanation.md
@@ -18,7 +18,7 @@ That scenario maps directly to STRIDE: **Spoofing**
 Here, Kate bypasses authentication entirely because the system fails insecure (defaults to granting access).
 Even though no valid credentials were provided, the system treats her as authenticated → she is spoofing identity. There might be secondary impacts that maps to the other STRIDE categories depending on the context.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized access to sensitive data and systems, potentially compromising the entire network or application.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/AT9/explanation.md
@@ -20,7 +20,7 @@ This scenario falls under STRIDE: **Spoofing**.
 Claudia uses weak authentication (password-only, no 2FA, no re-auth for critical functions) to impersonate legitimate users and gain access to high-value resources.
 The issue isn’t that the data is leaked by accident (Information Disclosure) or modified directly (Tampering), but that the system cannot strongly verify identity, making spoofing trivial.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized access to sensitive functions and data, posing a significant risk to the organization’s security and integrity.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATA/explanation.md
@@ -19,7 +19,7 @@ Any of the STRIDE categories may be applicable, but the primary concern is usual
 
 Authentication’s main purpose is to verify identity. If you can invent a new way to bypass or manipulate authentication, the attacker can impersonate legitimate users. That’s the essence of a **Spoofing** threat.
 
-### What can go Wrong?
+### What can go wrong?
 
 User impersonation, privilege escalation, credential theft, MFA bypass, session hijacking, account enumeration, denial of service, audit gaps.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATJ/explanation.md
@@ -20,7 +20,7 @@ This scenario maps directly to STRIDE: **Spoofing**.
 Even though no credentials are provided, Mark gains access to the system without authentication, effectively being treated as a valid user.
 The system’s failure is that it assumes authentication is done elsewhere or not needed — this lets an attacker bypass identity verification entirely.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such an absence of authentication exposes the system to unauthorized access, potentially leading to data breaches and exploitation of sensitive resources.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATK/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Tampering**.
 Olga alters the authentication module itself, changing how it behaves so she can bypass normal checks.
 The attack is not just exploiting weak authentication, it’s modifying the code that enforces authentication, which is classic integrity compromise, i.e., **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 This form of attack can lead to unauthorized system access, data breaches, and potentially allow for widespread manipulation of system functions.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATQ/explanation.md
@@ -20,7 +20,7 @@ This scenario is clearly STRIDE: **Spoofing**.
 Johan exploits inconsistent authentication enforcement across channels/functions to gain unauthorized access.
 Even though the main website is secure, weaker checks in the mobile app allow him to bypass identity verification, effectively impersonating a user.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such inconsistencies can lead to unauthorized access and exploitation of authentication weaknesses, posing a significant risk to user data and system integrity.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authentication/ATX/explanation.md
@@ -20,7 +20,7 @@ This case is a STRIDE: **Spoofing** issue.
 Here, Pravin bypasses authentication by exploiting fragmented, weak, or inconsistent authentication routines.
 The system’s failure is that it doesn’t enforce authentication uniformly through a centralized, proven mechanism. That lets him log in (spoof identity) without legitimate credentials.
 
-### What can go Wrong?
+### What can go wrong?
 
 This decentralized approach to authentication can lead to uneven security standards, making it easier for attackers to find and exploit the weakest link in the system.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ2/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Tampering**.
 Tim is able to redirect or forward data to locations under his control, altering the intended path or destination of sensitive information.
 The core issue is manipulating the system’s handling of data, which fits the definition of **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized data disclosure, data breaches, and the potential compromise of sensitive information.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ3/explanation.md
@@ -24,7 +24,7 @@ This scenario maps primarily to STRIDE: **Information Disclosure**.
 Christian leverages secondary mechanisms—such as a search indexer, logs, reports, caches, or residual data—to access sensitive information.
 The core issue is unauthorized access to confidential information, which fits squarely under **Information Disclosure**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized information access, breaches of confidentiality, and potential compliance issues.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ4/explanation.md
@@ -18,7 +18,7 @@ This scenario maps primarily to STRIDE: **Elevation of Privilege**.
 Kelly exploits a non-secure fallback in the authorization mechanism. When the system encounters an error, it defaults to granting access, allowing her to access areas she normally shouldn’t.
 The attack is not about impersonating someone else (Spoofing), but about accessing resources without proper authorization, which is classic **Elevation of Privilege**.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized access to sensitive data or functionalities, potentially compromising the entire system’s security.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ5/explanation.md
@@ -21,7 +21,7 @@ In this case, the attacker can access resources—files, processes, session data
 The root cause is missing authorization or excessive privileges, violating the principle of least privilege.
 The consequence of such an action leads to **Information Disclosure** in most cases.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized access to critical resources, potentially resulting in data breaches, system manipulation, and other security compromises.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ6/explanation.md
@@ -21,7 +21,7 @@ Eduardo has legitimate access to the page (entry point), but the backend does no
 The core issue is improper enforcement of authorization at the data level, enabling privilege escalation within the context of an allowed page.
 The consequence of such an action leads to **Information Disclosure** in most cases.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such gaps in authorization controls can lead to unauthorized data access, potentially resulting in information leakage, privacy breaches, and compliance violations.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ7/explanation.md
@@ -21,7 +21,7 @@ Yuanjing, a regular user, can access administrative functions and confidential o
 The attack’s core issue is unauthorized access to higher-privilege operations, which is classic **Elevation of Privilege**.
 The consequence of such an action leads to **Information Disclosure** in most cases.
 
-### What can go Wrong?
+### What can go wrong?
 
 This type of security lapse can lead to unauthorized access to critical application functionalities, potential data breaches, and misuse of sensitive system properties.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ8/explanation.md
@@ -24,7 +24,7 @@ This scenario maps primarily to STRIDE: **Elevation of Privilege** through the u
 Tom bypasses business rules by altering the normal sequence of operations, manipulating parameters, or changing date/time values, which allows him to exploit the application.
 The attack is focused on modifying the intended process or control data, which is classic **Tampering**, but by bypassing rules or manipulating time, Tom effectively escalates his privileges, e.g., the system treats him as if he is eligible for the time-limited offer which mean that the primary impact in many such **Tampering** cases is **Elevation of Privilege**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to process integrity breaches, unauthorized access to restricted functionalities, and potential financial losses or data inconsistencies.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZ9/explanation.md
@@ -24,7 +24,7 @@ This scenario maps primarily to STRIDE: **Denial of Service** (DoS).
 Mike exploits a valid feature too quickly or too frequently, consuming server resources and creating race conditions, which affects availability and correctness.
 The attack is focused on resource exhaustion and misuse of intended functionality, which aligns with the DoS category.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such misuse can lead to system overloads, degraded performance, unintended application behaviors, and negative impacts on other users.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZA/explanation.md
@@ -16,7 +16,7 @@ Inventing an authorization threat could lead to:
 
 Any of the STRIDE categories may be applicable, but primary impact is usually **Elevation of Privilege**, since bypassing authorization typically means doing more than you should.
 
-### What can go Wrong?
+### What can go wrong?
 
 Privilege escalation, data leaks, unauthorized actions, bypassed business rules, audit failures, chained attacks, potential DoS.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZJ/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Information Disclosure** and potential
 Dinis, a regular user, can access security configurations and ACLs, which are normally restricted and sensitive, meaning that there is a **Information Disclosure**. In the case that he can modify them, he can grant himself higher privileges, escalating his access.
 The core issue is unauthorized access to sensitive security controls, potentially, enabling privilege escalation.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized alterations in security settings, potential system breaches, and the compromise of network integrity.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZK/explanation.md
@@ -17,7 +17,7 @@ Ryan targets an enterprise application that has loosely managed authorization co
 This scenario maps primarily to STRIDE: **Elevation of Privilege** (EoP).
 Ryan modifies authorization settings. That means that he is **Tampering** with the settings, but as a direct result, he grants himself higher privileges, which is **Elevation of Privilege**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized access, data breaches, and potentially full system compromise.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZQ/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Elevation of Privilege** (EoP).
 Christopher injects a command that the system executes at a higher privilege level than his own user role, gaining unauthorized administrative access.
 The attack exploits lack of privilege checks combined with command injection, allowing him to perform higher-privilege operations.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized system access, data breaches, and potential control over critical system functionalities.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/authorization/AZX/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Elevation of Privilege**.
 Richard exploits the fact that centralized authorization is not applied consistently across all modules. By targeting modules that bypass the central controls, he accesses sensitive files and actions beyond his permissions.
 The core issue is inadequate enforcement of authorization, allowing a user to perform higher-privilege operations than intended.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such inconsistencies in authorization control application can lead to unauthorized access to sensitive functionalities and data, posing a significant risk to the application’s security.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C2/explanation.md
@@ -23,7 +23,7 @@ Lee is altering or influencing the application’s behavior through exploitation
 **Tampering** in STRIDE covers unauthorized modification of data or code or causing the application to behave differently than intended, which is what occurs here.
 Exploiting buffer overflows or unsafe functions to inject malicious code directly falls under **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to a range of issues, from unauthorized access and data breaches to complete system compromise.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C3/explanation.md
@@ -20,7 +20,7 @@ Andrew is gaining access to sensitive information (source code, embedded secrets
 STRIDE’s **Information Disclosure** covers scenarios where an attacker learns secrets or confidential information without proper authorization.
 Accessing or decompiling source code, and uncovering embedded credentials or business logic, constitutes unauthorized exposure of sensitive data, which is exactly what I**nformation Disclosure** describes.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such exposure of source code and business logic can lead to unauthorized access, intellectual property theft, and exploitation of hidden vulnerabilities or secrets within the application.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C4/explanation.md
@@ -22,7 +22,7 @@ The applicable STRIDE category here is **Repudiation**.
 In this scenario, Keith conducts unauthorized transactions, and the lack of proper logging prevents attribution, so he can deny responsibility.
 STRIDE’s **Repudiation** threat focuses on the inability to trace or hold users accountable for their actions.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized actions going unnoticed, hinder incident response efforts, and impede accountability, potentially resulting in financial losses and security breaches.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C5/explanation.md
@@ -18,7 +18,7 @@ The primary STRIDE category is **Spoofing**.
 
 This scenario is about exploiting trust for malicious gain, typically referred to in STRIDE as **Spoofing**, because Larry pretends to be the trusted application or uses its trusted identity to deceive others.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such manipulation can lead to significant breaches of user trust, unauthorized access to sensitive information, and exploitation of interconnected systems.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C6/explanation.md
@@ -22,7 +22,7 @@ Aaron is bypassing controls by exploiting weaknesses in error/exception handling
 Errors are not handled consistently, allowing Aaron to access sensitive functions and do not default to denying access, so application logic can be bypassed.
 Reliance on other systems for error handling introduces exploitable gaps.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities in error handling can lead to unauthorized access, exposure of sensitive information, and potentially allow attackers to manipulate application behavior.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C7/explanation.md
@@ -22,7 +22,7 @@ The STRIDE category applicable here is **Repudiation**.
 
 **Repudiation** occurs when actions cannot be traced back to the responsible party, typically due to missing or inadequate logging, auditing, or accountability mechanisms.
 
-### What can go Wrong?
+### What can go wrong?
 
 Inadequate logging and auditing can lead to significant gaps in security oversight, hindering the ability to detect, investigate, and respond to unauthorized activities.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C8/explanation.md
@@ -24,7 +24,7 @@ David is accessing data he should not be able to see because of weaknesses in th
 The primary impact is that confidential information is revealed to an unauthorized party.
 Even though the application layer is bypassed, the core effect is exposure of sensitive data, which aligns with **Information Disclosure**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized data access, data breaches, and potentially compromise the entire network and associated systems.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/C9/explanation.md
@@ -20,7 +20,7 @@ Michael is gaining access to administrative functions and sensitive data that he
 The core impact is that he is escalating his access from a normal user (or unauthenticated user) to an administrative level.
 Even though he can view and modify data, the underlying issue is that privilege boundaries are bypassed, which aligns with **Elevation of Privilege** rather than **Information Disclosure** (which focuses only on unauthorized reading) or **Tampering** (which focuses on modifying data within authorized access).
 
-### What can go Wrong?
+### What can go wrong?
 
 Unsecured administrative tools and interfaces can lead to major data breaches, unauthorized access to sensitive information, and potential system-wide compromises.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CA/explanation.md
@@ -17,7 +17,7 @@ Depending on which type of attack you invent, you may be able to:
 
 To address truly unknown or novel threats that don't fit the STRIDE categories, use techniques like adversarial thinking, red teaming, and keeping up with emerging vulnerabilities to anticipate and prepare for these unforeseen risks in a comprehensive threat model.
 
-### What can go Wrong?
+### What can go wrong?
 
 Almost anything, You name it!
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CJ/explanation.md
@@ -22,7 +22,7 @@ The scenario involves exploiting weaknesses introduced during development, compi
 The primary impact is that an attacker can manipulate, exploit, or modify the behavior of the application due to these weaknesses.
 Although this could also enable unauthorized access, the root cause is the application's susceptibility to manipulation or misuse, which is characteristic of **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 These vulnerabilities can lead to significant security breaches, unauthorized access, and potential exploitation of sensitive data and system functionalities.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CK/explanation.md
@@ -22,7 +22,7 @@ Grant’s actions prevent legitimate users from accessing the application.
 The impact is on availability, which is exactly what **Denial of Service** attacks target.
 STRIDE explicitly associates attacks that reduce or eliminate system availability with **Denial of Service**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to the application becoming unavailable or unresponsive, impacting user experience, and potentially causing financial and reputational damage to the service provider.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CQ/explanation.md
@@ -20,7 +20,7 @@ Jim can perform malicious actions without the system detecting or responding in 
 The key issue is that the system cannot reliably track or attribute actions as they happen, which aligns with **Repudiation** — the inability to prove who performed a given action.
 Lack of monitoring and automated response means there’s no immediate accountability or enforcement, which is central to repudiation concerns.
 
-### What can go Wrong?
+### What can go wrong?
 
 The inability to detect and respond to malicious activities in real-time can lead to extended unauthorized access, data breaches, and significant exploitation of system vulnerabilities.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cornucopia/CX/explanation.md
@@ -26,7 +26,7 @@ The scenario describes circumventing application controls via vulnerable or mali
 The primary impact is that an attacker can modify, manipulate, or exploit the application’s behavior through weaknesses in these components.
 The core issue in the context of vulnerable/malicious components is that the attacker can alter execution or manipulate application operations, which aligns with **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 The use of vulnerable or compromised software components can lead to significant security breaches, unauthorized data access, and potential system compromises.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR2/explanation.md
@@ -19,7 +19,7 @@ The applicable STRIDE category for this scenario is **Information Disclosure**.
 Kyun is able to access sensitive data (passwords, user details) that was not properly protected.
 The data was only obfuscated, not securely encrypted, so confidential information is exposed to an attacker.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such practices can lead to unauthorized data access and breaches, as obfuscation alone is insufficient to protect against determined attackers.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR3/explanation.md
@@ -21,7 +21,7 @@ The applicable STRIDE category for this scenario is **Tampering**.
 Axel is modifying data, source code, updates, or configuration in a way that the system cannot detect because integrity checks are missing.
 The core threat is unauthorized alteration of information or code, which could lead to malicious execution or corruption.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to unauthorized data manipulation, introduction of malware, corrupted system updates, and compromised system functionality.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR4/explanation.md
@@ -19,7 +19,7 @@ The applicable STRIDE category for this scenario is **Information Disclosure**.
 Paulo is able to access sensitive data (credentials, financial information) because it is not properly protected, even though the transport channel is encrypted.
 The core threat is exposure of confidential information — he is reading data he should not be able to see.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to data exposure and breaches, especially if endpoint security is compromised or if there are gaps in the transmission channel’s encryption.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR5/explanation.md
@@ -18,7 +18,7 @@ Kyle may be able to access sensitive data because the cryptographic controls fai
 The main impact than is that confidential information is exposed, rather than modified (Tampering) or misused to gain higher privileges (Elevation of Privilege), but if the scenario involves cryptographic integrity mechanisms, like digital signatures or message authentication codes (MACs), then a failure could allow Kyle to modify data undetected. In that case, the primary impact would be **Tampering** rather than **Information Disclosure**.
 
 
-### What can go Wrong?
+### What can go wrong?
 
 Such a vulnerability can lead to data exposure and breaches, as it allows sensitive information to be processed or transmitted without the intended cryptographic protection.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR6/explanation.md
@@ -19,7 +19,7 @@ Romain can both read and modify sensitive unencrypted data. That means two STRID
 1. **Information Disclosure**: because he can read cryptographic secrets, credentials, and personal/commercially-sensitive data in memory or in transit.
 2. **Tampering** because he can modify unencrypted data (e.g., session identifiers, payment details) in memory or on the wire.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized access to sensitive data, data breaches, and potential manipulation of critical information.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR7/explanation.md
@@ -22,7 +22,7 @@ The primary applicable STRIDE categories for this scenario is **Information Disc
 
 Because Gunter can intercept and decrypt the data in transit due to weak protocol deployment, misconfigured SSL/TLS, or untrusted/invalid certificates. This is a confidentiality failure, but as he can also modify the encrypted data (MITM style, degrade the connection, or re-encrypt altered content), it also falls into **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to data interception, unauthorized access, and information tampering, potentially compromising user privacy and data integrity.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR8/explanation.md
@@ -19,7 +19,7 @@ The applicable STRIDE category for this scenario is **Information Disclosure**.
 The weakness is that sensitive stored data (passwords, session IDs, PII, cardholder data) is not encrypted or hashed securely, so when Eoin gains access, he can directly read it. That’s a confidentiality failure.
 If what’s exposed are passwords or session identifiers, Eoin may go beyond just seeing them and actually log in or hijack accounts. That would then lead to **Elevation of Privilege**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Storing sensitive business data without secure encryption or hashing can lead to severe data breaches, compromising user privacy and leading to potential financial and reputational damage.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CR9/explanation.md
@@ -19,7 +19,7 @@ The primary applicable STRIDE categories for this scenario is **Information Disc
 1. Andy may be able to undermine the integrity of the system’s protections (random numbers, GUIDs, hashing, encryption). By bypassing or breaking them, he can alter outcomes (predictable GUIDs, weakened encryption, manipulated “random” values). This is a failure of integrity which makes the primary impact: **Tampering**.
 2. Andy’s bypass of weak/random crypto may give him a "backdoor" in encrypted communication that allow him to see what information is being sent. In that case the main harm is loss of confidentiality, primary impact: **Information Disclosure**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Reliance on weak, custom-built cryptographic functions can lead to compromised data security, unauthorized access, and potential breaches of sensitive information.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRA/explanation.md
@@ -16,7 +16,7 @@ Inventing a new cryptography threat could lead to:
 
 Any of the STRIDE categories may be applicable, but the primary concern is usually **Information Disclosure** or **Tampering** as breaking cryptography, in most cases, mean you can either disclose or modify data, depending on the context.
 
-### What can go Wrong?
+### What can go wrong?
 
 Data leaks, impersonation, tampering, privilege escalation, replay/forgery, DoS, loss of trust in audits.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRJ/explanation.md
@@ -19,7 +19,7 @@ That scenario clearly maps to **Information Disclosure** in STRIDE.
 The primary violation is exposure of sensitive credentials (database passwords, API keys, service credentials).
 Once Justin can read those secrets, he can then leverage them for further attacks (like **Tampering**, **Elevation of Privilege**, etc.), but the root threat is that information that should have been protected is disclosed in plaintext or source code.
 
-### What can go Wrong?
+### What can go wrong?
 
 Storing credentials in an unencrypted format or embedding them in source code can lead to unauthorized system access, data breaches, and potentially severe security incidents.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRK/explanation.md
@@ -20,7 +20,7 @@ Dan is modifying the cryptographic routines themselves — the code that enforce
 By altering this code, he changes the behavior of the system, allowing him to bypass security protections (e.g., decrypt data, predict random values).
 STRIDE defines **Tampering** as the unauthorized modification of data or code, which is what is happening here.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such manipulation can lead to the compromise of entire cryptographic systems, rendering them ineffective and exposing sensitive data to unauthorized access or manipulation.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRQ/explanation.md
@@ -19,7 +19,7 @@ That scenario clearly maps to **Information Disclosure** in STRIDE.
 The primary violation is exposure of sensitive credentials (database passwords, API keys, service credentials).
 Once Justin can read those secrets, he can then leverage them for further attacks (like **Tampering**, **Elevation of Privilege**, etc.), but the root threat is that information that should have been protected is disclosed in plaintext or source code.
 
-### What can go Wrong?
+### What can go wrong?
 
 Access to master cryptographic secrets can lead to widespread system compromise, unauthorized data access, and the potential decryption of sensitive information.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/cryptography/CRX/explanation.md
@@ -19,7 +19,7 @@ The primary applicable STRIDE categories for this scenario is **Information Disc
 1. STRIDE’s **Information Disclosure** covers unauthorized exposure of sensitive information — which is what occurs when encryption is insufficient and an attacker can decrypt data. Breaking weak or outdated cryptography lets an attacker read confidential data that was supposed to be protected (passwords, PII, cardholder data, secrets).
 2. If the cryptographic primitive is providing integrity (signatures or MACs) and an attacker is able to break or bypass that protection so they can alter data without detection, then the primary STRIDE impact is **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Using cryptography that is not sufficiently strong for the required level of protection can lead to data breaches, unauthorized access, and exposure of sensitive information.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE2/explanation.md
@@ -19,7 +19,7 @@ Brian attacks by accessing a server error page that is poorly configured. Instea
 The situation falls under the **Information Disclosure** category in the STRIDE threat modeling framework.
 Verbose error messages, default files, backup/test copies, exposed source code all give attackers extra visibility into the system’s inner workings, the risk is therefor **Information Disclosure**.
 
-### What can go Wrong?
+### What can go wrong?
 
 This kind of information leakage can lead to targeted attacks, exploitation of system vulnerabilities, and significant security breaches.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE3/explanation.md
@@ -20,7 +20,7 @@ Robert attacks by submitting a form on your website. He intentionally uses an un
 
 The primary STRIDE category for “being able to input malicious data due to missing protocol/structure/element validation” is **Tampering** with possible secondary impacts into **Information Disclosure**, **DoS**, or **Elevation of Privilege** depending on how the malformed data is exploited.
 
-### What can go Wrong?
+### What can go wrong?
 
 These oversights can result in significant security breaches, data corruption, and may compromise the integrity and reliability of the entire system.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE4/explanation.md
@@ -16,7 +16,7 @@ Dave attacks by altering a web form field. He changes a hidden field named 'user
 
 The primary STRIDE category for being able to “inputs malicious field names or data” is **Tampering**, but if Dave can change the `user_role` from user to admin, than that lets him obtain higher rights than he should — that is the textbook definition of **elevation of privilege**. The root cause would be missing contextual validation/authorization, so manipulated input is treated as authoritative and results in increased privileges.
 
-### What can go Wrong?
+### What can go wrong?
 
 This form of attack can lead to unauthorized access, data breaches, and potentially full system compromise.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE5/explanation.md
@@ -17,7 +17,7 @@ Jee finds that while your website correctly encodes data for HTML context, it fa
 This scenario is clearly STRIDE: **Information Disclosure** and **Tampering**.
 Bypassing or mis-using output encoding lets attacker-controlled data be sent to and executed in another party’s context. This lets the attacker can alter the rendered page or responses (injecting or changing content seen by users) which is **Tampering**, but the most immediate consequence is exposure and theft of sensitive information (session cookies, DOM data, or secrets accessible in-page) — which maps best to **Information Disclosure**.
 
-### What can go Wrong?
+### What can go wrong?
 
 These gaps in encoding practices can lead to serious security vulnerabilities, such as XSS attacks, compromising both the system and its users.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE6/explanation.md
@@ -15,7 +15,7 @@ Jason discovers that while most input fields on your web application are properl
 This scenario falls squarely into the **Tampering** category of STRIDE.
 By bypassing centralized validation routines, Jason is able to inject malicious or malformed input (e.g., code injection, buffer overflow payloads) that alters how the system processes the data. The core issue is that unchecked input lets him tamper with the system’s expected data flows and behavior. **Elevation of Privilege** could be a consequence (e.g., RCE via injection), but the root threat is tampering with input.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such lapses in validation can lead to severe security breaches, including data corruption, unauthorized access, and other forms of system compromise.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE7/explanation.md
@@ -23,7 +23,7 @@ Crafting special/ambiguously encoded payloads to foil validation is an attack on
 Jan is modifying the data semantics (by using alternate encodings, double-encoding, differing charset interpretations, etc.) so that filters/validators no longer recognize the malicious content.
 STRIDE’s **Tampering** covers unauthorized modification or manipulation of data or how data is interpreted, which is exactly what character-set/canonicalization tricks do.
 
-### What can go Wrong?
+### What can go wrong?
 
 These vulnerabilities can result in severe security issues, such as injection attacks, data corruption, and unauthorized system access.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE8/explanation.md
@@ -16,7 +16,7 @@ Bypassing centralized sanitization routines because they are not applied everywh
 Sanitization routines are meant to enforce integrity by ensuring data isn’t maliciously altered.
 If Oana can push malicious payloads through un-sanitized channels (e.g., overlooked URL parameters, hidden forms), she is modifying input data in a way the system was supposed to prevent.
 
-### What can go Wrong?
+### What can go wrong?
 
 This loophole can lead to significant security breaches, including Cross-Site Scripting (XSS) attacks, unauthorized access, and data compromise.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VE9/explanation.md
@@ -17,7 +17,7 @@ Shamun discovers that when certain inputs fail validation checks on your website
 Shamun is deliberately submitting malformed or invalid data.
 Because the application does not properly reject it, Shamun’s crafted input is accepted and modifies the system’s behavior or state in unintended ways. Hence **Tampering** is the most applicable category.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to various security threats, including data leakage, unauthorized actions within the system, and the execution of malicious code.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEA/explanation.md
@@ -23,7 +23,7 @@ Failing to validate and encode properly doesn’t just hit one STRIDE category �
 4. Spoofing → Auth bypass.
 5. Denial of Service → Crashes, resource exhaustion.
 
-### What can go Wrong?
+### What can go wrong?
 
 #### Input Validation Failures
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEJ/explanation.md
@@ -18,7 +18,7 @@ Toby exploits his control by disabling certain input validation checks on a form
 
 Toby is modifying or disabling the code/routines that enforce validation/encoding — that’s an integrity attack which alters the system processes or data so that malicious input is accepted. In STRIDE, that maps directly to **Tampering**, but the consequences of that tampering (XSS, RCE, auth bypass) may map to other STRIDE categories such as Elevation of Privilege or Information Disclosure, so treat those as secondary impacts.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such control over validation and encoding routines can lead to a wide array of security issues, including data corruption, unauthorized access, and execution of harmful scripts.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEK/explanation.md
@@ -15,7 +15,7 @@ Gabe targets a web application's database interaction. He enters a specially cra
 Gabe is injecting data that changes how the server processes queries/commands — turning data into action. That is an integrity attack: unauthorized modification of application behavior or data, which maps to **Tampering** in STRIDE.
 The injection itself modifies the server-side processing pipeline (SQL engine, OS shell, XPath processor, etc.), so the root threat is tampering with inputs/processing, but all of the other STRIDE categories can be used for the secondary impact depending on the context.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to severe consequences, including unauthorized data access, manipulation of server-side operations, and potentially full system compromise.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEQ/explanation.md
@@ -18,7 +18,7 @@ Xavier attacks by injecting a script into a web application that lacks proper en
 
 Xavier is modifying the content/behavior of the application delivered to or executed on the client which is classic **tampering** of data/processing, but the impact can be multiple things (cookie theft → **Information Disclosure**; session takeover → **Elevation of Privilege**; forging UI → **Spoofing**), but the root threat is the attacker tampering with the interpreter’s inputs.
 
-### What can go Wrong?
+### What can go wrong?
 
 This type of vulnerability can lead to client-side attacks like XSS, compromising user data and browser security.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/data-validation-&-encoding/VEX/explanation.md
@@ -21,7 +21,7 @@ Darío attacks by altering a session token stored in his browser's local storage
 Darío is pretending to be Colin by taking advantage of the application's trust in its data sources. 
 STRIDE’s **Spoofing** covers threats where an attacker assumes another identity or credentials to gain access. This is a textbook spoofing/impersonation attack: the system trusted the presented identity without adequate verification, but the consequences or secondary impacts can include any of the other categories depending on the context.
 
-### What can go Wrong?
+### What can go wrong?
 
 This kind of vulnerability can lead to identity theft, unauthorized access, and potentially severe data breaches.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM2/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM2/explanation.md
@@ -21,7 +21,7 @@ William manipulates session ID generation so he can predict valid session identi
 By doing this, he can assume the identity of another user without knowing their credentials.
 The core threat is unauthorized impersonation, which is **Spoofing**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Control over session ID generation can lead to session hijacking, unauthorized access, and potential breaches of user privacy and data security.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM3/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM3/explanation.md
@@ -18,7 +18,7 @@ This scenario falls under STRIDE: **Spoofing**.
 Ryan uses valid credentials to simultaneously access the account while the legitimate user is active, effectively impersonating the user in parallel.
 The system’s failure to restrict or monitor concurrent sessions enables him to bypass control over who is acting as that user.
 
-### What can go Wrong?
+### What can go wrong?
 
 Allowing concurrent sessions without proper controls can lead to unauthorized access and exploitation of user accounts, potentially compromising data security and privacy.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM4/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM4/explanation.md
@@ -18,7 +18,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 Alison sets cookies for another web application due to insufficient domain/path restrictions, which lets her impersonate users or hijack their sessions on that application.
 The root issue is unauthorized impersonation via session manipulation, making Spoofing the correct primary category.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to cross-domain attacks, unauthorized session tracking, and potentially session hijacking, compromising user security on multiple applications.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM5/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM5/explanation.md
@@ -24,7 +24,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 John predicts or guesses session identifiers because the system does not rotate or randomize them appropriately.
 By hijacking a valid session ID, he assumes the identity of the authenticated user, which is classic **Spoofing**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such practices expose users to session hijacking and potential privacy breaches, as attackers can easily predict or guess session IDs.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM6/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM6/explanation.md
@@ -21,7 +21,7 @@ This scenario falls under STRIDE: **Spoofing**.
 Gary exploits long or missing inactivity/overall session timeouts and the ability to use the same session from multiple locations.
 By taking over an active session, he effectively assumes the identity of the legitimate user, which is classic Spoofing.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized session takeovers, leading to potential data theft, financial loss, and privacy breaches.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM7/explanation.md
@@ -22,7 +22,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 Graham exploits the fact that Adam’s session remains active after he “logs out” or fails to log out, allowing him to assume Adam’s identity without needing credentials.
 The root issue is unauthorized impersonation via an active session, making **Spoofing** the correct primary category.
 
-### What can go Wrong?
+### What can go wrong?
 
 This flaw can lead to unauthorized session access and potential data breaches, as attackers exploit sessions that users believe to be safely closed.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM8/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM8/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Elevation of Privilege**.
 In this case, Matt exploits long sessions without periodic re-authentication. Even though the legitimate user’s privileges are reduced during the day, the session retains the previous access rights.
 The attack is not about impersonating someone new (Spoofing), but about continuing to have unauthorized privileges, which is classic **Elevation of Privilege**.
 
-### What can go Wrong?
+### What can go wrong?
 
 This vulnerability can lead to unauthorized access and misuse of privileges, especially in cases where user privileges have been altered or revoked.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM9/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SM9/explanation.md
@@ -26,7 +26,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 Ivan steals session identifiers through insecure transmission, logging, URL parameters, or code exposure.
 By using these stolen session IDs, he hijacks active sessions and impersonates the legitimate user, which is classic **Spoofing**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such practices expose users to session hijacking and potential data breaches, as their session identifiers can be easily intercepted and misused.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMA/explanation.md
@@ -16,7 +16,7 @@ Inventing a new session management attack could lead to:
 
 STRIDE categories affected, depends on the context. Potentially, all six may be affected (**Spoofing**, **Tampering**, **Repudiation**, **Information Disclosure**, **Elevation of Privilege**, **Denial of Service**).
 
-### What can go Wrong?
+### What can go wrong?
 
 Hijacking, escalation, data leaks, denial of service, loss of auditability.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMJ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMJ/explanation.md
@@ -18,7 +18,7 @@ This scenario maps primarily to STRIDE: **Tampering**.
 Jeff resends an identical request (a replay attack) and the system accepts it as new, effectively modifying the state of the system (e.g., triggering multiple transactions).
 The attack is not about impersonation (Spoofing) per se, but about unauthorized manipulation of data/state, which is classic **Tampering**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities can lead to replay attacks, resulting in unauthorized transactions, data breaches, and exploitation of system functionalities.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMK/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMK/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 Peter exploits weaknesses in a self-built or weak session management system, allowing him to bypass session controls and assume the identity of legitimate users.
 The attack is centered on unauthorized impersonation via inadequate session enforcement, making **Spoofing** the correct primary category.
 
-### What can go Wrong?
+### What can go wrong?
 
 Custom-built session management systems that lack the rigor of standard frameworks can lead to serious security breaches, including unauthorized access and data theft.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMQ/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMQ/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 Salim exploits areas of the application where session management is not applied consistently, allowing him to bypass session checks and act as an authenticated user without proper authorization.
 The attack’s core is unauthorized impersonation via gaps in session enforcement, making **Spoofing** the correct primary category.
 
-### What can go Wrong?
+### What can go wrong?
 
 Inconsistencies in session management across an application can lead to unauthorized access and potential exploitation of the less secure areas, compromising overall system security.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMX/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/session-management/SMX/explanation.md
@@ -20,7 +20,7 @@ This scenario maps primarily to STRIDE: **Spoofing**.
 Marce forges requests that appear to originate from an authenticated user because the server cannot distinguish legitimate requests from maliciously crafted ones.
 The attack allows her to perform actions on behalf of the user, which is impersonation—classic **Spoofing**.
 
-### What can go Wrong?
+### What can go wrong?
 
 Such vulnerabilities expose users to CSRF attacks, where attackers can manipulate users' actions without their knowledge, potentially leading to unauthorized state changes and data breaches.
 

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/wild-card/JOA/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/wild-card/JOA/explanation.md
@@ -12,7 +12,7 @@ Primary impact depends on the impact of attack:
 2. **Phishing / impersonation**: Could be **Spoofing** or **Information Disclosure**.
 3. **Data exfiltration** could be **Information Disclosure**.
 
-### What can go Wrong?
+### What can go wrong?
 
 1. Users’ devices get infected with malware, ransomware, or spyware.
 2. Sensitive personal or financial data is stolen.

--- a/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/wild-card/JOB/explanation.md
+++ b/cornucopia.owasp.org/data/cards/webapp-cards-2.2-en/wild-card/JOB/explanation.md
@@ -13,7 +13,7 @@ Primary impact depends on the impact of attack:
 3. **Information Disclosure**: Exposing regulated or sensitive data inappropriately may violate privacy regulations.
 4. **Repudiation**: If logs or audit trails can be altered, proving compliance or tracking violations becomes impossible.
 
-### What can go Wrong?
+### What can go wrong?
 
 1. Non-compliance with regulations such as GDPR, HIPAA, or PCI DSS.
 2. Violations of contractual obligations or internal policies.

--- a/cornucopia.owasp.org/src/lib/components/cardFound.svelte
+++ b/cornucopia.owasp.org/src/lib/components/cardFound.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { run } from 'svelte/legacy';
-
+  import { Text } from "$lib/utils/text";
   import {
     GetCardAttacks, type Attack } from "$lib/cardAttacks";
   import Summary from "./summary.svelte";
@@ -40,7 +40,7 @@
 </script>
 
 <div>
-  <h1 title="OWASP Cornucopia card {card.name}" class="title">{card.name}</h1>
+  <h1 title="OWASP Cornucopia card {Text.convertToTitleCase(card.suitName)} ({card.id})" class="title">{Text.convertToTitleCase(card.suitName)} ({card.id})</h1>
   <CardBrowser bind:card={card} {cards} mappingData={mappings}></CardBrowser>
   <a title="How to play OWASP Cornucopia" class="link" href="/how-to-play">{$t('cards.cardFound.a')}</a>
   <Summary card={card}></Summary>
@@ -80,6 +80,7 @@
     background: var(--background);
     color: white;
     padding: 0.5rem;
+    text-transform: uppercase;
   }
 
   .clicable {

--- a/cornucopia.owasp.org/src/lib/components/renderers/heading.svelte
+++ b/cornucopia.owasp.org/src/lib/components/renderers/heading.svelte
@@ -76,7 +76,7 @@
     h2
     {
       font-size: 1.8rem;
-      padding: .5rem;
+      padding: .5rem .5rem .5rem 0;
       font-weight: bold;
      }
 

--- a/cornucopia.owasp.org/src/lib/utils/text.ts
+++ b/cornucopia.owasp.org/src/lib/utils/text.ts
@@ -26,6 +26,15 @@ export class Text
         return input;
     }
 
+    public static convertToTitleCase( str: string ) : string{
+        if (!str) {
+        return "";
+        }
+        return str.toLowerCase().replace(/\b\w/g, function(char) {
+        return char.toUpperCase();
+        });
+    }
+
     public static FormatDate(input : string) : string
     {
         // This method expects 19 december 2020 as 20201219 (YYYMMDD)

--- a/cornucopia.owasp.org/src/routes/cards/[card]/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/cards/[card]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PageData } from "./$types";
+  import { Text } from "$lib/utils/text";
   import CardFound from "$lib/components/cardFound.svelte";
   import CardNotFound from "$lib/components/cardNotFound.svelte";
   import type { Card } from "../../../domain/card/card";
@@ -33,16 +34,31 @@
       "JOA","JOB","JOAM","JOBM","CORNUCOPIA"]
     return (cards_options.includes(String(card?.id).toUpperCase()))
   }
+
+  function convertToTitleCase( str: string ) : string{
+    if (!str) {
+      return "";
+    }
+    return str.toLowerCase().replace(/\b\w/g, function(char) {
+      return char.toUpperCase();
+    });
+  }
+
+  function getEdition(str: string) : string {
+    if (str == "webapp") return "Website App Edition";
+    if (str == "mobileapp") return "Mobile App Edition";
+    return str;
+  }
 </script>
 <svelte:head>
   {#if cardFound()}
-    <link rel="canonical" href="/cards" />
-    <title>OWASP Cornucopia - {card.edition} - {card.name}</title>
+    <link rel="canonical" href="/cards/{card.id}" />
+    <title>OWASP Cornucopia - {getEdition(card.edition)} - {Text.convertToTitleCase(card.suitName)} ({card.id})</title>
     <meta name="description" content="{card.desc}" />
-	  <meta name="keywords" content="OWASP, Cornucopia,{card.edition}, {card.suitName}, {card.id}" />
-    <meta property="og:title" content="OWASP Cornucopia - {card.edition} - {card.name}">
+	  <meta name="keywords" content="OWASP, Cornucopia,{card.edition}, {convertToTitleCase(card.suitName)}, {card.id}" />
+    <meta property="og:title" content="OWASP Cornucopia - {getEdition(card.edition)} - {card.name}">
     <meta property="og:description" content="{card.desc}">
-    <meta name="twitter:title" content="OWASP Cornucopia - {card.edition} - {card.name}">
+    <meta name="twitter:title" content="OWASP Cornucopia - {getEdition(card.edition)} - {card.name}">
     <meta name="twitter:description" content="{card.desc}">
   {/if}
 </svelte:head>

--- a/cornucopia.owasp.org/src/routes/cards/[card]/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/cards/[card]/+page.svelte
@@ -35,15 +35,6 @@
     return (cards_options.includes(String(card?.id).toUpperCase()))
   }
 
-  function convertToTitleCase( str: string ) : string{
-    if (!str) {
-      return "";
-    }
-    return str.toLowerCase().replace(/\b\w/g, function(char) {
-      return char.toUpperCase();
-    });
-  }
-
   function getEdition(str: string) : string {
     if (str == "webapp") return "Website App Edition";
     if (str == "mobileapp") return "Mobile App Edition";
@@ -55,7 +46,7 @@
     <link rel="canonical" href="/cards/{card.id}" />
     <title>OWASP Cornucopia - {getEdition(card.edition)} - {Text.convertToTitleCase(card.suitName)} ({card.id})</title>
     <meta name="description" content="{card.desc}" />
-	  <meta name="keywords" content="OWASP, Cornucopia,{card.edition}, {convertToTitleCase(card.suitName)}, {card.id}" />
+	  <meta name="keywords" content="OWASP, Cornucopia,{card.edition}, {Text.convertToTitleCase(card.suitName)}, {card.id}" />
     <meta property="og:title" content="OWASP Cornucopia - {getEdition(card.edition)} - {card.name}">
     <meta property="og:description" content="{card.desc}">
     <meta name="twitter:title" content="OWASP Cornucopia - {getEdition(card.edition)} - {card.name}">


### PR DESCRIPTION
In this pull request:

- Correcting meta tags, H1 titles, and page titles
- Removing left padding
- Remove upper case for Wrong in 'What can go Wrong'