### PR TITLE
Revert ClusterFuzzLite Dockerfile to python3 setup

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -12,10 +12,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     python3-venv \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-# Atheris only supports python 3.11 https://github.com/google/atheris/blob/master/README.md#installation-instructions
+
+# Atheris only supports python 3.11
+# https://github.com/google/atheris/blob/master/README.md#installation-instructions
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 RUN python3 -m pip install --no-cache-dir --upgrade PyInstaller==6.18.0 setuptools setuptools_scm wheel 
+
 COPY . $SRC/cornucopia
 WORKDIR $SRC/cornucopia
 COPY .clusterfuzzlite/build.sh $SRC/
+


### PR DESCRIPTION
This PR is opened from a fresh branch based on the latest master.
It reverts .clusterfuzzlite/Dockerfile to the python3-based setup using base-builder-python:ubuntu-24-04 and Atheris, matching the configuration that previously passed all 12 ClusterFuzzLite checks in #2119.