### PR TITLE
Fixed the documentation typo

### DIFF
--- a/copi.owasp.org/lib/copi/cornucopia.ex
+++ b/copi.owasp.org/lib/copi/cornucopia.ex
@@ -256,10 +256,10 @@ defmodule Copi.Cornucopia do
 
   ## Examples
 
-      iex> get_card_by_external_id!(DV2)
+      iex> get_card_by_external_id!("1.0", "DV2")
       %Card{}
 
-      iex>get_card_by_external_id!(XXX)
+      iex> get_card_by_external_id!("1.0", "XXX")
       ** (Ecto.NoResultsError)
 
   """


### PR DESCRIPTION
I have fixed the documentation typo in the `get_card_by_external_id!/2` function in `copi.owasp.org/lib/copi/cornucopia.ex`.

Closes: #2230 

The issue was that the examples showed invalid Elixir syntax:

- `iex> get_card_by_external_id!(DV2)` - Missing quotes and second parameter
- `iex> get_card_by_external_id!(XXX)` - Invalid syntax (XXX interpreted as undefined variable)

The corrected documentation now shows proper Elixir syntax:

- `iex> get_card_by_external_id!("1.0", "DV2")` - Valid example with both required parameters as strings
- `iex> get_card_by_external_id!("1.0", "XXX")` - Valid error case example with proper string syntax

This fix ensures developers can properly understand how to call the function with the correct parameters and syntax.
