### PR TITLE
Fix: Exclude archive directory from YAML file collection

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -567,7 +567,7 @@ def get_files_from_of_type(path: str, ext: str) -> List[str]:
     files = []
     for root, dirnames, filenames in os.walk(path):
         # Exclude archive directory from recursion
-        dirnames[:] = [d for d in dirnames if d != 'archive']
+        dirnames[:] = [d for d in dirnames if d != "archive"]
         for filename in fnmatch.filter(filenames, "*." + str(ext)):
             files.append(os.path.join(root, filename))
     if not files:


### PR DESCRIPTION
Closes - #2587 

- get_files_from_of_type() now excludes archive/ directory from os.walk()
- Reduces processed YAML files from 65 to 43 (excludes 22 archive files)
- Prevents version conflicts and mixed content in generated documents
- Fixes data integrity issue in build process