### PR TITLE
Add copy URL button to player pages

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/player_live/form_component.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/form_component.ex
@@ -13,6 +13,11 @@ defmodule CopiWeb.PlayerLive.FormComponent do
         <%= @title %>
       </.header1>
 
+      <%= if String.starts_with?(@title, "You're joining the game") do %>
+        <p class="mb-4">Share this game link with other players who want to join:</p>
+        <.copy_url_button uri={"#{@socket.endpoint.url()}/games/#{@player.game_id}"} />
+      <% end %>
+
       <.simple_form
         for={@form}
         id="player-form"

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
@@ -1,5 +1,7 @@
 <.header1><%= display_game_session(@game.edition) %> <%= @player.game.name %> </.header1>
 
+<.copy_url_button uri={"#{@socket.endpoint.url()}/games/#{@game.id}"} />
+
 <%= if @player.game.finished_at do %>
 
   <h2>Thanks for playing, <%= @player.name %>! This game finished at <%= @player.game.finished_at %></h2>


### PR DESCRIPTION
Closes - #2540 

Add copy URL button functionality to all player-associated pages for easy game sharing


https://github.com/user-attachments/assets/e0e03116-c6e4-46a5-a07c-2ea0216c07c0

