### PR TITLE
fix: handle nil player in play_card API to prevent 500 crash

### DIFF
--- a/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
@@ -1,47 +1,43 @@
 defmodule CopiWeb.ApiController do
   use CopiWeb, :controller
   alias Copi.Cornucopia.Game
-
-
   def play_card(conn, %{"game_id" => game_id, "player_id" => player_id, "dealt_card_id" => dealt_card_id}) do
     with {:ok, game} <- Game.find(game_id) do
-
       player = Enum.find(game.players, fn player -> player.id == player_id end)
-      dealt_card = Enum.find(player.dealt_cards, fn dealt_card -> Integer.to_string(dealt_card.id) == dealt_card_id end)
-
-      if player && dealt_card do
-        current_round = game.rounds_played + 1
-
-        cond do
-          dealt_card.played_in_round ->
-            conn |> put_status(:not_acceptable) |> json(%{"error" => "Card already played"})
-          Enum.find(player.dealt_cards, fn dealt_card -> dealt_card.played_in_round == current_round end) ->
-            conn |> put_status(:forbidden) |> json(%{"error" => "Player already played a card in this round"})
-          true ->
-            dealt_card = Ecto.Changeset.change dealt_card, played_in_round: current_round
-
-            case Copi.Repo.update dealt_card do
-              {:ok, dealt_card} ->
-                with {:ok, updated_game} <- Game.find(game.id) do
-                  CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
-                else
-                  {:error, _reason} ->
-                    conn |> put_status(:internal_server_error) |> json(%{"error" => "Could not find updated game"})
-                end
-
-                conn |> json(%{"id" => dealt_card.id})
-              {:error, _changeset} ->
-                conn |> put_status(:internal_server_error) |> json(%{"error" => "Could not update dealt card"})
-            end
+      if player do
+        dealt_card = Enum.find(player.dealt_cards, fn dealt_card -> Integer.to_string(dealt_card.id) == dealt_card_id end)
+        if dealt_card do
+          current_round = game.rounds_played + 1
+          cond do
+            dealt_card.played_in_round ->
+              conn |> put_status(:not_acceptable) |> json(%{"error" => "Card already played"})
+            Enum.find(player.dealt_cards, fn dealt_card -> dealt_card.played_in_round == current_round end) ->
+              conn |> put_status(:forbidden) |> json(%{"error" => "Player already played a card in this round"})
+            true ->
+              dealt_card = Ecto.Changeset.change dealt_card, played_in_round: current_round
+              case Copi.Repo.update dealt_card do
+                {:ok, dealt_card} ->
+                  with {:ok, updated_game} <- Game.find(game.id) do
+                    CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
+                  else
+                    {:error, _reason} ->
+                      conn |> put_status(:internal_server_error) |> json(%{"error" => "Could not find updated game"})
+                  end
+                  conn |> json(%{"id" => dealt_card.id})
+                {:error, _changeset} ->
+                  conn |> put_status(:internal_server_error) |> json(%{"error" => "Could not update dealt card"})
+              end
+          end
+        else
+          conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
         end
       else
-        conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
+        conn |> put_status(:not_found) |> json(%{"error" => "Player not found in this game"})
       end
     else
       {:error, _reason} -> conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
     end
   end
-
   def topic(game_id) do
     "game:#{game_id}"
   end

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -18,9 +18,6 @@ defmodule CopiWeb.ApiControllerTest do
 
     {:ok, dealt_card} = Repo.insert(%DealtCard{player_id: player.id, card_id: card.id})
 
-    # We need to reload game to ensure preloads work if Game.find relies on them being associated
-    # But usually tests run in transaction. Game.find likely does a fresh query.
-
     %{game: game, player: player, dealt_card: dealt_card}
   end
 
@@ -32,13 +29,12 @@ defmodule CopiWeb.ApiControllerTest do
     })
 
     assert json_response(conn, 200)["id"] == dealt_card.id
-    
+
     updated = Repo.get(DealtCard, dealt_card.id)
     assert updated.played_in_round == 1
   end
 
   test "play_card fails if card already played", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
-    # Play it first
     {:ok, _} = Repo.update(Ecto.Changeset.change(dealt_card, played_in_round: 1))
 
     conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
@@ -51,7 +47,6 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card fails if player already played in round", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
-    # Create another card and mark it as played in this round (0 + 1 => 1)
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
       edition: "webapp", external_id: "2", language: "en", version: "1",
@@ -68,5 +63,15 @@ defmodule CopiWeb.ApiControllerTest do
     })
 
     assert json_response(conn, 403)["error"] == "Player already played a card in this round"
+  end
+
+  test "play_card returns 404 when player_id doesn't belong to game", %{conn: conn, game: game} do
+    conn = put(conn, "/api/games/#{game.id}/players/99999/card", %{
+      "game_id" => game.id,
+      "player_id" => "99999",
+      "dealt_card_id" => "1"
+    })
+
+    assert json_response(conn, 404)["error"] == "Player not found in this game"
   end
 end


### PR DESCRIPTION
Fixes #2562

## Problem
When a valid game_id is provided but the player_id doesn't belong to that game, 
Enum.find returns nil for player. The code then immediately tries to access 
player.dealt_cards on this nil value, causing a 500 Internal Server Error crash.

## Fix
Added a nil check for player before accessing player.dealt_cards. If player is 
not found in the game, the API now returns a proper 404 response instead of crashing.

## Test
Added a test case to api_controller_test.exs that verifies the API returns 404 
when player_id doesn't belong to the game.