### PR TITLE
Update headers-stage.js

### DIFF
--- a/cornucopia.owasp.org/script/headers-stage.js
+++ b/cornucopia.owasp.org/script/headers-stage.js
@@ -24,14 +24,8 @@ function main() {
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
-  Permissions-Policy: accelerometer=(), autoplay=(), camera=(), document-domain=(), encrypted-media=(), fullscreen=(self "https://www.youtube.com/"), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()
-  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: base-uri 'self'; default-src 'none'; frame-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self' 'nonce-DhcnhD3khTMePgXw'; style-src 'self'; style-src-elem 'self'; upgrade-insecure-requests
-
-/how-to-play
-  ! Permissions-Policy
   Permissions-Policy: accelerometer=(), autoplay=(), camera=(), document-domain=(), encrypted-media=(), fullscreen=(self "https://www.youtube.com/"), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(self "https://www.youtube.com/"), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()
-  ! Content-Security-Policy
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Content-Security-Policy: base-uri 'self'; default-src 'none'; frame-src 'self' www.youtube.com youtube.com; connect-src 'self'; img-src 'self' i.ytimg.com; script-src 'self' 'nonce-DhcnhD3khTMePgXw'; style-src 'self'; style-src-elem 'self'; upgrade-insecure-requests
 /api/cre/mobileapp/en
   ! Access-Control-Allow-Origin


### PR DESCRIPTION
It may be because it is a single page app that headers only gets sent once and that player therefore fails. This will allow youtube to load for all pages and should therefore allow the player even when there is no real page load when navigating.
Update staging first. If it works, also do it for production.