### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/cornucopia.owasp.org/data/news/20240229-a-deep-dive-into-the-information-on-a-cornucopia-card/index.md
+++ b/cornucopia.owasp.org/data/news/20240229-a-deep-dive-into-the-information-on-a-cornucopia-card/index.md
@@ -41,9 +41,9 @@ We have incorporated interactive links to the mappings listed on the Cornucopia 
 
 We've transitioned from ASVS Version 3 to ASVS Version 4. The physical cards display the mappings to ASVS v3.0, but the website has been updated to reflect the mappings to ASVS 4.0. I believe that the OWASP ASVS is one of the most practical projects for enhancing the cybersecurity of your application.
 
-The OWASP Application Security Verification Standard (ASVS) is a framework established by the Open Web Application Security Project (OWASP) for securing web applications. 
+The OWASP Application Security Verification Standard (ASVS) is a framework established by the Open Worldwide Application Security Project (OWASP) for securing web applications. 
 Learning about OWASP ASVS and incorporating its requirements into your application development process is highly recommended.
-The OWASP Application Security Verification Standard (ASVS) is a framework for securing web applications developed by the Open Web Application Security Project (OWASP). It establishes a foundation for testing web application security controls and provides developers with a comprehensive set of requirements for secure development.
+The OWASP Application Security Verification Standard (ASVS) is a framework for securing web applications developed by the Open Worldwide Application Security Project (OWASP). It establishes a foundation for testing web application security controls and provides developers with a comprehensive set of requirements for secure development.
 
 OWASP ASVS offers a definitive suite of functionalities that should be integrated into your application to ensure its security.
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)
- BlueSky: [arkid15r.com](https://bsky.app/profile/arkid15r.com)