### PR TITLE
Fix duplicate cards issue on /cards endpoint

### DIFF
--- a/copi.owasp.org/lib/copi/cornucopia.ex
+++ b/copi.owasp.org/lib/copi/cornucopia.ex
@@ -222,7 +222,16 @@ defmodule Copi.Cornucopia do
 
   """
   def list_cards do
-    Card |> order_by(:id) |> Repo.all()
+    # Temporary fix: get all cards and deduplicate in memory
+    # This is less efficient but guaranteed to work
+    Card 
+    |> Repo.all()
+    |> Enum.group_by(fn card -> {card.external_id, card.edition, card.language} end)
+    |> Enum.map(fn {_key, cards} -> 
+         # Get the card with the highest version (simple string comparison)
+         Enum.max_by(cards, fn card -> card.version end)
+       end)
+    |> Enum.sort_by(fn card -> {card.edition, card.external_id, card.language} end)
   end
 
   def list_cards_shuffled(edition, suits, version) do


### PR DESCRIPTION
Closes - #2516 

- Eliminate duplicate cards (same ID appearing multiple times)
- Show only latest version of each card by external_id, edition, language
- Replace simple Card |> order_by(:id) |> Repo.all() with deduplication logic
- Use Enum.group_by and Enum.max_by to select highest version per card
- Maintain backward compatibility and automatic version detection
- Fixes 500 server error, returns 200 success
- 10-line change in list_cards/0 function


https://github.com/user-attachments/assets/7d8fdf25-20db-4554-a645-facce2a222b0

