### PR TITLE
Critical security fix: Prevent self-voting authorization bypass

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -131,26 +131,32 @@ defmodule CopiWeb.PlayerLive.Show do
 
     {:ok, dealt_card} = DealtCard.find(dealt_card_id)
 
-    vote = get_vote(dealt_card, player)
-
-    if vote do
-      Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-      Copi.Repo.delete!(vote)
+    # Critical authorization check: prevent self-voting
+    if dealt_card.player_id == player.id do
+      Logger.warning("Self-voting attempt blocked: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+      {:noreply, socket}
     else
-      Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-      case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
-        {:ok, _vote} ->
-          Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-        {:error, changeset} ->
-          Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+      vote = get_vote(dealt_card, player)
+
+      if vote do
+        Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+        Copi.Repo.delete!(vote)
+      else
+        Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+        case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
+          {:ok, _vote} ->
+            Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+          {:error, changeset} ->
+            Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+        end
       end
+
+      {:ok, updated_game} = Game.find(game.id)
+
+      CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
+
+      {:noreply, assign(socket, :game, updated_game)}
     end
-
-    {:ok, updated_game} = Game.find(game.id)
-
-    CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
-
-    {:noreply, assign(socket, :game, updated_game)}
   end
 
   def topic(game_id) do

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -123,6 +123,33 @@ defmodule CopiWeb.PlayerLiveTest do
       assert Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: dealt.id, player_id: player.id)
     end
 
+    test "prevents self-voting authorization bypass", %{conn: conn, player: player} do
+      game_id = player.game_id
+      
+      # Create a card for the current player
+      {:ok, card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Self Card", edition: "webapp"})
+      {:ok, own_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: player.id, card_id: card.id, played_in_round: 1})
+      
+      {:ok, show_live, _html} = live(conn, "/games/#{game_id}/players/#{player.id}")
+      
+      # Attempt to vote on own card (simulates JavaScript exploit)
+      show_live |> element("[phx-click=\"toggle_vote\"][phx-value-dealt_card_id=\"#{own_dealt_card.id}\"]") |> render_click()
+      
+      # Verify NO vote was created - self-voting blocked
+      refute Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: own_dealt_card.id, player_id: player.id)
+      
+      # Verify normal voting still works - create another player's card
+      {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: game_id})
+      {:ok, other_card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Other Card", edition: "webapp"})
+      {:ok, other_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: other_player.id, card_id: other_card.id, played_in_round: 1})
+      
+      # Vote on other player's card should work
+      show_live |> element("[phx-click=\"toggle_vote\"][phx-value-dealt_card_id=\"#{other_dealt_card.id}\"]") |> render_click()
+      
+      # Verify vote was created for other player's card
+      assert Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: other_dealt_card.id, player_id: player.id)
+    end
+
     test "allows continue voting and resets votes on next round", %{conn: conn, player: player} do
       # Setup another player
       game_id = player.game_id

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -130,6 +130,11 @@ defmodule CopiWeb.PlayerLiveTest do
       {:ok, card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Self Card", edition: "webapp"})
       {:ok, own_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: player.id, card_id: card.id, played_in_round: 1})
       
+      # Setup other player's card BEFORE mounting LiveView to ensure DOM contains vote buttons
+      {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: game_id})
+      {:ok, other_card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Other Card", edition: "webapp"})
+      {:ok, other_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: other_player.id, card_id: other_card.id, played_in_round: 1})
+      
       {:ok, show_live, _html} = live(conn, "/games/#{game_id}/players/#{player.id}")
       
       # Attempt to vote on own card (simulates JavaScript exploit)
@@ -138,12 +143,7 @@ defmodule CopiWeb.PlayerLiveTest do
       # Verify NO vote was created - self-voting blocked
       refute Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: own_dealt_card.id, player_id: player.id)
       
-      # Verify normal voting still works - create another player's card
-      {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: game_id})
-      {:ok, other_card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Other Card", edition: "webapp"})
-      {:ok, other_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: other_player.id, card_id: other_card.id, played_in_round: 1})
-      
-      # Vote on other player's card should work
+      # Vote on other player's card should work (DOM now contains this element)
       show_live |> element("[phx-click=\"toggle_vote\"][phx-value-dealt_card_id=\"#{other_dealt_card.id}\"]") |> render_click()
       
       # Verify vote was created for other player's card

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -127,18 +127,29 @@ defmodule CopiWeb.PlayerLiveTest do
       game_id = player.game_id
       
       # Create a card for the current player
-      {:ok, card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Self Card", edition: "webapp"})
+      {:ok, card} = Cornucopia.create_card(%{
+        category: "C", value: "Self", description: "Self Card", edition: "webapp",
+        version: "2.2", external_id: "SELF", language: "en",
+        misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [], 
+        owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
+      })
       {:ok, own_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: player.id, card_id: card.id, played_in_round: 1})
       
       # Setup other player's card BEFORE mounting LiveView to ensure DOM contains vote buttons
       {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: game_id})
-      {:ok, other_card} = Copi.Repo.insert(%Copi.Cornucopia.Card{word: "Other Card", edition: "webapp"})
+      {:ok, other_card} = Cornucopia.create_card(%{
+        category: "C", value: "Other", description: "Other Card", edition: "webapp",
+        version: "2.2", external_id: "OTHER", language: "en",
+        misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [], 
+        owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
+      })
       {:ok, other_dealt_card} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: other_player.id, card_id: other_card.id, played_in_round: 1})
       
       {:ok, show_live, _html} = live(conn, "/games/#{game_id}/players/#{player.id}")
       
-      # Attempt to vote on own card (simulates JavaScript exploit)
-      show_live |> element("[phx-click=\"toggle_vote\"][phx-value-dealt_card_id=\"#{own_dealt_card.id}\"]") |> render_click()
+      # Attempt to vote on own card (simulates JavaScript exploit by calling event directly)
+      # This should be blocked by the authorization check in handle_event
+      render_hook(show_live, "toggle_vote", %{"dealt_card_id" => "#{own_dealt_card.id}"})
       
       # Verify NO vote was created - self-voting blocked
       refute Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: own_dealt_card.id, player_id: player.id)


### PR DESCRIPTION
Closes - #2561 

This PR addresses a **critical authorization bypass vulnerability** in the voting system that allowed any authenticated player to vote on any dealt card, including their own, by executing JavaScript commands in the browser console.

- before 

https://github.com/user-attachments/assets/6f77c026-0321-43d2-a19c-db171b601ee5

- after

https://github.com/user-attachments/assets/4dce5f2c-e333-42bf-83f2-493a25084649

## Vulnerability Details
- **Root Cause**: Missing ownership validation toggle_vote handler
- **Impact**: Players could boost own scores, compromising game integrity
- **Attack Vector**: JavaScript exploit bypassing UI restrictions

##  Fix Implementation
- **Server-side authorization check** added to prevent self-voting
- **Audit logging** for security monitoring
- **Comprehensive test coverage** for the vulnerability
- **Zero breaking changes** to legitimate functionality