### PR TITLE
fix: use proper -z flag config for ZAP scan duration limit

### DIFF
--- a/.github/workflows/zap-nightly-scan.yml
+++ b/.github/workflows/zap-nightly-scan.yml
@@ -100,7 +100,7 @@ jobs:
             -x copi_dast_report.xml \
             -a \
             -d \
-            -z 180 \
+            -z "-config scanner.maxScanDurationInMins=180" \
             || true
 
       - name: Stop Phoenix server


### PR DESCRIPTION
## Summary

This PR fixes the ZAP nightly security scan configuration to properly limit scan duration.

### Changes

- Replaced `-z 180` with `-z "-config scanner.maxScanDurationInMins=180"` in the ZAP scan workflow

### Rationale

The `-z 180` flag passes `180` as a raw ZAP command-line argument, which is not a valid configuration. Using `-z "-config scanner.maxScanDurationInMins=180"` correctly configures ZAP's internal scanner to respect the 180-minute maximum scan duration limit.

Closes #2347