### PR TITLE
fix: preserve ODT files after PDF conversion in pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -236,6 +236,10 @@
               pipenv run python scripts/convert.py -l en -lt guide -t bridge -v 3.0 -e webapp --pdf
               pipenv run python scripts/convert.py -l en -lt guide -t bridge_qr -v 3.0 -e webapp --pdf
               #
+              # Debug: List generated files to verify PDF and ODT files exist
+              echo "Listing generated guide files:"
+              ls -lh output/*guide*.odt output/*guide*.pdf 2>/dev/null || echo "Some guide files may be missing"
+              #
               cp output/owasp_cornucopia_mobileapp_1.1_cards_bridge_en.idml output/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_en.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_en.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_en.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_en.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_en.idml output/cornucopia_mobileapp/
               cp output/owasp_cornucopia_webapp_2.2_cards_bridge_en.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_en.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_en.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_en.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_en.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_en.idml output/cornucopia_webapp/
               cp output/owasp_cornucopia_webapp_2.2_cards_bridge_es.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_es.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_es.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_es.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_es.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_es.idml output/cornucopia_webapp/

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -143,6 +143,11 @@ def _rename_libreoffice_output(source_filename: str, output_pdf_filename: str) -
 
 
 def convert_to_pdf(source_filename: str, output_pdf_filename: str) -> None:
+    """Convert a document file (ODF, DOCX) to PDF using LibreOffice or docx2pdf.
+
+    Note: The source file is preserved after conversion, as it's typically an output
+    file that should be kept alongside the PDF, not a temporary file.
+    """
     logging.debug(
         f" --- source_file = {source_filename} convert to {output_pdf_filename}\n--- starting pdf conversion now."
     )
@@ -150,7 +155,7 @@ def convert_to_pdf(source_filename: str, output_pdf_filename: str) -> None:
     # 1. Attempt using LibreOffice
     if _convert_with_libreoffice(source_filename, output_pdf_filename):
         _rename_libreoffice_output(source_filename, output_pdf_filename)
-        _cleanup_temp_file(source_filename)
+        # Don't delete the source file - we want to keep both ODF and PDF
         return
 
     # 2. Fallback to docx2pdf
@@ -160,7 +165,7 @@ def convert_to_pdf(source_filename: str, output_pdf_filename: str) -> None:
 
     # 3. Everything failed
     _handle_conversion_failure(source_filename)
-    _cleanup_temp_file(source_filename)
+    # Don't delete the source file even on failure - it may still be useful
 
 
 def create_edition_from_template(


### PR DESCRIPTION
## Description
Fixes the issue where PDF files were not found during the pre-release workflow because source ODT files were being deleted after PDF conversion.

Fixes: #2264 

## Solution
- Modified `convert_to_pdf()` in `scripts/convert.py` to preserve source ODT files after PDF conversion
- Added docstring explaining that source files are output files, not temporary files
- Added debug logging in the workflow to verify both file types are generated during CI runs

## Changes
- **scripts/convert.py**: Removed `_cleanup_temp_file()` calls after LibreOffice conversion to preserve ODT files
- **.github/workflows/pre-release.yml**: Added debug step to list generated guide files for verification

## Testing
- ✅ All tests pass
- ✅ Verified ODT files are preserved after conversion attempts
- ✅ Verified both ODT and PDF files exist after successful conversion
- ✅ No breaking changes to existing functionality
