### PR TITLE
fix: Update CAPEC links to use internal taxonomy pages instead of external site.

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/mobileAppCardTaxonomy.svelte
+++ b/cornucopia.owasp.org/src/lib/components/mobileAppCardTaxonomy.svelte
@@ -46,7 +46,7 @@
     }
   
     function linkCapec(input: string) {
-      return "https://capec.mitre.org/data/definitions/" + input + ".html";
+      return "/taxonomy/capec-3.9/" + input;
     }
     let mappings: MobileAppMapping = $state({} as MobileAppCardMapping);
     let attacks: Attack[] = $state([] as Attack[]);

--- a/cornucopia.owasp.org/src/lib/components/webAppCardTaxonomy.svelte
+++ b/cornucopia.owasp.org/src/lib/components/webAppCardTaxonomy.svelte
@@ -59,7 +59,7 @@
     }
   
     function linkCapec(input: string) {
-      return "https://capec.mitre.org/data/definitions/" + input + ".html";
+      return "/taxonomy/capec-3.9/" + input;
     }
     let mappings: WebAppMapping = $state(controller.getWebAppCardMappings(card.id));
     let attacks: Attack[] = $state(GetCardAttacks(card.id));


### PR DESCRIPTION
## Description
Updates CAPEC links throughout the application to point to internal taxonomy pages instead of the external MITRE site.

Fixes: #2248 

## Changes
- Updated `webAppCardTaxonomy.svelte` to use `/taxonomy/capec-3.9/{id}` format
- Updated `mobileAppCardTaxonomy.svelte` to use `/taxonomy/capec-3.9/{id}` format
- Removed all references to `https://capec.mitre.org/data/definitions/` in code

## Example
**Before:** `https://capec.mitre.org/data/definitions/560.html`  
**After:** `https://cornucopia.owasp.org/taxonomy/capec-3.9/560`

## Testing
-  Verified all CAPEC links now use internal taxonomy format
-  Confirmed no remaining external MITRE links in source code
-  All existing tests continue to pass
