### PR TITLE
Fix mobile padding on news page

### DIFF
--- a/cornucopia.owasp.org/src/routes/news/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/news/+page.svelte
@@ -221,4 +221,24 @@
         align-items: center;
         gap: 1rem;
     }
+
+    @media (max-aspect-ratio: 1/1) {
+        div {
+            margin: 0 1rem;
+        }
+        
+        .year-heading {
+            margin-left: 1rem;
+            margin-right: 1rem;
+        }
+        
+        .year-divider {
+            margin-left: 1rem;
+            margin-right: 1rem;
+        }
+        
+        .list {
+            margin: 0 1rem;
+        }
+    }
 </style>


### PR DESCRIPTION
Add horizontal padding for mobile devices to prevent content from touching screen edges. Applies consistent 1rem margins to year headings, dividers, and article cards on mobile viewports.

Fixes issue where breadcrumbs, year labels, and article cards were flush against screen edge on mobile.

resolves - #2398 

- before 

https://github.com/user-attachments/assets/0afd03a2-fdbc-48f7-8e51-00f3b7440ef9



- after

https://github.com/user-attachments/assets/922d5c27-f994-4827-b8b9-6ea9904a3c25

