### PR TITLE
feat: implement pnpm caching in CI workflows

### DIFF
--- a/.github/workflows/build-website-staging.yml
+++ b/.github/workflows/build-website-staging.yml
@@ -36,6 +36,21 @@
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
               node-version: 20.18.2
+          
+          - name: Get pnpm store directory
+            shell: bash
+            run: |
+              echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+            id: pnpm-cache
+          
+          - uses: actions/cache@v4
+            name: Setup pnpm cache
+            with:
+              path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+              key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                ${{ runner.os }}-pnpm-store-
+          
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -38,6 +38,21 @@
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
               node-version: '22.12'
+          
+          - name: Get pnpm store directory
+            shell: bash
+            run: |
+              echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+            id: pnpm-cache
+          
+          - uses: actions/cache@v4
+            name: Setup pnpm cache
+            with:
+              path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+              key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                ${{ runner.os }}-pnpm-store-
+          
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/deploy-website-production.yml
+++ b/.github/workflows/deploy-website-production.yml
@@ -36,6 +36,21 @@
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
               node-version: 20.18.2
+          
+          - name: Get pnpm store directory
+            shell: bash
+            run: |
+              echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+            id: pnpm-cache
+          
+          - uses: actions/cache@v4
+            name: Setup pnpm cache
+            with:
+              path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+              key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                ${{ runner.os }}-pnpm-store-
+          
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/deploy-website-staging.yml
+++ b/.github/workflows/deploy-website-staging.yml
@@ -43,6 +43,21 @@
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
               node-version: 20.18.2
+          
+          - name: Get pnpm store directory
+            shell: bash
+            run: |
+              echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+            id: pnpm-cache
+          
+          - uses: actions/cache@v4
+            name: Setup pnpm cache
+            with:
+              path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+              key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                ${{ runner.os }}-pnpm-store-
+          
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |


### PR DESCRIPTION
**Title:** Optimize CI performance: Add pnpm store caching to all website build & deploy workflows

**Closes:** #2447

**Description:**

This PR implements pnpm store caching in the four website-related GitHub Actions workflows to significantly speed up `pnpm install` steps, reduce network usage, lower CI minutes consumption, and provide faster feedback for contributors (especially useful during active development, PR checks, staging deploys, and GSoC contributions to `cornucopia.owasp.org`).

**Changes:**

Added the following steps **before** each `pnpm install` in all affected workflows:

```yaml
- name: Get pnpm store directory
  id: pnpm-cache
  shell: bash
  run: |
    echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT

- name: Setup pnpm cache
  uses: actions/cache@v4
  with:
    path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
    key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
    restore-keys: |
      ${{ runner.os }}-pnpm-store-
```

Updated workflows:
- `.github/workflows/build-website.yml`
- `.github/workflows/build-website-staging.yml`
- `.github/workflows/deploy-website-production.yml`
- `.github/workflows/deploy-website-staging.yml`

**Benefits:**
- **Faster CI runs** — `pnpm install` becomes near-instant on cache hit (after initial build)
- **Cache invalidation** handled correctly via `pnpm-lock.yaml` hash
- **Zero risk** — cache miss falls back to normal install behavior
- **Follows official best practices** — based on [pnpm CI guide for GitHub Actions](https://pnpm.io/continuous-integration#github-actions) and avoids less reliable `node_modules` caching

**Validation:**
- YAML syntax verified in all files
- No changes to application code, `package.json`, or `pnpm-lock.yaml`
- Backward compatible and low-risk

This should improve developer experience and CI efficiency for the SvelteKit-based website.