### PR TITLE
 implement direct GitHub source links for cards and taxonomy items

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/cardFound.svelte
+++ b/cornucopia.owasp.org/src/lib/components/cardFound.svelte
@@ -65,7 +65,7 @@
   <MobileAppCardTaxonomy bind:card={card} {mappingData} {routes}></MobileAppCardTaxonomy>
   {/if}
     {#key card}
-        <ViewSourceOnGithub></ViewSourceOnGithub>
+        <ViewSourceOnGithub path={card.githubUrl}></ViewSourceOnGithub>
     {/key}
 </div>
 

--- a/cornucopia.owasp.org/src/lib/components/viewSourceOnGithub.svelte
+++ b/cornucopia.owasp.org/src/lib/components/viewSourceOnGithub.svelte
@@ -1,8 +1,24 @@
 <script lang="ts">
+    interface Props {
+        path?: string;
+    }
 
-    let base : string = "https://github.com/OWASP/cornucopia/tree/master/cornucopia.owasp.org/data/cards/";
-    //@TODO Would it be possible to link directly to the card?
-    let href : string = base; //+ path;
+    let { path = "" }: Props = $props();
+
+    const REPO_BASE = "https://github.com/OWASP/cornucopia";
+    const BRANCH = "master";
+    const SUBFOLDER = "cornucopia.owasp.org";
+
+    let href = $derived.by(() => {
+        if (!path) {
+            return `${REPO_BASE}/tree/${BRANCH}/${SUBFOLDER}/data/cards/`;
+        }
+        // Normalize path: ensure no double slashes and correct path format
+        let cleanPath = path.startsWith('./') ? path.substring(2) : path;
+        cleanPath = cleanPath.startsWith('/') ? cleanPath.substring(1) : cleanPath;
+        
+        return `${REPO_BASE}/blob/${BRANCH}/${SUBFOLDER}/${cleanPath}`;
+    });
 </script>
 
 <div>

--- a/cornucopia.owasp.org/src/lib/services/deckService.ts
+++ b/cornucopia.owasp.org/src/lib/services/deckService.ts
@@ -15,77 +15,66 @@ export class DeckService {
     private static cache: object[] = [];
 
     private static readonly latests: Deck[] = [
-        {lang: ['en'], edition: 'mobileapp', version: '1.1'}, 
-        {lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it'], edition: 'webapp', version: '2.2'}
+        { lang: ['en'], edition: 'mobileapp', version: '1.1' },
+        { lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it'], edition: 'webapp', version: '2.2' }
     ];
     private static readonly decks: Deck[] = [
-        {edition: 'mobileapp', version: '1.1', lang: ['en']},
-        {edition: 'webapp', version: '2.2', lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it']},
-        {edition: 'webapp', version: '3.0', lang: ['en']}];
+        { edition: 'mobileapp', version: '1.1', lang: ['en'] },
+        { edition: 'webapp', version: '2.2', lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it'] },
+        { edition: 'webapp', version: '3.0', lang: ['en'] }];
 
-    public static hasEdition(edition: string): boolean
-    {
+    public static hasEdition(edition: string): boolean {
         return DeckService.decks.find((deck) => deck.edition == edition) != undefined;
     }
 
-    public static hasVersion(edition: string, version: string): boolean
-    {
+    public static hasVersion(edition: string, version: string): boolean {
         return DeckService.decks.find((deck) => (deck.edition == edition && deck.version == version)) != undefined;
     }
 
-    public static hasLanguage(edition: string, lang: string): boolean
-    {
+    public static hasLanguage(edition: string, lang: string): boolean {
         return DeckService.decks.find((deck) => (deck.edition == edition && deck.lang.includes(lang))) != undefined;
     }
 
-    public static getDecks(): Deck[]
-    {
+    public static getDecks(): Deck[] {
         return DeckService.decks;
     }
 
-    public static getLatestVersion(edition: string): string
-    {
+    public static getLatestVersion(edition: string): string {
         return DeckService.latests.find((deck) => deck.edition == edition)?.version || '2.2';
     }
 
-    public static getLatestEditions(): string[]
-    {
+    public static getLatestEditions(): string[] {
         return DeckService.latests.map((deck) => deck.edition);
     }
-    
-    public static getLanguages(edition: string) : string[]
-    {
-        let languages : string[] = DeckService.decks.filter((deck) => deck.edition == edition).flatMap((deck) => deck.lang);
+
+    public static getLanguages(edition: string): string[] {
+        let languages: string[] = DeckService.decks.filter((deck) => deck.edition == edition).flatMap((deck) => deck.lang);
         return languages.length !== 0 ? languages : ['en'];
     }
-    public static getVersions(edition: string) : string[]
-    {
+    public static getVersions(edition: string): string[] {
         return DeckService.decks.filter((deck) => deck.edition == edition).flatMap((deck) => deck.version);
     }
 
-    public getCards(lang: string): Map<string, Card>
-    {
+    public getCards(lang: string): Map<string, Card> {
         return DeckService.cache.find((deck) => deck?.lang == lang && deck?.version == 'latest')?.data || this.getCardData(lang);
     }
 
-    private getCardData(lang: string)
-    {
+    private getCardData(lang: string) {
         let cards = new Map<string, Card>;
         const decks = DeckService.latests;
         for (let i in decks) {
             cards = new Map([...this.getCardDataForEditionVersionLang(decks[i].edition, decks[i].version, lang), ...cards]);
-            DeckService.cache.push({lang: lang, data: cards, version: 'latest'});
+            DeckService.cache.push({ lang: lang, data: cards, version: 'latest' });
         }
         return cards;
     }
 
-    public getCardDataForEditionVersionLang(edition:string, version: string, lang: string)
-    {
+    public getCardDataForEditionVersionLang(edition: string, version: string, lang: string) {
         const cards = new Map<string, Card>;
 
         let cardFile = `${__dirname}${DeckService.path}${edition}-cards-${version}-${lang}.yaml`;
 
-        if(!FileSystemHelper.hasFile(cardFile)) {
+        if (!FileSystemHelper.hasFile(cardFile)) {
             return cards;
         }
 
@@ -93,7 +82,7 @@ export class DeckService {
         let data = yaml.load(yamlData);
         let base = `data/cards/${edition}-cards-${version}-${lang}/`;
 
-        if(!FileSystemHelper.hasDir(base)) {
+        if (!FileSystemHelper.hasDir(base)) {
             base = `data/cards/${edition}-cards-${version}-en/`;
         }
 
@@ -102,7 +91,7 @@ export class DeckService {
         for (let suit in data['suits']) {
             let suitObject: any = data['suits'][suit];
             let suitName: string = mapping['suits'][suit]['name'];
-            for(let card in suitObject['cards']) {
+            for (let card in suitObject['cards']) {
                 let cardObject = suitObject['cards'][card];
                 cardObject.id = cardObject['id'];
                 cardObject.edition = edition;
@@ -114,9 +103,10 @@ export class DeckService {
                 cardObject.name = `${cardObject.suitName} (${cardObject.id})`;
                 cardObject.suit = cardObject.suitName.replaceAll(' ', '-').toLocaleLowerCase();
                 cardObject.url = `/edition/${edition}/${cardObject.id}/${version}/${lang}`;
-                cardObject.githubUrl = `` + cardObject.suit + '/' + cardObject.id;
-                
-                let path : string = `./${base}${cardObject.githubUrl}/technical-note.md`;  // '/explanation.md';
+                let cardFolderPath = cardObject.suit + '/' + cardObject.id;
+                cardObject.githubUrl = base + cardFolderPath + '/explanation.md';
+
+                let path: string = `./${base}${cardFolderPath}/technical-note.md`;  // '/explanation.md';
                 let file: string;
                 try {
                     file = fs.readFileSync(path, 'utf8');
@@ -127,43 +117,42 @@ export class DeckService {
                 let parsed = fm(file);
                 cardObject.concept = parsed.body;
                 try {
-                    cardObject.summary = fm(fs.readFileSync(`./${base}${cardObject.githubUrl}/explanation.md`, 'utf8')).body;
+                    cardObject.summary = fm(fs.readFileSync(`./${base}${cardFolderPath}/explanation.md`, 'utf8')).body;
                 } catch (e) {
-                    console.error(`Error reading file at path: ./${base}${cardObject.githubUrl}/explanation.md`, e);
+                    console.error(`Error reading file at path: ./${base}${cardFolderPath}/explanation.md`, e);
                     continue;
                 }
 
 
                 if (+card == 0 && +suit == 0) {
-                    cardObject.prevous = data['suits'][(+data['suits'].length-1)]['cards'][+data['suits'][(+data['suits'].length-1)]['cards'].length-1]['id'];
+                    cardObject.prevous = data['suits'][(+data['suits'].length - 1)]['cards'][+data['suits'][(+data['suits'].length - 1)]['cards'].length - 1]['id'];
                 } else if (Number(card) == 0) {
-                    cardObject.prevous = data['suits'][+suit-1]['cards'][+data['suits'][+suit-1]['cards'].length-1]['id'];
+                    cardObject.prevous = data['suits'][+suit - 1]['cards'][+data['suits'][+suit - 1]['cards'].length - 1]['id'];
                 } else {
-                    cardObject.prevous = suitObject['cards'][+card-1]['id'];
+                    cardObject.prevous = suitObject['cards'][+card - 1]['id'];
                 }
 
-                if (suitObject['cards'].length == +card+1 && data['suits'].length == +suit+1) {
+                if (suitObject['cards'].length == +card + 1 && data['suits'].length == +suit + 1) {
                     cardObject.next = data['suits'][0]['cards'][0]['id'];
-                } else if (suitObject['cards'].length == +card+1) {
-                    cardObject.next = data['suits'][+suit+1]['cards'][0]['id'];
+                } else if (suitObject['cards'].length == +card + 1) {
+                    cardObject.next = data['suits'][+suit + 1]['cards'][0]['id'];
                 } else {
-                    cardObject.next = suitObject['cards'][+card+1]['id'];
+                    cardObject.next = suitObject['cards'][+card + 1]['id'];
                 }
                 cardObject.prevous = cardObject.prevous;
                 cardObject.next = cardObject.next;
-                
+
                 cards.set(cardObject.id, cardObject);
             }
         }
 
         console.log(`Caching cards for ${edition} ${version} ${lang} - total cards: ${cards.size}`);
 
-        DeckService.cache.push({edition: edition, version: version, lang: lang, data: cards});
+        DeckService.cache.push({ edition: edition, version: version, lang: lang, data: cards });
         return cards;
     }
 
-    public static clear(): void
-    {
+    public static clear(): void {
         DeckService.cache = [];
     }
 }

--- a/cornucopia.owasp.org/src/routes/taxonomy/[...path]/+page.server.ts
+++ b/cornucopia.owasp.org/src/routes/taxonomy/[...path]/+page.server.ts
@@ -1,12 +1,28 @@
 import { FileSystemHelper } from "$lib/filesystem/fileSystemHelper.js";
+import path from "path";
 
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ url }) {
+  const lang = 'en';
+  let [categories, content] = FileSystemHelper.getDataByRoute(url.pathname, lang);
 
-export async function load({ params, url }) {
-  let [categories, content] = FileSystemHelper.getDataByRoute(url.pathname, 'en');
+  // Resolve the canonical path for GitHub links
+  let route = url.pathname;
+  if (!route.includes(`taxonomy/${lang}`)) route = route.replace(/taxonomy\/?/, `taxonomy/${lang}/`);
+
+  // Resolve actual casing using FileSystemHelper
+  // @ts-ignore
+  const baseDataPath = path.join(FileSystemHelper.root, "data");
+  // @ts-ignore
+  const resolvedFullPath = FileSystemHelper.resolveCaseInsensitivePath(baseDataPath, route);
+  // @ts-ignore
+  const truePath = path.relative(FileSystemHelper.root, resolvedFullPath).replace(/\\/g, '/');
+
   return {
     categories: categories,
     content: content,
     path: url.pathname,
+    truePath: truePath,
     title: FileSystemHelper.getCurrentPageNameByRoute(url.pathname as string),
     timestamp: new Date().toUTCString(),
   };

--- a/cornucopia.owasp.org/src/routes/taxonomy/[...path]/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/taxonomy/[...path]/+page.svelte
@@ -29,7 +29,7 @@
 <!--The location is filecontent -->
 {#if data.content && data.content != ''}
     <SvelteMarkdown {renderers} source={data.content}></SvelteMarkdown>
-    <ViewSourceOnGithub path={'./data/taxonomy/' + data.path + '/index.md'} ></ViewSourceOnGithub>
+    <ViewSourceOnGithub path={data.truePath + '/index.md'} ></ViewSourceOnGithub>
 {/if}
 </div>
 <style>


### PR DESCRIPTION
This PR updates the "View source on GitHub" button to link directly to specific source files instead of top-level directories.

 Changes

- Dynamic URL resolution (viewSourceOnGithub.svelte):
Uses /blob/ for file links and /tree/ for directories with proper path normalization.

- Card source paths (deckService.ts):
Generates full relative paths to each card’s explanation.md.
Fixes double-appending regression in local file reads.

- Taxonomy canonicalization (+page.server.ts):
Resolves correct filesystem casing (e.g., ASVS-4.0.3) to prevent GitHub 404 errors.

- UI integration:
Connected dynamic paths to cardFound.svelte and taxonomy page.

 Result

Users can now view the exact source file for cards and taxonomy items directly on GitHub.