### PR TITLE
Fix ArithmeticError when starting game with zero players

### DIFF
--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -1,0 +1,89 @@
+defmodule CopiWeb.GameLive.ShowTest do
+  use CopiWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Copi.Cornucopia
+
+  @game_attrs %{name: "Edge Case Test Game", edition: "webapp", suits: ["hearts", "clubs"]}
+
+  defp create_game(_) do
+    {:ok, game} = Cornucopia.create_game(@game_attrs)
+    %{game: game}
+  end
+
+  describe "Show - Edge Cases" do
+    setup [:create_game]
+
+    test "prevents starting game with fewer than 3 players", %{conn: conn, game: game} do
+      # Test with 0 players
+      {:ok, view, html} = live(conn, "/games/#{game.id}")
+      refute html =~ "Start Game"
+      
+      # Directly trigger start_game event to test server-side validation
+      render_click(view, "start_game", %{})
+      assert render(view) =~ "At least 3 players are required"
+      
+      {:ok, updated_game} = Cornucopia.Game.find(game.id)
+      assert updated_game.started_at == nil
+
+      # Test with 1 player
+      {:ok, _player1} = Cornucopia.create_player(%{name: "Player 1", game_id: game.id})
+      {:ok, view, html} = live(conn, "/games/#{game.id}")
+      refute html =~ "Start Game"
+      
+      render_click(view, "start_game", %{})
+      assert render(view) =~ "At least 3 players are required"
+
+      # Test with 2 players
+      {:ok, _player2} = Cornucopia.create_player(%{name: "Player 2", game_id: game.id})
+      {:ok, view, html} = live(conn, "/games/#{game.id}")
+      refute html =~ "Start Game"
+      
+      render_click(view, "start_game", %{})
+      assert render(view) =~ "At least 3 players are required"
+    end
+
+    test "successfully starts game with 3+ players", %{conn: conn, game: game} do
+      # Add 3 players
+      {:ok, _player1} = Cornucopia.create_player(%{name: "Player 1", game_id: game.id})
+      {:ok, _player2} = Cornucopia.create_player(%{name: "Player 2", game_id: game.id})
+      {:ok, _player3} = Cornucopia.create_player(%{name: "Player 3", game_id: game.id})
+
+      {:ok, view, html} = live(conn, "/games/#{game.id}")
+      
+      # Button should be visible with 3+ players
+      assert html =~ "Start Game"
+
+      # Start game
+      view |> element("button", "Start Game") |> render_click()
+
+      # Verify game was started
+      {:ok, updated_game} = Cornucopia.Game.find(game.id)
+      assert updated_game.started_at != nil
+    end
+
+    test "does not restart an already started game", %{conn: conn, game: game} do
+      # Add 3 players
+      {:ok, _player1} = Cornucopia.create_player(%{name: "Player 1", game_id: game.id})
+      {:ok, _player2} = Cornucopia.create_player(%{name: "Player 2", game_id: game.id})
+      {:ok, _player3} = Cornucopia.create_player(%{name: "Player 3", game_id: game.id})
+
+      # Start game first
+      {:ok, started_game} = Cornucopia.update_game(game, %{started_at: DateTime.truncate(DateTime.utc_now(), :second)})
+      original_time = started_game.started_at
+
+      {:ok, view, html} = live(conn, "/games/#{started_game.id}")
+
+      # Button should not be visible after game has started
+      refute html =~ "Start Game"
+
+      # Try to start again via direct event trigger - should do nothing
+      render_click(view, "start_game", %{})
+
+      # Verify started_at timestamp hasn't changed
+      {:ok, updated_game} = Cornucopia.Game.find(started_game.id)
+      assert DateTime.compare(updated_game.started_at, original_time) == :eq
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes #2335 

This PR resolves a critical bug where attempting to start a game without sufficient players causes an `ArithmeticError` crash due to division by zero in the card distribution logic.

## Problem

The `start_game` event handler would crash when:
1. A game is created
2. Fewer than required players join
3. Someone triggers "Start Game" event

The crash occurred at this line:
```elixir
player_id: Enum.fetch!(players, rem(i, Enum.count(players))).id
```

When `Enum.count(players) = 0`, the `rem(i, 0)` operation throws an `ArithmeticError`.

Additional issues identified during Copilot AI review:
- Server-side validation didn't match UI requirement (3+ players)
- `update_game` errors were not handled
- `length(players)` was computed in every loop iteration (inefficient)

## Solution

### Code Changes

1. **Server-Side Validation (Aligned with UI)**
   - Require minimum **3 players** to start (matches UI requirement)
   - Display user-friendly error message: "Cannot start game: At least 3 players are required to start."
   - Prevent game start with 0, 1, or 2 players

2. **Error Handling**
   - Pattern match on `update_game` result
   - Show error flash if update fails: "Failed to start game. Please try again."
   - Reload game state on failure to maintain consistency

3. **Performance Optimization**
   - Compute `player_count = length(players)` once before loop
   - Reuse `player_count` in `rem/2` to avoid repeated traversals

4. **Code Safety**
   - Replaced `Enum.fetch!` with safer `Enum.at`
   - Added proper error handling for all edge cases
   - Consistent return values in all `cond` branches

5. **Comprehensive Tests**
   - Test validation with 0/1/2 players (all blocked with same error)
   - Test successful start with 3+ players (button visible, game starts)
   - Test idempotency (cannot restart already-started game)
   - All tests directly trigger events to verify server-side security

## Testing

All tests pass:

```elixir
test "prevents starting game with fewer than 3 players"
test "successfully starts game with 3+ players"  
test "does not restart an already started game"
```

