### PR TITLE
feature/swagger-docs-fix : Add Swagger API documentation endpoint & fixed PR 2227 issues

### DIFF
--- a/cornucopia.owasp.org/data/website/pages/cards/en/index.md
+++ b/cornucopia.owasp.org/data/website/pages/cards/en/index.md
@@ -1,3 +1,8 @@
 # The Card Decks
 
 Both current decks have six suits and there are also two Joker cards. Each suit contains 13 cards (Ace, 2-10, Jack, Queen and King). This page contains the card browser where you can browse through each of the cards in the OWASP Cornucopia decks.
+
+## API integration
+
+Here you will find the [API documentation](/api/docs) to more easily integrate against OWASP Cornucopia and use the cards and card codes in other systems.
+

--- a/cornucopia.owasp.org/package.json
+++ b/cornucopia.owasp.org/package.json
@@ -45,6 +45,7 @@
 		"svelte-i18n": "^4.0.1",
 		"svelte-markdown": "^0.4.1",
 		"sveltekit-i18n": "^2.4.2",
+		"swagger-ui-dist": "^5.31.1",
 		"sync-request": "^6.1.0",
 		"vite-plugin-restart": "^2.0.0",
 		"vite-plugin-static-copy": "^3.2.0"

--- a/cornucopia.owasp.org/pnpm-lock.yaml
+++ b/cornucopia.owasp.org/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       sveltekit-i18n:
         specifier: ^2.4.2
         version: 2.4.2(svelte@5.50.3)
+      swagger-ui-dist:
+        specifier: ^5.31.1
+        version: 5.31.1
       sync-request:
         specifier: ^6.1.0
         version: 6.1.0
@@ -691,89 +694,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -891,56 +910,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -966,6 +996,9 @@ packages:
     resolution: {integrity: sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==}
     cpu: [x64]
     os: [win32]
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -2026,6 +2059,9 @@ packages:
     peerDependencies:
       svelte: '>=3.49.0'
 
+  swagger-ui-dist@5.31.1:
+    resolution: {integrity: sha512-XdgQ8wkRGj1P0H0Vvo0TRMOQNz+8Q8J64/vcPOhxlaFx9eB3PYvHMXeyNrP46PXa9SUs/cg7OW/jm9U34KzUfA==}
+
   sync-request@6.1.0:
     resolution: {integrity: sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==}
     engines: {node: '>=8.0.0'}
@@ -2814,6 +2850,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.52.5':
     optional: true
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sindresorhus/is@7.2.0': {}
 
@@ -4011,6 +4049,10 @@ snapshots:
       '@sveltekit-i18n/base': 1.3.7(svelte@5.50.3)
       '@sveltekit-i18n/parser-default': 1.1.1
       svelte: 5.50.3
+
+  swagger-ui-dist@5.31.1:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   sync-request@6.1.0:
     dependencies:

--- a/cornucopia.owasp.org/src/routes/api/cre/mobileapp/+server.js
+++ b/cornucopia.owasp.org/src/routes/api/cre/mobileapp/+server.js
@@ -1,0 +1,14 @@
+import { json } from '@sveltejs/kit';
+
+export function GET() {
+    return json({
+        meta: {
+            edition: "OWASP Cornucopia Mobile App Edition",
+            component: "cards",
+            language: "all",
+            languages: ["en"],
+            version: "1.1"
+        }
+    });
+}
+

--- a/cornucopia.owasp.org/src/routes/api/cre/webapp/+server.js
+++ b/cornucopia.owasp.org/src/routes/api/cre/webapp/+server.js
@@ -1,0 +1,13 @@
+import { json } from '@sveltejs/kit';
+
+export function GET() {
+    return json({
+        meta: {
+            edition: "OWASP Cornucopia Website App Edition",
+            component: "cards",
+            language: "all",
+            languages: ["en", "es", "fr", "nl", "no_nb", "pt_br", "pt_pt", "it", "ru"],
+            version: "2.2"
+        }
+    });
+}

--- a/cornucopia.owasp.org/src/routes/api/docs/+page.server.ts
+++ b/cornucopia.owasp.org/src/routes/api/docs/+page.server.ts
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/cornucopia.owasp.org/src/routes/api/docs/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/api/docs/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { onMount } from 'svelte';
+	onMount(async () => {
+		const SwaggerUIBundle = (await import('swagger-ui-dist/swagger-ui-bundle.js')).default;
+		await import('swagger-ui-dist/swagger-ui.css');
+		SwaggerUIBundle({
+			url: '/api/openapi.yaml',
+			dom_id: '#swagger-ui'
+		});
+	});
+</script>
+
+<div id="swagger-ui"></div>

--- a/cornucopia.owasp.org/static/api/openapi.yaml
+++ b/cornucopia.owasp.org/static/api/openapi.yaml
@@ -1,0 +1,194 @@
+openapi: 3.0.3
+
+info:
+  title: OWASP Cornucopia API
+  description: |
+    Public API for accessing OWASP Cornucopia card data and metadata.
+    This API exposes language metadata and Open CRE mappings
+    for both Website App and Mobile App editions.
+  version: 1.0.0
+
+servers:
+  - url: /api
+
+paths:
+
+  /cre/webapp:
+    get:
+      summary: Get supported languages for Webapp edition
+      description: |
+        Returns metadata about supported languages for the
+        OWASP Cornucopia Website App Edition.
+      responses:
+        '200':
+          description: Language metadata for Website App edition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LanguageMetaWeb'
+              examples:
+                example:
+                  summary: Example language metadata response
+                  value:
+                    meta:
+                      edition: OWASP Cornucopia Website App Edition
+                      component: cards
+                      language: all
+                      languages: [en, es, fr, nl, no_nb, pt_br, pt_pt, it, ru]
+                      version: "2.2"
+
+  /cre/mobileapp:
+    get:
+      summary: Get supported languages for Mobile edition
+      description: |
+        Returns metadata about supported languages for the
+        OWASP Cornucopia Mobile App Edition.
+      responses:
+        '200':
+          description: Language metadata for Mobile App edition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LanguageMetaMobile'
+              examples:
+                example:
+                  summary: Example language metadata response
+                  value:
+                    meta:
+                      edition: OWASP Cornucopia Mobile App Edition
+                      component: cards
+                      language: all
+                      languages: [en]
+                      version: "1.1"
+
+  /cre/webapp/{lang}:
+    get:
+      summary: Get Webapp cards by language
+      description: |
+        Get the OWASP Cornucopia Website App Edition cards and
+        their corresponding Open CRE codes by language.
+        See Open CRE: https://www.opencre.org/
+      parameters:
+        - name: lang
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [en, es, fr, nl, no_nb, pt_br, pt_pt, it, ru]
+      responses:
+        '200':
+          description: Website App cards and Open CRE mappings
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                example:
+                  summary: Example Website App response
+                  value:
+                    meta:
+                      edition: OWASP Cornucopia Website App Edition
+                      component: cards
+                      language: en
+                      version: "2.2"
+                    data:
+                      - id: AAA
+                        title: Authentication Architecture
+                        cre:
+                          - CRE-1
+                          - CRE-2
+
+  /cre/mobileapp/{lang}:
+    get:
+      summary: Get Mobile cards by language
+      description: |
+        Get the OWASP Cornucopia Mobile App Edition cards and
+        their corresponding Open CRE codes by language.
+        See Open CRE: https://www.opencre.org/
+      parameters:
+        - name: lang
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [en]
+      responses:
+        '200':
+          description: Mobile App cards and Open CRE mappings
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                example:
+                  summary: Example Mobile App response
+                  value:
+                    meta:
+                      edition: OWASP Cornucopia Mobile App Edition
+                      component: cards
+                      language: en
+                      version: "1.1"
+                    data:
+                      - id: M01
+                        title: Secure Storage
+                        cre:
+                          - CRE-5
+
+components:
+
+  schemas:
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Language not available
+
+    LanguageMetaWeb:
+      type: object
+      properties:
+        meta:
+          type: object
+          properties:
+            edition:
+              type: string
+              example: OWASP Cornucopia Website App Edition
+            component:
+              type: string
+              example: cards
+            language:
+              type: string
+              example: all
+            languages:
+              type: array
+              items:
+                type: string
+              example: [en, es, fr, nl, no_nb, pt_br, pt_pt, it, ru]
+            version:
+              type: string
+              example: "2.2"
+
+    LanguageMetaMobile:
+      type: object
+      properties:
+        meta:
+          type: object
+          properties:
+            edition:
+              type: string
+              example: OWASP Cornucopia Mobile App Edition
+            component:
+              type: string
+              example: cards
+            language:
+              type: string
+              example: all
+            languages:
+              type: array
+              items:
+                type: string
+              example: [en]
+            version:
+              type: string
+              example: "1.1"


### PR DESCRIPTION
### Related Issue : #2193 

---

## Summary

This PR introduces a Swagger documentation endpoint and enhances the existing API by adding metadata endpoints that list supported languages for both the WebApp and MobileApp editions. It also adds an **API integration** section to the cards page to improve discoverability of the documentation.

These changes make it easier for developers to understand, explore, and integrate with the API.

---

## Changes Implemented

### ✅ Swagger Documentation

* Added a new endpoint:

```
/api/docs
```

* Serves Swagger UI generated from a manually created OpenAPI specification.
* Provides a centralized interface to explore all available API routes.

<img width="1522" height="928" alt="api-endpoints" src="https://github.com/user-attachments/assets/8832a796-e48d-4c86-b923-35ec55eec16e" />


---

### ✅ Language Metadata Endpoints

Added endpoints that return supported languages along with edition metadata:

**WebApp**

```
/api/cre/webapp
```

Response:

```json
{
  "meta": {
    "edition": "OWASP Cornucopia Website App Edition",
    "component": "cards",
    "language": "all",
    "languages": ["en", "es", "fr", "nl", "no_nb", "pt_br", "pt_pt", "it", "ru"],
    "version": "2.2"
  }
}
```

**MobileApp**

```
/api/cre/mobileapp
```

Response:

```json
{
  "meta": {
    "edition": "OWASP Cornucopia Mobile App Edition",
    "component": "cards",
    "language": "all",
    "languages": ["en"],
    "version": "1.1"
  }
}
```

---

### ✅ Existing Language Endpoints Preserved

The following endpoints continue to return the full card datasets:

```
/api/cre/webapp/{lang}
/api/cre/mobileapp/{lang}
```

---

### ✅ Cards Page Update

Added a new section to improve API visibility:


<img width="1914" height="928" alt="cards-route" src="https://github.com/user-attachments/assets/c5f40333-d9ea-4cea-b20b-0b32434fddd5" />


```
## API integration

Here you will find the [API documentation](/api/docs) to more easily integrate against OWASP Cornucopia and use the cards and card codes in other systems.
```

Location:

```
data/website/pages/cards/en/index.md
```

---

## Why This PR?

* Improves developer experience by exposing structured API documentation.
* Makes supported languages discoverable without guessing endpoints.
* Keeps implementation simple by using a manual OpenAPI spec.
* Aligns the website with the available API capabilities.

---

## Testing Performed

✔ Verified Swagger UI loads correctly at `/api/docs`
✔ Confirmed metadata endpoints return expected JSON
✔ Valid language endpoints return full card data
✔ Removed Invalid languages
✔ Confirmed the cards page renders the new API integration section

---

## Impact

* Non-breaking change
* No modifications to existing response structures
* Safe addition to the website content

---

## Future Improvements (Optional)

* Auto-generate OpenAPI spec from routes
* Expand MobileApp language support if translations become available
* Add examples inside Swagger

---

Thanks for reviewing! 🙂
