### PR TITLE
fix: add Content-Type header to CRE API response

### DIFF
--- a/cornucopia.owasp.org/src/routes/api/cre/[edition]/+server.ts
+++ b/cornucopia.owasp.org/src/routes/api/cre/[edition]/+server.ts
@@ -12,13 +12,20 @@ export const GET: RequestHandler = ({ params }) => {
     throw error(404, 'Edition not found. Only: ' + DeckService.getLatestEditions().join(', ') + ' are supported.');
   }
 
-  return json({
-    meta: {
-      edition: CreController.getEditionName(edition),
-      component: "cards",
-      language: "en",
-      languages: DeckService.getLanguages(edition),
-      version: DeckService.getLatestVersion(edition),
+  return json(
+    {
+      meta: {
+        edition: CreController.getEditionName(edition),
+        component: "cards",
+        language: "en",
+        languages: DeckService.getLanguages(edition),
+        version: DeckService.getLatestVersion(edition),
+      }
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json'
+      }
     }
-  });
+  );
 };


### PR DESCRIPTION
## Problem
After #2407 was merged, the `/api/cre/webapp` and `/api/cre/mobileapp` routes were working but missing the explicit `Content-Type: application/json` header, which could cause issues for API consumers.

## Solution
Added explicit `Content-Type: application/json` header to the JSON response in the `[edition]/+server.ts` route handler, following the same pattern used in the working `[edition]/[lang]/+server.ts` route.

## Changes
- Modified `cornucopia.owasp.org/src/routes/api/cre/[edition]/+server.ts`
- Added headers object to the `json()` response with explicit `Content-Type: application/json`

## Related
Follow-up to #2407 
