### PR TITLE
Improve blogpost metadata layout on mobile (#2259)

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/blogpostMetadata.svelte
+++ b/cornucopia.owasp.org/src/lib/components/blogpostMetadata.svelte
@@ -9,63 +9,106 @@
 
     let { blogpost }: Props = $props();
 
-    let authorLink = $derived('/author/' + blogpost.author);
+    let authorLink = $derived("/author/" + blogpost.author);
 </script>
 
 <div class="metadata">
     <div class="left">
         <p>Date: {Text.FormatDate(blogpost.date)}</p>
-        <p>Author: <a href="{authorLink}">{Text.Format(blogpost.author)}</a></p>
-        <p>Tags: 
-            {#each blogpost.tags || [] as tag}
-            <a title="OWASP Cornucopia new post titled: {Text.Format(tag)}" class="tag" href="/news">{Text.Format(tag)}</a><span></span>
-            {/each}
+        <p>
+            Author:
+            <a href={authorLink}>{Text.Format(blogpost.author)}</a>
         </p>
+        <div class="tags">
+            <span class="tags-label">Tags:</span>
+            <div class="tags-container">
+                {#each blogpost.tags || [] as tag}
+                    <a
+                        title={`OWASP Cornucopia new post titled: ${Text.Format(tag)}`}
+                        class="tag"
+                        href="/news"
+                    >
+                        {Text.Format(tag)}
+                    </a>
+                {/each}
+            </div>
+        </div>
     </div>
     <div class="right">
-        <button onclick={()=>goto(authorLink)}>
-        <img title="OWASP Cornucopia news author {Text.Format(blogpost.author)}" alt="{blogpost.author} profile picture" src="/data/author/{blogpost.author}/profile-picture.jpg"/>
+        <button onclick={() => goto(authorLink)}>
+            <img
+                title={`OWASP Cornucopia news author ${Text.Format(blogpost.author)}`}
+                alt={`${blogpost.author} profile picture`}
+                src={`/data/author/${blogpost.author}/profile-picture.jpg`}
+            />
         </button>
     </div>
 </div>
 
 <style>
-    .tag
-    {
-        padding: .25rem;
-        color:var(--background);
+    .tag {
+        padding: 0.25rem 0.5rem;
+        color: var(--background);
         background-color: var(--white);
-        margin: .25rem;
         text-decoration: none;
+        border-radius: 4px;
     }
 
-    .tag:hover
-    {
+    .tag:hover {
         opacity: 70%;
     }
-    .metadata
-    {
+
+    .metadata {
         display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1rem;
         padding-bottom: 2rem;
     }
 
-
-    img
-    {
-        width : 5rem;
-        outline: 1px white solid;
-        cursor:pointer;
-        margin: 1rem;   
+    .left {
+        flex: 1;
+        min-width: 1rem;
     }
 
-    img:hover
-    {
+    .right {
+        flex-shrink: 0;
+        display: flex;
+        align-items: flex-start; /* important */
+        justify-content: flex-end;
+        margin-top: 1rem;
+    }
+
+    img {
+        width: 6rem;
+        height: 6rem;
+        object-fit: cover;
+        border-radius: 50%;
+        outline: 1px white solid;
+        cursor: pointer;
+        margin-top: 0; /* remove vertical offset */
+    }
+
+    .img:hover {
         opacity: 70%;
     }
 
-    button
-    {
+    .button {
         background: none;
-        border:none;
+        border: none;
+    }
+    .tags {
+        margin-top: 0.5rem;
+    }
+
+    .tags-label {
+        display: block;
+        margin-bottom: 0.25rem;
+    }
+
+    .tags-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
     }
 </style>


### PR DESCRIPTION
Fixes #2259

This PR improves the layout of the blogpost metadata section on smaller screens.

Changes include:
- Stabilized flex layout to keep the author image aligned to the right
- Improved tag rendering using a flex container with proper wrapping
- Increased author image size for better visual balance
- Cleaned spacing and alignment for improved mobile readability

The overall structure remains unchanged, but responsiveness and visual consistency have been improved.
