### PR TITLE
Add Tanmay Ranjan to contributors list

### DIFF
--- a/cornucopia.owasp.org/data/website/pages/about/en/index.md
+++ b/cornucopia.owasp.org/data/website/pages/about/en/index.md
@@ -97,6 +97,7 @@ Cornucopia is developed, maintained, updated and promoted by a worldwide team of
 - Cam Morris
 - Christoph Niehoff
 - Grant Ongers
+- Tanmay Ranjan
 - Susana Romaniz
 - Ravishankar Sahadevan
 - Abhijit Sahoo
@@ -112,7 +113,6 @@ Cornucopia is developed, maintained, updated and promoted by a worldwide team of
 - Wagner Voltzcontributors 
 - Stephen de Vries
 - Colin Watson
-- Tanmay Ranjan
 -  
 Additionally, Gerardo Canedo and student volunteers to [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/ 'OWASP Threat Dragon [internal]') from the Universidad Católica del Uruguay ([UCU](https://www.ucu.edu.uy/ 'UCU [external]')) who took part in a Coding Challenge to provide integration between Cornucopia and Threat Dragon.
 


### PR DESCRIPTION
Adds Tanmay Ranjan to the alphabetical contributors list under the Volunteers section.

This change only updates the contributors list and does not affect any functionality.

Update:
I have fixed the typo mistake.
