### PR TITLE
test(website): generate Cobertura coverage with Vitest

### DIFF
--- a/cornucopia.owasp.org/vite.config.ts
+++ b/cornucopia.owasp.org/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import VitePluginRestart from 'vite-plugin-restart';
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import path from 'path';
@@ -24,9 +24,19 @@ export default defineConfig({
 			$domain: path.resolve(__dirname, './src/domain')
 		}
 	},
+
 	plugins: [
 		sveltekit(),
 		VitePluginRestart(vitePluginRestartOptions),
 		viteStaticCopy(viteStaticCopyOptions)
-	]
+	],
+	test: {
+		   environment: 'jsdom',
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['cobertura'],
+      reportsDirectory: 'coverage',
+      exclude: ['node_modules/', '.svelte-kit/']
+	}
+}
 });


### PR DESCRIPTION
### Summary
Enable Cobertura coverage generation for the website project.

### Changes
- Added Vitest test configuration to `vite.config.ts`
- Switched coverage provider to Istanbul
- Output coverage in Cobertura format under `coverage/`

### Notes
Coverage verified locally with:
`npx vitest run --coverage`
