### PR TITLE
fix-dropdown-design : adding previous dropdown layout design

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/languagePicker.svelte
+++ b/cornucopia.owasp.org/src/lib/components/languagePicker.svelte
@@ -82,31 +82,77 @@ onchange={(e) => {
 </div>
 
 
+
 <style>
-
-.pickers {
-  display: flex;
-  gap: 1rem;
-  margin: 1rem 0;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.pickers > div {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-@media (max-aspect-ratio: 1/1) {
   .pickers {
-    flex-direction: column;
-    align-items: flex-start;
+    display: flex;
+    gap: 1.5rem;
+    margin: 1rem 0;
+    flex-wrap: wrap;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+
+  .picker-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  label {
+    font-weight: 700;
+    color: #1f2937; /* Dark slate text from screenshot */
+    font-size: 1.1rem;
+  }
+
+  /* Container to handle the custom arrow */
+  .select-wrapper {
+    position: relative;
+    display: inline-block;
   }
 
   select {
-    width: 100%;
+    appearance: none; /* Remove default browser styling */
+    background-color: #ffffff;
+    border: 1.5px solid #374151; /* Thicker, darker border per screenshot */
+    border-radius: 8px; /* Rounded corners */
+    padding: 0.5rem 2.5rem 0.5rem 1rem; /* Extra right padding for arrow */
+    font-size: 1rem;
+    color: #1f2937;
+    cursor: pointer;
+    min-width: 140px;
+    transition: border-color 0.2s;
   }
-}
 
+  select:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+  }
+
+  /* Custom Chevron Arrow matching the screenshot */
+  .select-wrapper::after {
+    content: "";
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0.8rem;
+    height: 0.8rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%231f2937' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    pointer-events: none;
+  }
+
+  @media (max-aspect-ratio: 1/1) {
+    .pickers {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 1rem;
+    }
+
+    .select-wrapper, select {
+      width: 100%;
+    }
+  }
 </style>


### PR DESCRIPTION
Issue Related : #2424 

Added the previous dropdown design,

## Before changes

<img width="1224" height="323" alt="Screenshot 2026-02-27 at 19 05 10" src="https://github.com/user-attachments/assets/4d4a8ab9-a80d-41ce-9b9b-b42eb174e31c" />


## After Changes

<img width="631" height="167" alt="Screenshot 2026-02-27 at 19 14 30" src="https://github.com/user-attachments/assets/8b7eeec0-4612-487d-9491-16fc6d05488c" />
