### PR TITLE
Update run-tests-generate-output.yaml

### DIFF
--- a/.github/workflows/run-tests-generate-output.yaml
+++ b/.github/workflows/run-tests-generate-output.yaml
@@ -145,6 +145,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      issues: write
     needs: uploadoutputfiles
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
Allow write comments on the pull-request

related to https://github.com/OWASP/cornucopia/pull/2026