### PR TITLE
fix: explicitly use FAILSAFE_SCHEMA for yaml.load() security hardening

### DIFF
--- a/cornucopia.owasp.org/src/lib/services/capecService.ts
+++ b/cornucopia.owasp.org/src/lib/services/capecService.ts
@@ -27,7 +27,7 @@ export class CapecService {
                 `${__dirname}${this.path}${edition}-capec-${version}.yaml`, 
                 'utf8'
             );
-            const data = yaml.load(yamlData) as CapecData;
+            const data = yaml.load(yamlData, { schema: yaml.FAILSAFE_SCHEMA }) as CapecData;
             this.capecData.set(key, data);
             return data;
         } catch (e) {

--- a/cornucopia.owasp.org/src/lib/services/deckService.ts
+++ b/cornucopia.owasp.org/src/lib/services/deckService.ts
@@ -79,7 +79,7 @@ export class DeckService {
         }
 
         let yamlData = fs.readFileSync(cardFile, 'utf8');
-        let data = yaml.load(yamlData);
+        let data = yaml.load(yamlData, { schema: yaml.FAILSAFE_SCHEMA });
         let base = `data/cards/${edition}-cards-${version}-${lang}/`;
 
         if (!FileSystemHelper.hasDir(base)) {

--- a/cornucopia.owasp.org/src/lib/services/mappingService.ts
+++ b/cornucopia.owasp.org/src/lib/services/mappingService.ts
@@ -10,7 +10,7 @@ export class MappingService {
     public getLatestsCardMappingData(edition: string)
     {
         const yamlData = fs.readFileSync(`${__dirname}${MappingService.path}${edition}-mappings-${DeckService.getLatestVersion(edition)}.yaml`, 'utf8');
-        let data = yaml.load(yamlData);
+        let data = yaml.load(yamlData, { schema: yaml.FAILSAFE_SCHEMA });
         MappingService.mappings.push({edition: edition, version: 'latests', data: data});
         return data;
     }
@@ -24,7 +24,7 @@ export class MappingService {
     {
         DeckService.getDecks().forEach((deck) => {
             const yamlData = fs.readFileSync(`${__dirname}${MappingService.path}${deck.edition}-mappings-${deck.version}.yaml`, 'utf8');
-            let data = yaml.load(yamlData);
+            let data = yaml.load(yamlData, { schema: yaml.FAILSAFE_SCHEMA });
             MappingService.mappings.push({edition: deck.edition, version: deck.version, data: data});
         });
         
@@ -60,7 +60,7 @@ export class MappingService {
             if (!mappingData) {
                 try {
                     const yamlData = fs.readFileSync(`${__dirname}${MappingService.path}${deck.edition}-mappings-${deck.version}.yaml`, 'utf8');
-                    mappingData = yaml.load(yamlData);
+                    mappingData = yaml.load(yamlData, { schema: yaml.FAILSAFE_SCHEMA });
                     MappingService.mappings.push({edition: deck.edition, version: deck.version, data: mappingData});
                 } catch (e) {
                     console.error(`Failed to load mapping for ${deck.edition}-${deck.version}:`, e);


### PR DESCRIPTION
Replace implicit yaml.load() calls with explicit FAILSAFE_SCHEMA for defense-in-depth security. This follows OWASP secure coding practices and provides clear audit trail.

resolves: #2396 

Affected files:
- deckService.ts:82
- mappingService.ts:13,27,63
- capecService.ts:30

Benefits:
- Explicit security documentation
- Protection against accidental version downgrades
- Clear audit trail