### PR TITLE
BOT attack attack format update; AAI duplicate tidy-up

### DIFF
--- a/source/companion-cards-1.0.yaml
+++ b/source/companion-cards-1.0.yaml
@@ -76,76 +76,6 @@ suits:
     desc: You have invented a new attack against LLM
     misc:
 -
-  id: AAI
-  name: Agentic AI
-  cards:
-  -
-    id: AAI2
-    value: 2
-    url: https://cornucopia.owasp.org/cards/AAI2
-    desc: 
-  -
-    id: AAI3
-    value: 3
-    url: https://cornucopia.owasp.org/cards/AAI3
-    desc: 
-  -
-    id: AAI4
-    value: 4
-    url: https://cornucopia.owasp.org/cards/AAI4
-    desc: 
-  -
-    id: AAI5
-    value: 5
-    url: https://cornucopia.owasp.org/cards/AAI5
-    desc: 
-  -
-    id: AAI6
-    value: 6
-    url: https://cornucopia.owasp.org/cards/AAI6
-    desc: 
-  -
-    id: AAI7
-    value: 7
-    url: https://cornucopia.owasp.org/cards/AAI7
-    desc: 
-  -
-    id: AAI8
-    value: 8
-    url: https://cornucopia.owasp.org/cards/AAI8
-    desc: 
-  -
-    id: AAI9
-    value: 9
-    url: https://cornucopia.owasp.org/cards/AAI9
-    desc: 
-  -
-    id: AAIX
-    value: X
-    url: https://cornucopia.owasp.org/cards/AAIX
-    desc: 
-  -
-    id: AAIJ
-    value: J
-    url: https://cornucopia.owasp.org/cards/AAIJ
-    desc: 
-  -
-    id: AAIQ
-    value: Q
-    url: https://cornucopia.owasp.org/cards/AAIQ
-    desc: 
-  -
-    id: AAIK
-    value: K
-    url: https://cornucopia.owasp.org/cards/AAIK
-    desc: 
-  -
-    id: AAIA
-    value: A
-    url: https://cornucopia.owasp.org/cards/AAIA
-    desc: You have identified an attack that misuses inherent Agentic AI functionality or a related design flaw
-    misc: Read More about threats and mitigations at the OWASP Gen AI Security projects 
--
   id: API
   name: Web API
   cards:
@@ -573,62 +503,62 @@ suits:
     id: BOT2
     value: 2
     url: https://cornucopia.owasp.org/cards/BOT2
-    desc: The ENIAC can profit from utilising functionality built on paid-for supporting services
+    desc: ENIAC can profit from utilising functionality built on paid-for supporting services
   -
     id: BOT3
     value: 3
     url: https://cornucopia.owasp.org/cards/BOT3
-    desc: The Mark 1 Colossus can hasten the progress of usually slow, tedious or time-consuming actions
+    desc: Mark 1 Colossus can hasten the progress of usually slow, tedious or time-consuming actions
   -
     id: BOT4
     value: 4
     url: https://cornucopia.owasp.org/cards/BOT4
-    desc: The IBM 701 can make last minute bids or offers for goods/services
+    desc: IBM 701 can make last minute bids or offers for goods/services
   -
     id: BOT5
     value: 5
     url: https://cornucopia.owasp.org/cards/BOT5
-    desc: The Ferranti Mercury can deplete the stock of goods/services, without ever completing the purchase or committing to the transaction
+    desc: Ferranti Mercury can deplete the stock of goods/services, without ever completing the purchase or committing to the transaction
   -
     id: BOT6
     value: 6
     url: https://cornucopia.owasp.org/cards/BOT6
-    desc: The EDSAC can obtain limited-availability and/or preferred goods/services by unfair methods
+    desc: EDSAC can obtain limited-availability and/or preferred goods/services by unfair methods
   -
     id: BOT7
     value: 7
     url: https://cornucopia.owasp.org/cards/BOT7
-    desc: The Manchester Mark 1 can utilise stolen payment card data, or other user account data, to buy goods or obtain cash
+    desc: Manchester Mark 1 can utilise stolen payment card data, or other user account data, to buy goods or obtain cash
   -
     id: BOT8
     value: 8
     url: https://cornucopia.owasp.org/cards/BOT8
-    desc: The UNIVAC 1 can create multiple accounts for subsequent misuse
+    desc: UNIVAC 1 can create multiple accounts for subsequent misuse
   -
     id: BOT9
     value: 9
     url: https://cornucopia.owasp.org/cards/BOT9
-    desc: The CSIRAC can alter a metric by using repeated link clicks, page requests or form submissions
+    desc: CSIRAC can alter a metric by using repeated link clicks, page requests or form submissions
   -
     id: BOTX
     value: X
     url: https://cornucopia.owasp.org/cards/BOTX
-    desc: The Ferranti Pegasus can enumerate individual authentication credentials, or payment card data (e.g. start/expiry dates, security codes), or other tokens (e.g. coupon numbers, voucher codes, discount tokens) by trying different values
+    desc: Ferranti Pegasus can enumerate individual authentication credentials, or payment card data (e.g. start/expiry dates, security codes), or other tokens (e.g. coupon numbers, voucher codes, discount tokens) by trying different values
   -
     id: BOTJ
     value: J
     url: https://cornucopia.owasp.org/cards/BOTJ
-    desc: The Zuse Z3 can validate stolen bulk authentication credentials, or payment cardholder data (e.g. PAN, security code, expiry date)
+    desc: Zuse Z3 can validate stolen bulk authentication credentials, or payment cardholder data (e.g. PAN, security code, expiry date)
   -
     id: BOTQ
     value: Q
     url: https://cornucopia.owasp.org/cards/BOTQ
-    desc: The Manchester Baby can add malicious or questionable information to content, databases or user messages
+    desc: Manchester Baby can add malicious or questionable information to content, databases or user messages
   -
     id: BOTK
     value: K
     url: https://cornucopia.owasp.org/cards/BOTK
-    desc: The EDVAC can collect application content and/or other data for use elsewhere
+    desc: EDVAC can collect application content and/or other data for use elsewhere
   -
     id: BOTA
     value: A
@@ -703,5 +633,5 @@ suits:
     id: AAIA
     value: A
     url: https://cornucopia.owasp.org/cards/AAIA
-    desc: You have invented a new attack against Agentic AI
-    misc: 
+    desc: You have identified an attack that misuses inherent Agentic AI functionality or a related design flaw
+    misc: Read more about threats and mitigations at the OWASP Gen AI Security projects


### PR DESCRIPTION
Deleted duplicate AAI suit definition section, removed "The" prefix from BOT suit attacks to match the new AAI suit, and added the previous AAI Ace text