### PR TITLE
run audit after coverage

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -43,8 +43,8 @@
             run: |
               pnpm install          # Install dependencies
               npm run build        # Build production version
-              pnpm audit --prod
               pnpm run coverage
+              pnpm audit --prod
 
           - name: Smoke test
             working-directory: cornucopia.owasp.org


### PR DESCRIPTION
In this pull-request:

- We should look for security vulnerabilities after running the audit so that we are sure to have test coverage.