### PR TITLE
docs: fix typos in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The "tarot" files are (2.75 x 4.75" or 71mm x 121 mm) standard playing cards.
 The "bridge" is 60 x 89.25 mm x 27.15 mm
 The "tarot" is 122.2 x 73.1 x 29.1 mm
 
-the "tarrot" box has standard dimensions used by Agile Stationary to print their Cyber Security Cornucopia Edition.
+the "tarot" box has standard dimensions used by Agile Stationary to print their Cyber Security Cornucopia Edition.
 the "bridge" box may need some refitting if used.
 
 #### Leaflets:

--- a/cornucopia.owasp.org/README.md
+++ b/cornucopia.owasp.org/README.md
@@ -2,7 +2,7 @@
 
 https://cornucopia.owasp.org contains the card browser for each of the cards in the cornucopia suits together with the taxonomy and in depth explaination for each of the cards in the suits.
 
-## Production buid
+## Production build
 
     npm run productionbuild
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## Building the Cornucopia Card Decks
 
-Merges to the main branch will generate new DOCX and IDML files to use to print off new version of the deck but if you wish to produce these locally yourself then use the [convert.py](convert.py) scipt to do this:
+Merges to the main branch will generate new DOCX and IDML files to use to print off new version of the deck but if you wish to produce these locally yourself then use the [convert.py](convert.py) script to do this:
 
 ```bash
 (cornucopia) ➜  cornucopia git:(master) ✗ python ./scripts/convert.py --help
@@ -43,19 +43,19 @@ options:
                         Bridge cards are 2.25 x 3.5 inch and have the mappings printed on them,
                         tarot cards are 2.75 x 4.75 (71 x 121 mm) inch large,
                         qr cards have a QRCode that points to an maintained list.
-                        You can also speficy your own template. If so, there needs to be a file in the templates folder where the name contains the template code. Eg. owasp_cornucopia_edition_ver_layout_template_lang.idml
+                        You can also specify your own template. If so, there needs to be a file in the templates folder where the name contains the template code. Eg. owasp_cornucopia_edition_ver_layout_template_lang.idml
   -e EDITION, --edition EDITION
                         Output decks to produce. [`all`, `webapp` or `mobileapp`]
                         The various Cornucopia decks. `web` will give you the Website App edition.
                         `mobileapp` will give you the Mobile App edition.
-                        You can also speficy your own edition. If so, there needs to be a yaml file in the source folder where the name contains the edition code. Eg. edition-template-ver-lang.yaml
+                        You can also specify your own edition. If so, there needs to be a yaml file in the source folder where the name contains the edition code. Eg. edition-template-ver-lang.yaml
   -lt LAYOUT, --layout LAYOUT
                         Document layouts to produce. [`all`, `guide`, `leaflet` or `cards`]
                         The various Cornucopia document layouts.
                         `cards` will output the high quality print card deck.
                         `guide` will generate the docx guide with the low quality print deck.
                         `leaflet` will output the high quality print leaflet.
-                        You can also speficy your own layout. If so, there needs to be a yaml file in the source folder where the name contains the layout code. Eg. edition-layout-ver-lang.yaml
+                        You can also specify your own layout. If so, there needs to be a yaml file in the source folder where the name contains the layout code. Eg. edition-layout-ver-lang.yaml
 ```
 
 ## Additional Utility Scripts


### PR DESCRIPTION
Fixes minor typos across three README files:


- `scripts/README.md` : scipt → script, speficy → specify (×3)
- `cornucopia.owasp.org/README.md` : Production buid → Production build
- `README.md` : tarrot → tarot