### PR TITLE
Update our threat model to take into account accidental disruptors

### DIFF
--- a/ThreatDragonModels/copi.json
+++ b/ThreatDragonModels/copi.json
@@ -382,7 +382,7 @@
                 {
                   "id": "74115038-e386-442a-8220-7de792548fb6",
                   "title": "Given that the url to the game gets accidently exposed, a hostile actor may disrupt the game to move backward and forward to the next and previous rounds",
-                  "status": "Open",
+                  "status": "Mitigated",
                   "severity": "TBD",
                   "type": "Tampering",
                   "description": "What can go wrong?\n\nSometimes players fall out of the game. When that happens, it is impossible to continue the game. We want to provide for a possibility to move to the next round if a player falls out of the game, but there is a risk that the url to the game gets accidently exposed, a hostile actor may disrupt the game to move backward and forward to the next and previous rounds.\nhttps://github.com/OWASP/cornucopia/issues/2129",
@@ -395,12 +395,19 @@
               ],
               "threatFrequency": {
                 "spoofing": 4,
-                "tampering": 1,
+                "tampering": 2,
                 "repudiation": 0,
                 "informationDisclosure": 2,
                 "denialOfService": 2,
                 "elevationOfPrivilege": 0
               }
+            },
+            "tools": {
+              "items": [
+                "boundary",
+                "button-remove"
+              ],
+              "name": null
             }
           },
           {


### PR DESCRIPTION
Related to the conversation about allowing game rounds to be incomplete. https://github.com/OWASP/cornucopia/issues/2129#issuecomment-3852939727

### What can go wrong?

Sometimes players fall out of the game. When that happens, it is impossible to continue the game. We want to provide for a possibility to move to the next round if a player falls out of the game, but there is a risk that the url to the game gets accidently exposed, a hostile actor may disrupt the game to move backward and forward to the next and previous rounds.
https://github.com/OWASP/cornucopia/issues/2129

### What are we going to do about it?

We will add a voting mechanism so that players can continue to the next round by a majority vote even if some players have dropped out. This will ensure that it's not possible to accidently or maliciously move to the next round.