### PR TITLE
fix: use gh release upload for ZAP report upload to pre-release

### DIFF
--- a/.github/workflows/zap-nightly-scan.yml
+++ b/.github/workflows/zap-nightly-scan.yml
@@ -141,13 +141,15 @@ jobs:
 
       - name: Upload reports to pre-release
         if: always()
-        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
-        with:
-          tag_name: pre-release
-          prerelease: true
-          name: Latest pre-release
-          files: |
-            zap-reports/copi_dast_report.html
-            zap-reports/copi_dast_report.json
-            zap-reports/copi_dast_report.xml
-            zap-reports/copi_dast_report.md
+        run: |
+          for f in \
+            zap-reports/copi_dast_report.html \
+            zap-reports/copi_dast_report.json \
+            zap-reports/copi_dast_report.xml \
+            zap-reports/copi_dast_report.md; do
+            if [ -f "$f" ]; then
+              gh release upload "pre-release" "$f" --clobber
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
The softprops/action-gh-release action cannot upload files to an already existing release, so the nightly ZAP DAST reports were silently failing to attach to the pre-release. This replaces it with gh release upload --clobber, which properly uploads files to existing releases.

Closes #2333 

### Changes

- Replaced softprops/action-gh-release with gh release upload "pre-release" --clobber
- Each report file is checked for existence before upload (since ZAP scan uses || true)
- Uses GITHUB_TOKEN for authentication (already available via permissions: contents: write)