### PR TITLE
Fix/zap max scan duration

### DIFF
--- a/.github/workflows/zap-nightly-scan.yml
+++ b/.github/workflows/zap-nightly-scan.yml
@@ -100,7 +100,6 @@ jobs:
             -x copi_dast_report.xml \
             -a \
             -d \
-            -m 5 \
             -z "-config scanner.maxScanDurationInMins=180" \
             || true
 


### PR DESCRIPTION
# Description
Added time limit of 3 hours for ZAP active scan phase using `scanner.maxScanDurationInMins`.
- Closes #2347

## Changes
### .github/workflows/zap-nightly-scan.yml
- Changed `-z 180` to `-z "-config scanner.maxScanDurationInMins=180"` to correctly pass the scan duration limit as a ZAP internal config option.

## How it was tested
- Tested by setting a small time bound for both the AJAX spider and active scanning phases:
```
-z "-config ajaxSpider.maxDuration=5 -config scanner.maxScanDurationInMins=20"
```
- This puts a 5-minute limit on the AJAX spider and a 20-minute limit on the active scanning phase.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/72e94154-0256-4725-bf6e-2735c3c98be5" />
<img width="1323" alt="image" src="https://github.com/user-attachments/assets/cdbff9ca-4493-4cad-acd7-4edbc6185943" />

- Scanning timed out correctly after the 20-minute limit specified for testing.
<br/>