### PR TITLE
Fix: remove hardcoded version in card route loader and use DeckServic…

### DIFF
--- a/scripts/capec_map_enricher.py
+++ b/scripts/capec_map_enricher.py
@@ -20,9 +20,7 @@ import yaml
 
 class EnricherVars:
     TEMPLATE_FILE_NAME: str = "EDITION-capec-VERSION.yaml"
-    DEFAULT_CAPEC_JSON_PATH = (
-        Path(__file__).parent / "../cornucopia.owasp.org/data/capec-3.9/3000.json"
-    )
+    DEFAULT_CAPEC_JSON_PATH = Path(__file__).parent / "../cornucopia.owasp.org/data/capec-3.9/3000.json"
     DEFAULT_SOURCE_DIR = Path(__file__).parent / "../source"
     args: argparse.Namespace
 
@@ -75,9 +73,7 @@ def extract_capec_names(json_data: dict[str, Any]) -> dict[int, str]:
     return capec_names
 
 
-def enrich_capec_mappings(
-    capec_mappings: dict[str, Any], capec_names: dict[int, str]
-) -> dict[str, Any]:
+def enrich_capec_mappings(capec_mappings: dict[str, Any], capec_names: dict[int, str]) -> dict[str, Any]:
     """
     Enrich CAPEC mappings with names from the CAPEC catalog.
 
@@ -111,9 +107,7 @@ def enrich_capec_mappings(
 
         enriched[capec_id_key] = enriched_entry
 
-    logging.info(
-        "Enriched %d CAPEC mappings", len(enriched) - (1 if "meta" in enriched else 0)
-    )
+    logging.info("Enriched %d CAPEC mappings", len(enriched) - (1 if "meta" in enriched else 0))
     return enriched
 
 
@@ -161,9 +155,7 @@ def save_yaml_file(filepath: Path, data: dict[str, Any]) -> bool:
     """Save data as YAML file."""
     try:
         with open(filepath, "w", encoding="utf-8") as f:
-            yaml.dump(
-                data, f, default_flow_style=False, sort_keys=False, allow_unicode=True
-            )
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
         logging.info("Successfully saved YAML file: %s", filepath)
         return True
     except Exception as e:
@@ -185,9 +177,7 @@ def set_logging() -> None:
 
 def parse_arguments(input_args: list[str]) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Enrich CAPEC mappings with names from CAPEC JSON catalog"
-    )
+    parser = argparse.ArgumentParser(description="Enrich CAPEC mappings with names from CAPEC JSON catalog")
     parser.add_argument(
         "-c",
         "--capec-json",
@@ -259,9 +249,9 @@ def main() -> None:
     if enricher_vars.args.input_path:
         input_path = Path(enricher_vars.args.input_path).resolve()
     else:
-        filename = EnricherVars.TEMPLATE_FILE_NAME.replace(
-            "EDITION", enricher_vars.args.edition
-        ).replace("VERSION", enricher_vars.args.version)
+        filename = EnricherVars.TEMPLATE_FILE_NAME.replace("EDITION", enricher_vars.args.edition).replace(
+            "VERSION", enricher_vars.args.version
+        )
         input_path = directory / filename
 
     # Determine output file path

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -69,9 +69,7 @@ class TranslationChecker:
 
         return file_groups
 
-    def _separate_english_and_translations(
-        self, files: List[Path]
-    ) -> Tuple[Path | None, List[Path]]:
+    def _separate_english_and_translations(self, files: List[Path]) -> Tuple[Path | None, List[Path]]:
         """Separate English reference file from translation files."""
         english_file = None
         translation_files = []
@@ -85,9 +83,7 @@ class TranslationChecker:
 
         return english_file, translation_files
 
-    def _check_translation_tags(
-        self, english_tags: Dict[str, str], trans_tags: Dict[str, str]
-    ) -> Dict[str, Any]:
+    def _check_translation_tags(self, english_tags: Dict[str, str], trans_tags: Dict[str, str]) -> Dict[str, Any]:
         """Check translation tags against English reference."""
         missing = []
         untranslated = []
@@ -126,14 +122,10 @@ class TranslationChecker:
         file_groups = self.get_file_groups()
 
         for base_name, files in file_groups.items():
-            english_file, translation_files = self._separate_english_and_translations(
-                files
-            )
+            english_file, translation_files = self._separate_english_and_translations(files)
 
             if not english_file:
-                print(
-                    f"Warning: No English file found for {base_name}", file=sys.stderr
-                )
+                print(f"Warning: No English file found for {base_name}", file=sys.stderr)
                 continue
 
             english_tags = self.extract_tags(english_file)
@@ -161,9 +153,7 @@ class TranslationChecker:
             return "\n".join(report_lines)
 
         report_lines.append("# Translation Check Report\n")
-        report_lines.append(
-            "The following sentences/tags have issues in the translations:\n"
-        )
+        report_lines.append("The following sentences/tags have issues in the translations:\n")
 
         # Language name mapping
         lang_names = {
@@ -199,9 +189,7 @@ class TranslationChecker:
 
                 if issues["untranslated"]:
                     report_lines.append("### Untranslated Tags\n")
-                    report_lines.append(
-                        "The following tags have identical text to English (not translated):\n"
-                    )
+                    report_lines.append("The following tags have identical text to English (not translated):\n")
                     tags_str = ", ".join(issues["untranslated"])
                     report_lines.append(f"{tags_str}\n")
 
@@ -226,11 +214,31 @@ def main() -> None:
         sys.exit(1)
 
     # Run checker
-    checker = TranslationChecker(source_dir, 
-        excluded_tags=["T02330", "T02530", 
-            "T03130", "T03150", "T03170", "T03190", "T03240", "T03260",
-            "T03350", "T03420", "T03470", "T03490", "T03540", "T03580",
-            "T03710", "T03730", "T03750", "T03770", "T03772", "T03774"])
+    checker = TranslationChecker(
+        source_dir,
+        excluded_tags=[
+            "T02330",
+            "T02530",
+            "T03130",
+            "T03150",
+            "T03170",
+            "T03190",
+            "T03240",
+            "T03260",
+            "T03350",
+            "T03420",
+            "T03470",
+            "T03490",
+            "T03540",
+            "T03580",
+            "T03710",
+            "T03730",
+            "T03750",
+            "T03770",
+            "T03772",
+            "T03774",
+        ],
+    )
     results = checker.check_translations()
 
     # Generate report

--- a/scripts/check_translations_itest.py
+++ b/scripts/check_translations_itest.py
@@ -29,16 +29,12 @@ class TestTranslationTagsIntegration(unittest.TestCase):
 
     def test_source_directory_exists(self) -> None:
         """Test that the source directory exists."""
-        self.assertTrue(
-            self.source_dir.exists(), f"Source directory not found: {self.source_dir}"
-        )
+        self.assertTrue(self.source_dir.exists(), f"Source directory not found: {self.source_dir}")
 
     def test_english_files_exist(self) -> None:
         """Test that English card files exist."""
         english_files = list(self.source_dir.glob("*-cards-*-en.yaml"))
-        self.assertGreater(
-            len(english_files), 0, "No English card files found in source directory"
-        )
+        self.assertGreater(len(english_files), 0, "No English card files found in source directory")
 
     def test_translations_completeness(self) -> None:
         """
@@ -63,9 +59,7 @@ class TestTranslationTagsIntegration(unittest.TestCase):
                     total_issues += len(issues.get("untranslated", []))
                     total_issues += len(issues.get("empty", []))
 
-            self.fail(
-                f"\\n\\nTranslation issues found ({total_issues} total):\\n\\n{report}\\n"
-            )
+            self.fail(f"\\n\\nTranslation issues found ({total_issues} total):\\n\\n{report}\\n")
 
     def test_no_duplicate_tags_in_english(self) -> None:
         """Test that English files don't have duplicate T0xxx tags."""

--- a/scripts/check_translations_utest.py
+++ b/scripts/check_translations_utest.py
@@ -86,9 +86,7 @@ class TestTranslationCheckerUnit(unittest.TestCase):
         tags = self.checker.extract_tags(english_file)
 
         for tag_id in tags.keys():
-            self.assertIsNotNone(
-                tag_pattern.match(tag_id), f"Tag {tag_id} doesn't match format T0xxxx"
-            )
+            self.assertIsNotNone(tag_pattern.match(tag_id), f"Tag {tag_id} doesn't match format T0xxxx")
 
     def test_no_duplicate_tags(self) -> None:
         """Test that files don't have duplicate T0xxx tags."""
@@ -145,9 +143,7 @@ class TestWhitespaceHandling(unittest.TestCase):
 
         result = self.checker._check_translation_tags(english_tags, trans_tags)
 
-        self.assertIn(
-            "T00002", result["empty"], "Tabs and newlines should be detected as empty"
-        )
+        self.assertIn("T00002", result["empty"], "Tabs and newlines should be detected as empty")
 
     def test_extra_spaces_detected_as_untranslated(self) -> None:
         english_tags = {"T00001": "Login", "T00002": "Register"}
@@ -171,9 +167,7 @@ class TestWhitespaceHandling(unittest.TestCase):
         result = self.checker._check_translation_tags(english_tags, trans_tags)
 
         self.assertEqual(len(result["missing"]), 0, "No missing tags expected")
-        self.assertEqual(
-            len(result["untranslated"]), 0, "No untranslated tags expected"
-        )
+        self.assertEqual(len(result["untranslated"]), 0, "No untranslated tags expected")
         self.assertEqual(len(result["empty"]), 0, "No empty tags expected")
 
 
@@ -238,12 +232,8 @@ class TestCompoundLocales(unittest.TestCase):
             "Norwegian (no_nb) results should be present",
         )
         no_nb_issues = results["test-cards-1.0"]["no_nb"]
-        self.assertIn(
-            "T00004", no_nb_issues["missing"], "T00004 should be missing in no_nb"
-        )
-        self.assertIn(
-            "T00003", no_nb_issues["empty"], "T00003 should be empty in no_nb"
-        )
+        self.assertIn("T00004", no_nb_issues["missing"], "T00004 should be missing in no_nb")
+        self.assertIn("T00003", no_nb_issues["empty"], "T00003 should be empty in no_nb")
 
     def test_portuguese_brazil_untranslated_detected(self) -> None:
         """Test that untranslated tags in Portuguese Brazil (pt_br) are detected."""
@@ -267,18 +257,14 @@ class TestCompoundLocales(unittest.TestCase):
         results = self.checker.check_translations()
 
         pt_pt_issues = results.get("test-cards-1.0", {}).get("pt_pt", None)
-        self.assertIsNone(
-            pt_pt_issues, "pt_pt has no issues and should not appear in results"
-        )
+        self.assertIsNone(pt_pt_issues, "pt_pt has no issues and should not appear in results")
 
     def test_lang_names_in_report(self) -> None:
         """Test that generate_markdown_report resolves compound locale display names correctly."""
         self.checker.check_translations()
         report = self.checker.generate_markdown_report()
 
-        self.assertIn(
-            "Norwegian", report, "Norwegian display name should appear for no_nb"
-        )
+        self.assertIn("Norwegian", report, "Norwegian display name should appear for no_nb")
         self.assertIn(
             "Portuguese (Brazil)",
             report,
@@ -309,9 +295,7 @@ class TestCoverageBranches(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             # Place a YAML file whose name contains "archive" directly in source dir
-            (tmp_path / "webapp-archive-cards-1.0-en.yaml").write_text(
-                "---\nparagraphs: []"
-            )
+            (tmp_path / "webapp-archive-cards-1.0-en.yaml").write_text("---\nparagraphs: []")
             (tmp_path / "test-cards-1.0-en.yaml").write_text("---\nparagraphs: []")
             checker = TranslationChecker(tmp_path)
             file_groups = checker.get_file_groups()
@@ -350,9 +334,7 @@ class TestCoverageBranches(unittest.TestCase):
             (tmp_path / "test-cards-1.0-es.yaml").write_text("---\nparagraphs: []")
             checker = TranslationChecker(tmp_path)
             results = checker.check_translations()
-            self.assertEqual(
-                results, {}, "Should produce no results when English has no tags"
-            )
+            self.assertEqual(results, {}, "Should produce no results when English has no tags")
 
     def test_main_exits_when_source_dir_missing(self) -> None:
         """Test that main() exits with code 1 when source directory does not exist."""
@@ -373,13 +355,9 @@ class TestCoverageBranches(unittest.TestCase):
         mock_checker.check_translations.return_value = {}
         mock_checker.generate_markdown_report.return_value = "# Report\n\u2705 Done"
 
-        with patch.object(
-            check_translations, "TranslationChecker", return_value=mock_checker
-        ), patch("builtins.open", mock_open()), patch(
-            "builtins.print"
-        ), self.assertRaises(
-            SystemExit
-        ) as cm:
+        with patch.object(check_translations, "TranslationChecker", return_value=mock_checker), patch(
+            "builtins.open", mock_open()
+        ), patch("builtins.print"), self.assertRaises(SystemExit) as cm:
             check_translations.main()
         self.assertEqual(cm.exception.code, 0)
 

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -53,9 +53,7 @@ class ConvertVars:
             "owasp_cornucopia_edition_ver_layout_document_template_lang",
         ]
     )
-    DEFAULT_OUTPUT_FILENAME: str = os.sep.join(
-        ["output", "owasp_cornucopia_edition_ver_layout_document_template_lang"]
-    )
+    DEFAULT_OUTPUT_FILENAME: str = os.sep.join(["output", "owasp_cornucopia_edition_ver_layout_document_template_lang"])
     args: argparse.Namespace
     can_convert_to_pdf: bool = False
 
@@ -82,9 +80,7 @@ def check_make_list_into_text(var: List[str]) -> str:
     return text_output
 
 
-def _validate_file_paths(
-    source_filename: str, output_pdf_filename: str
-) -> Tuple[bool, str, str]:
+def _validate_file_paths(source_filename: str, output_pdf_filename: str) -> Tuple[bool, str, str]:
     """Validate and sanitize file paths to prevent command injection."""
     source_path = os.path.abspath(source_filename)
     output_dir = os.path.abspath(os.path.dirname(output_pdf_filename))
@@ -126,9 +122,7 @@ def _safe_extractall(archive: zipfile.ZipFile, target_dir: str) -> None:
         # Block any member whose resolved path escapes the target directory.
         # The os.sep suffix prevents prefix collisions (e.g. /tmp/d vs /tmp/d_evil).
         if not member_path.startswith(abs_target + os.sep):
-            raise ValueError(
-                f"Zip Slip blocked: member '{member.filename}' would extract outside target directory"
-            )
+            raise ValueError(f"Zip Slip blocked: member '{member.filename}' would extract outside target directory")
 
         archive.extract(member, target_dir)
 
@@ -174,17 +168,13 @@ def _convert_with_libreoffice(source_filename: str, output_pdf_filename: str) ->
         logging.info(f"Using LibreOffice for conversion: {libreoffice_bin}")
 
         # Validate file paths
-        is_valid, source_path, output_dir = _validate_file_paths(
-            source_filename, output_pdf_filename
-        )
+        is_valid, source_path, output_dir = _validate_file_paths(source_filename, output_pdf_filename)
         if not is_valid:
             logging.warning(source_path)  # source_path contains the error message
             return False
 
         # Create user profile directory safely
-        user_profile_dir = os.path.abspath(
-            os.path.join(convert_vars.BASE_PATH, "output", "lo_profile")
-        )
+        user_profile_dir = os.path.abspath(os.path.join(convert_vars.BASE_PATH, "output", "lo_profile"))
         os.makedirs(user_profile_dir, exist_ok=True)
         user_profile_url = "file:///" + user_profile_dir.replace("\\", "/")
 
@@ -301,15 +291,11 @@ def create_edition_from_template(
 ) -> None:
 
     # Get the list of available translation files
-    yaml_files = get_files_from_of_type(
-        os.sep.join([convert_vars.BASE_PATH, "source"]), "yaml"
-    )
+    yaml_files = get_files_from_of_type(os.sep.join([convert_vars.BASE_PATH, "source"]), "yaml")
     if not yaml_files:
         return
 
-    mapping: Dict[str, Any] = get_mapping_for_edition(
-        yaml_files, version, language, edition, template, layout
-    )
+    mapping: Dict[str, Any] = get_mapping_for_edition(yaml_files, version, language, edition, template, layout)
 
     if not mapping:
         logging.warning(
@@ -319,9 +305,7 @@ def create_edition_from_template(
         # return
 
     # Get the language data from the correct language file (checks vars.args.language to select the correct file)
-    language_data: Dict[str, Dict[str, str]] = get_language_data(
-        yaml_files, language, version, edition
-    )
+    language_data: Dict[str, Dict[str, str]] = get_language_data(yaml_files, language, version, edition)
 
     # Transform the language data into the template mapping
     language_dict: Dict[str, str] = map_language_data_to_template(language_data)
@@ -441,9 +425,7 @@ def main() -> None:
             for language in get_valid_language_choices():
                 for template in get_valid_templates():
                     for version in get_valid_version_choices():
-                        create_edition_from_template(
-                            layout, language, template, version, edition
-                        )
+                        create_edition_from_template(layout, language, template, version, edition)
 
 
 def parse_arguments(input_args: List[str]) -> argparse.Namespace:
@@ -650,9 +632,7 @@ def get_files_from_of_type(path: str, ext: str) -> List[str]:
     return files
 
 
-def get_find_replace_list(
-    meta: Dict[str, str], template: str, layout: str
-) -> List[Tuple[str, str]]:
+def get_find_replace_list(meta: Dict[str, str], template: str, layout: str) -> List[Tuple[str, str]]:
     ll: List[Tuple[str, str]] = [
         ("_edition", "_" + meta["edition"].lower()),
         ("_layout", "_" + layout.lower()),
@@ -679,15 +659,11 @@ def get_mapping_for_edition(
     template: str,
     layout: str,
 ) -> Dict[str, Any]:
-    mapping_data: Dict[str, Any] = get_mapping_data_for_edition(
-        yaml_files, language, version, edition
-    )
+    mapping_data: Dict[str, Any] = get_mapping_data_for_edition(yaml_files, language, version, edition)
     if not mapping_data:
         logging.warning("No mapping file found")
         return {}
-    if "meta" not in mapping_data or not valid_meta(
-        mapping_data["meta"], language, edition, version, template, layout
-    ):
+    if "meta" not in mapping_data or not valid_meta(mapping_data["meta"], language, edition, version, template, layout):
         logging.warning("Metadata is missing or invalid in mapping file")
         return {}
     try:
@@ -723,22 +699,13 @@ def get_mapping_data_for_edition(
         except yaml.YAMLError as e:
             logging.info(f"Error loading yaml file: {mappingfile}. Error = {e}")
             data = {}
-    if (
-        "meta" in data.keys()
-        and "component" in data["meta"].keys()
-        and data["meta"]["component"] == "mappings"
-    ):
+    if "meta" in data.keys() and "component" in data["meta"].keys() and data["meta"]["component"] == "mappings":
         logging.debug(" --- found mappings file: " + os.path.split(mappingfile)[1])
     else:
-        logging.debug(
-            " --- found source file, but it was missing metadata: "
-            + os.path.split(mappingfile)[1]
-        )
+        logging.debug(" --- found source file, but it was missing metadata: " + os.path.split(mappingfile)[1])
         if "meta" in list(data.keys()):
             meta_keys = data["meta"].keys()
-            logging.debug(
-                f" --- data.keys() = {data.keys()}, data[meta].keys() = {meta_keys}"
-            )
+            logging.debug(f" --- data.keys() = {data.keys()}, data[meta].keys() = {meta_keys}")
         data = {}
     logging.debug(f" --- Len = {len(data)}.")
     return data
@@ -756,12 +723,8 @@ def build_template_dict(input_data: Dict[str, Any]) -> Dict[str, Any]:
                 text_type = "sentences"
             logging.debug(f" --- key = {key}.")
             logging.debug(f" --- suit name = {paragraphs['name']}")
-            logging.debug(
-                f" --- suit id = {is_valid_string_argument(paragraphs['id'])}"
-            )
-            full_tag = "${{{}}}".format(
-                "_".join([is_valid_string_argument(paragraphs["id"]), "suit"])
-            )
+            logging.debug(f" --- suit id = {is_valid_string_argument(paragraphs['id'])}")
+            full_tag = "${{{}}}".format("_".join([is_valid_string_argument(paragraphs["id"]), "suit"]))
             logging.debug(f" --- suit tag = {full_tag}")
             if data["meta"]["component"] == "cards":
                 data[full_tag] = paragraphs["name"]
@@ -834,14 +797,10 @@ def get_language_data(
     """Get the raw data of the replacement text from correct yaml file"""
     language_file: str = ""
     for file in yaml_files:
-        if is_yaml_file(file) and is_lang_file_for_version(
-            file, version, language, edition
-        ):
+        if is_yaml_file(file) and is_lang_file_for_version(file, version, language, edition):
             language_file = file
     if not language_file:
-        logging.error(
-            f"Did not find translation for version: {version}, lang: {language}, edition: {edition}"
-        )
+        logging.error(f"Did not find translation for version: {version}, lang: {language}, edition: {edition}")
         return {}
 
     logging.debug(f" --- Loading language file: {language_file}")
@@ -892,21 +851,15 @@ def map_language_data_to_template(input_data: Dict[str, Any]) -> Dict[str, str]:
     try:
         data = build_template_dict(input_data)
     except Exception as e:
-        logging.warning(
-            f"Could not build valid template mapping. The Yaml file is not valid. Got exception: {e}"
-        )
+        logging.warning(f"Could not build valid template mapping. The Yaml file is not valid. Got exception: {e}")
         data = input_data
 
     if convert_vars.args.debug:
         debug_txt = " --- Translation data showing First 4 (key: text):\n* "
-        debug_txt += "\n* ".join(
-            l1 + ": " + str(data[l1]) for l1 in list(data.keys())[:4]
-        )
+        debug_txt += "\n* ".join(l1 + ": " + str(data[l1]) for l1 in list(data.keys())[:4])
         logging.debug(debug_txt)
         debug_txt = " --- Translation data showing Last 4 (key: text):\n* "
-        debug_txt += "\n* ".join(
-            l1 + ": " + str(data[l1]) for l1 in list(data.keys())[-4:]
-        )
+        debug_txt += "\n* ".join(l1 + ": " + str(data[l1]) for l1 in list(data.keys())[-4:])
         logging.debug(debug_txt)
     return data
 
@@ -925,9 +878,7 @@ def get_replacement_mapping_value(k: str, v: str, el_text: str) -> str:
     return ""
 
 
-def get_replacement_value_from_dict(
-    el_text: str, replacement_values: List[Tuple[str, str]]
-) -> str:
+def get_replacement_value_from_dict(el_text: str, replacement_values: List[Tuple[str, str]]) -> str:
     # Fast path: if no $ and no OWASP, likely no tags
     if "$" not in el_text and "OWASP" not in el_text:
         return el_text
@@ -961,9 +912,7 @@ def get_suit_tags_and_key(key: str, edition: str) -> Tuple[List[str], str]:
     return suit_tags, suit_key
 
 
-def get_template_for_edition(
-    layout: str = "guide", template: str = "bridge", edition: str = "webapp"
-) -> str:
+def get_template_for_edition(layout: str = "guide", template: str = "bridge", edition: str = "webapp") -> str:
     template_doc: str
     args_input_file: str = convert_vars.args.inputfile
     sfile_ext = "idml"
@@ -974,38 +923,22 @@ def get_template_for_edition(
         if os.path.isabs(args_input_file):
             template_doc = args_input_file
         elif os.path.isfile(convert_vars.BASE_PATH + os.sep + args_input_file):
+            template_doc = os.path.normpath(convert_vars.BASE_PATH + os.sep + args_input_file)
+        elif os.path.isfile(convert_vars.BASE_PATH + os.sep + args_input_file.replace(".." + os.sep, "")):
             template_doc = os.path.normpath(
-                convert_vars.BASE_PATH + os.sep + args_input_file
-            )
-        elif os.path.isfile(
-            convert_vars.BASE_PATH + os.sep + args_input_file.replace(".." + os.sep, "")
-        ):
-            template_doc = os.path.normpath(
-                convert_vars.BASE_PATH
-                + os.sep
-                + args_input_file.replace(".." + os.sep, "")
+                convert_vars.BASE_PATH + os.sep + args_input_file.replace(".." + os.sep, "")
             )
         elif args_input_file.find("..") == -1 and os.path.isfile(
             convert_vars.BASE_PATH + os.sep + ".." + os.sep + args_input_file
         ):
+            template_doc = os.path.normpath(convert_vars.BASE_PATH + os.sep + ".." + os.sep + args_input_file)
+        elif os.path.isfile(convert_vars.BASE_PATH + os.sep + args_input_file.replace("scripts" + os.sep, "")):
             template_doc = os.path.normpath(
-                convert_vars.BASE_PATH + os.sep + ".." + os.sep + args_input_file
-            )
-        elif os.path.isfile(
-            convert_vars.BASE_PATH
-            + os.sep
-            + args_input_file.replace("scripts" + os.sep, "")
-        ):
-            template_doc = os.path.normpath(
-                convert_vars.BASE_PATH
-                + os.sep
-                + args_input_file.replace("scripts" + os.sep, "")
+                convert_vars.BASE_PATH + os.sep + args_input_file.replace("scripts" + os.sep, "")
             )
         else:
             template_doc = args_input_file
-            logging.debug(
-                f" --- Template_doc NOT found. Input File = {args_input_file}"
-            )
+            logging.debug(f" --- Template_doc NOT found. Input File = {args_input_file}")
     else:
         # No input file specified - using defaults
         template_doc = os.path.normpath(
@@ -1025,9 +958,7 @@ def get_template_for_edition(
         logging.debug(f" --- Returning template_doc = {template_doc}")
         return template_doc
     else:
-        logging.error(
-            f"Source file not found: {template_doc}. Please ensure file exists and try again."
-        )
+        logging.error(f"Source file not found: {template_doc}. Please ensure file exists and try again.")
         return "None"
 
 
@@ -1062,10 +993,7 @@ def get_valid_version_choices() -> List[str]:
     edition: str = convert_vars.args.edition.lower()
     if convert_vars.args.version.lower() == "all":
         for version in convert_vars.VERSION_CHOICES:
-            if (
-                version not in ("all", "latest")
-                and not get_valid_mapping_for_version(version, edition) == ""
-            ):
+            if version not in ("all", "latest") and not get_valid_mapping_for_version(version, edition) == "":
                 versions.append(version)
     elif convert_vars.args.version == "" or convert_vars.args.version == "latest":
         for version in convert_vars.LATEST_VERSION_CHOICES:
@@ -1075,9 +1003,7 @@ def get_valid_version_choices() -> List[str]:
         versions.append(convert_vars.args.version)
 
     if not versions:
-        logging.debug(
-            f"No deck with version: {convert_vars.args.version} for edition: {edition} exists"
-        )
+        logging.debug(f"No deck with version: {convert_vars.args.version} for edition: {edition} exists")
     return versions
 
 
@@ -1100,10 +1026,7 @@ def get_valid_templates() -> List[str]:
 
 def get_valid_edition_choices() -> List[str]:
     editions = []
-    if (
-        convert_vars.args.edition.lower() == "all"
-        or not convert_vars.args.edition.lower()
-    ):
+    if convert_vars.args.edition.lower() == "all" or not convert_vars.args.edition.lower():
         for edition in convert_vars.EDITION_CHOICES:
             if edition not in "all":
                 editions.append(edition)
@@ -1132,17 +1055,13 @@ def save_docx_file(doc: Any, output_file: str) -> None:
     doc.save(output_file)
 
 
-def save_odt_file(
-    template_doc: str, language_dict: Dict[str, str], output_file: str
-) -> None:
+def save_odt_file(template_doc: str, language_dict: Dict[str, str], output_file: str) -> None:
     # Get the output path and temp output path to put the temp xml files
     output_path = os.path.join(convert_vars.BASE_PATH, "output")
     temp_output_path = os.path.join(output_path, "temp_odt")
     # Ensure the output folder and temp output folder exist
     ensure_folder_exists(temp_output_path)
-    logging.debug(
-        " --- temp_folder for extraction of xml files = %s", str(temp_output_path)
-    )
+    logging.debug(" --- temp_folder for extraction of xml files = %s", str(temp_output_path))
 
     # Unzip source xml files and place in temp output folder
     with zipfile.ZipFile(template_doc) as odt_archive:
@@ -1158,9 +1077,7 @@ def save_odt_file(
             replace_text_in_xml_file(xml_file, replacement_values)
 
     # Zip the files as an odt file in output folder
-    logging.debug(
-        " --- finished replacing text in xml files. Now zipping into odt file"
-    )
+    logging.debug(" --- finished replacing text in xml files. Now zipping into odt file")
     zip_dir(temp_output_path, output_file)
 
     # If not debugging, delete temp folder and files
@@ -1168,17 +1085,13 @@ def save_odt_file(
         shutil.rmtree(temp_output_path, ignore_errors=True)
 
 
-def save_idml_file(
-    template_doc: str, language_dict: Dict[str, str], output_file: str
-) -> None:
+def save_idml_file(template_doc: str, language_dict: Dict[str, str], output_file: str) -> None:
     # Get the output path and temp output path to put the temp xml files
     output_path = convert_vars.BASE_PATH + os.sep + "output"
     temp_output_path = output_path + os.sep + "temp"
     # Ensure the output folder and temp output folder exist
     ensure_folder_exists(temp_output_path)
-    logging.debug(
-        " --- temp_folder for extraction of xml files = %s", str(temp_output_path)
-    )
+    logging.debug(" --- temp_folder for extraction of xml files = %s", str(temp_output_path))
 
     # Unzip source xml files and place in temp output folder
     with zipfile.ZipFile(template_doc) as idml_archive:
@@ -1197,9 +1110,7 @@ def save_idml_file(
         replace_text_in_xml_file(file, replacement_values)
 
     # Zip the files as an idml file in output folder
-    logging.debug(
-        " --- finished replacing text in xml files. Now zipping into idml file"
-    )
+    logging.debug(" --- finished replacing text in xml files. Now zipping into idml file")
     zip_dir(temp_output_path, output_file)
 
     # If not debugging, delete temp folder and files
@@ -1209,13 +1120,9 @@ def save_idml_file(
 
 def set_can_convert_to_pdf() -> bool:
     operating_system: str = sys.platform.lower()
-    can_convert = (
-        operating_system.find("win") != -1 or operating_system.find("darwin") != -1
-    )
+    can_convert = operating_system.find("win") != -1 or operating_system.find("darwin") != -1
     convert_vars.can_convert_to_pdf = can_convert
-    logging.debug(
-        f" --- operating system = {operating_system}, can_convert_to_pdf = {convert_vars.can_convert_to_pdf}"
-    )
+    logging.debug(f" --- operating system = {operating_system}, can_convert_to_pdf = {convert_vars.can_convert_to_pdf}")
     return can_convert
 
 
@@ -1236,9 +1143,7 @@ def sort_keys_longest_to_shortest(
     return sorted(new_list, key=lambda s: len(s[0]), reverse=True)
 
 
-def remove_short_keys(
-    replacement_dict: Dict[str, str], min_length: int = 8
-) -> Dict[str, str]:
+def remove_short_keys(replacement_dict: Dict[str, str], min_length: int = 8) -> Dict[str, str]:
     data2: Dict[str, str] = {}
     for key, value in replacement_dict.items():
         if len(key) >= min_length:
@@ -1250,9 +1155,7 @@ def remove_short_keys(
     return data2
 
 
-def rename_output_file(
-    file_extension: str, template: str, layout: str, meta: Dict[str, str]
-) -> str:
+def rename_output_file(file_extension: str, template: str, layout: str, meta: Dict[str, str]) -> str:
     """Rename output file replacing place-holders from meta dict (edition, component, language, version)."""
     args_output_file: str = convert_vars.args.outputfile
     logging.debug(f" --- args_output_file = {args_output_file}")
@@ -1261,19 +1164,12 @@ def rename_output_file(
         if os.path.isabs(args_output_file):
             output_filename = args_output_file
         else:
-            output_filename = str(
-                Path(convert_vars.BASE_PATH + os.sep + args_output_file)
-            )
+            output_filename = str(Path(convert_vars.BASE_PATH + os.sep + args_output_file))
     else:
 
         # No output file specified - using default
         output_filename = str(
-            Path(
-                convert_vars.BASE_PATH
-                + os.sep
-                + convert_vars.DEFAULT_OUTPUT_FILENAME
-                + file_extension
-            )
+            Path(convert_vars.BASE_PATH + os.sep + convert_vars.DEFAULT_OUTPUT_FILENAME + file_extension)
         )
 
     logging.debug(f" --- output_filename before fix extension = {output_filename}")
@@ -1333,9 +1229,7 @@ def _find_xml_elements(tree: Any) -> List[ElTree.Element]:
     return cast(List[ElTree.Element], elements)
 
 
-def replace_text_in_xml_file(
-    filename: str, replacement_values: List[Tuple[str, str]]
-) -> None:
+def replace_text_in_xml_file(filename: str, replacement_values: List[Tuple[str, str]]) -> None:
     logging.debug(f" --- starting xml_replace for {filename}")
     try:
         tree = DefusedElTree.parse(filename)

--- a/scripts/convert_asvs.py
+++ b/scripts/convert_asvs.py
@@ -15,16 +15,12 @@ from typing import Any, List, TextIO
 
 
 class ConvertVars:
-    DEFAULT_OUTPUT_PATH = Path(
-        Path(__file__).parent / "../cornucopia.owasp.org/data/taxonomy/en/ASVS-5.0"
-    )
+    DEFAULT_OUTPUT_PATH = Path(Path(__file__).parent / "../cornucopia.owasp.org/data/taxonomy/en/ASVS-5.0")
     DEFAULT_INPUT_PATH = (
         Path(__file__).parent / "../cornucopia.owasp.org/data/asvs-5.0/en/"
         "OWASP_Application_Security_Verification_Standard_5.0.0_en.json"
     )
-    DEFAULT_ASVS_TO_CAPEC_INPUT_PATH = (
-        Path(__file__).parent / "../source/webapp-asvs-3.0.yaml"
-    )
+    DEFAULT_ASVS_TO_CAPEC_INPUT_PATH = Path(__file__).parent / "../source/webapp-asvs-3.0.yaml"
     LATEST_CAPEC_VERSION_CHOICES: List[str] = ["3.9"]
     LATEST_ASVS_VERSION_CHOICES: List[str] = ["5.0"]
     args: argparse.Namespace
@@ -48,21 +44,14 @@ def create_level_summary(level: int, arr: List[dict[str, Any]]) -> None:
         if link["cat"] != category:
             category = link["cat"]
             f.write(f"### {category}\n\n")
-        shortdesc = (
-            link["description"].replace("Verify that", "").strip().capitalize()[0:50]
-            + " ..."
-        )
+        shortdesc = link["description"].replace("Verify that", "").strip().capitalize()[0:50] + " ..."
         f.write(f"- [{link['name']}]({link['link']}) *{shortdesc}* \n\n")
     f.close()
 
 
 def _format_directory_name(ordinal: int, name: str) -> str:
     """Format ordinal and name into directory-safe string."""
-    return (
-        str(ordinal).rjust(2, "0")
-        + "-"
-        + name.lower().replace(" ", "-").replace(",", "")
-    )
+    return str(ordinal).rjust(2, "0") + "-" + name.lower().replace(" ", "-").replace(",", "")
 
 
 def _get_level_requirement_text(level: int) -> str:
@@ -134,10 +123,7 @@ def _write_subitem_content(
 ) -> None:
     """Write a single subitem's content to the file."""
     file_handle.write("## " + subitem["Shortcode"] + "\n\n")
-    file_handle.write(
-        subitem["Description"].encode("ascii", "ignore").decode("utf8", "ignore")
-        + "\n\n"
-    )
+    file_handle.write(subitem["Description"].encode("ascii", "ignore").decode("utf8", "ignore") + "\n\n")
 
     level = int(subitem["L"])
     level_text = _get_level_requirement_text(level)
@@ -149,9 +135,7 @@ def _write_subitem_content(
         logging.info("ASVS ID %s has no CAPEC mapping", asvs_id)
     else:
         file_handle.write("### Related CAPEC™ Requirements\n\n")
-        file_handle.write(
-            f"CAPEC™ ({capec_version}): {create_link_list(asvs_map.get(asvs_id, {}), capec_version)}\n\n"
-        )
+        file_handle.write(f"CAPEC™ ({capec_version}): {create_link_list(asvs_map.get(asvs_id, {}), capec_version)}\n\n")
 
     logging.debug("object: %s", subitem)
     logging.debug("🟪")
@@ -180,9 +164,7 @@ def _process_requirement_item(
 
         for subitem in item["Items"]:
             _write_subitem_content(f, subitem, asvs_map, capec_version)
-            _categorize_by_level(
-                subitem, requirement_name, item_name, L1, L2, L3, asvs_version
-            )
+            _categorize_by_level(subitem, requirement_name, item_name, L1, L2, L3, asvs_version)
 
         _write_disclaimer(f)
 
@@ -199,9 +181,7 @@ def create_asvs_pages(
     L3: List[dict[str, Any]] = []
 
     for requirement in data["Requirements"]:
-        requirement_name = _format_directory_name(
-            requirement["Ordinal"], requirement["Name"]
-        )
+        requirement_name = _format_directory_name(requirement["Ordinal"], requirement["Name"])
         logging.debug(requirement_name)
         os.mkdir(Path(convert_vars.args.output_path, requirement_name))
 
@@ -222,21 +202,17 @@ def create_asvs_pages(
     create_level_summary(3, L3)
 
 
-def has_no_capec_mapping(
-    asvs_id: str, capec_to_asvs_map: dict[str, dict[str, List[str]]]
-) -> bool:
-    return not capec_to_asvs_map.get(asvs_id) or not capec_to_asvs_map.get(
-        asvs_id, {"capec_codes": []}
-    ).get("capec_codes")
+def has_no_capec_mapping(asvs_id: str, capec_to_asvs_map: dict[str, dict[str, List[str]]]) -> bool:
+    return not capec_to_asvs_map.get(asvs_id) or not capec_to_asvs_map.get(asvs_id, {"capec_codes": []}).get(
+        "capec_codes"
+    )
 
 
 def create_link_list(requirements: dict[str, Any], capec_version: str) -> str:
     link_list = ""
     asvs_requirements = requirements.get("capec_codes", [])
     if not asvs_requirements:
-        logging.debug(
-            "No CAPEC requirements found in requirements: %s", str(requirements)
-        )
+        logging.debug("No CAPEC requirements found in requirements: %s", str(requirements))
         return ""
     sorted_requirements = sorted(asvs_requirements)
     for idx, capec_code in enumerate(sorted_requirements):
@@ -248,9 +224,7 @@ def create_link_list(requirements: dict[str, Any], capec_version: str) -> str:
 
 
 def parse_arguments(input_args: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Convert CAPEC™ JSON to Cornucopia format"
-    )
+    parser = argparse.ArgumentParser(description="Convert CAPEC™ JSON to Cornucopia format")
     parser.add_argument(
         "-o",
         "--output-path",
@@ -372,9 +346,7 @@ def main() -> None:
     empty_folder(Path(convert_vars.args.output_path))
     create_folder(Path(convert_vars.args.output_path))
     data = load_json_file(Path(convert_vars.args.input_path))
-    asvs_map: dict[str, dict[str, List[str]]] = load_asvs_to_capec_mapping(
-        Path(convert_vars.args.asvs_to_capec)
-    )
+    asvs_map: dict[str, dict[str, List[str]]] = load_asvs_to_capec_mapping(Path(convert_vars.args.asvs_to_capec))
 
     create_asvs_pages(data, asvs_map, capec_version, asvs_version)
     logging.info("ASVS conversion process completed")

--- a/scripts/convert_capec.py
+++ b/scripts/convert_capec.py
@@ -15,15 +15,9 @@ from pathvalidate.argparse import validate_filepath_arg
 
 
 class ConvertVars:
-    DEFAULT_OUTPUT_PATH = (
-        Path(__file__).parent / "../cornucopia.owasp.org/data/taxonomy/en/capec-3.9"
-    )
-    DEFAULT_INPUT_PATH = (
-        Path(__file__).parent / "../cornucopia.owasp.org/data/capec-3.9/3000.json"
-    )
-    DEFAULT_CAPEC_TO_ASVS_INPUT_PATH = (
-        Path(__file__).parent / "../source/webapp-capec-3.0.yaml"
-    )
+    DEFAULT_OUTPUT_PATH = Path(__file__).parent / "../cornucopia.owasp.org/data/taxonomy/en/capec-3.9"
+    DEFAULT_INPUT_PATH = Path(__file__).parent / "../cornucopia.owasp.org/data/capec-3.9/3000.json"
+    DEFAULT_CAPEC_TO_ASVS_INPUT_PATH = Path(__file__).parent / "../source/webapp-capec-3.0.yaml"
     DEFAULT_ASVS_MAPPING_PATH = (
         Path(__file__).parent / "../cornucopia.owasp.org/data/asvs-5.0/en/"
         "OWASP_Application_Security_Verification_Standard_5.0.0_en.json"
@@ -51,9 +45,7 @@ def create_capec_pages(
         f.write("## Description\n\n")
         f.write(f"{parse_description(i.get('Description', ''))}\n\n")
         capec_id = int(i["_ID"])
-        f.write(
-            f"Source: [CAPEC™ {capec_id}](https://capec.mitre.org/data/definitions/{capec_id}.html)\n\n"
-        )
+        f.write(f"Source: [CAPEC™ {capec_id}](https://capec.mitre.org/data/definitions/{capec_id}.html)\n\n")
         if has_no_asvs_mapping(capec_id, capec_to_asvs_map):
             logging.debug("CAPEC ID %d has no ASVS mapping", capec_id)
         else:
@@ -75,9 +67,7 @@ def create_capec_pages(
         f.write("## Description\n\n")
         f.write(f"{parse_description(i.get('Summary', ''))}\n\n")
         capec_id = int(i["_ID"])
-        f.write(
-            f"Source: [CAPEC™ {capec_id}](https://capec.mitre.org/data/definitions/{capec_id}.html)\n\n"
-        )
+        f.write(f"Source: [CAPEC™ {capec_id}](https://capec.mitre.org/data/definitions/{capec_id}.html)\n\n")
         if has_no_asvs_mapping(capec_id, capec_to_asvs_map):
             logging.debug("CAPEC ID %d has no ASVS mapping", capec_id)
         else:
@@ -90,47 +80,31 @@ def create_capec_pages(
     logging.info("Created %d CAPEC pages", pages)
 
 
-def has_no_asvs_mapping(
-    capec_id: int, capec_to_asvs_map: dict[int, dict[str, List[str]]]
-) -> bool:
-    return not capec_to_asvs_map.get(capec_id) or not capec_to_asvs_map.get(
-        capec_id, {"owasp_asvs": []}
-    ).get("owasp_asvs")
+def has_no_asvs_mapping(capec_id: int, capec_to_asvs_map: dict[int, dict[str, List[str]]]) -> bool:
+    return not capec_to_asvs_map.get(capec_id) or not capec_to_asvs_map.get(capec_id, {"owasp_asvs": []}).get(
+        "owasp_asvs"
+    )
 
 
 def parse_description(description_field: Any) -> str:
     """Parse CAPEC description field which can be dict, list, or string."""
     if isinstance(description_field, dict):
-        if (
-            "Description" in description_field
-            and "p" in description_field["Description"]
-        ):
+        if "Description" in description_field and "p" in description_field["Description"]:
             p_content = description_field["Description"]["p"]
             if isinstance(p_content, dict) and "__text" in p_content:
                 return str(p_content["__text"])
             elif isinstance(p_content, list):
                 return " ".join(
-                    [
-                        (
-                            str(p["__text"])
-                            if isinstance(p, dict) and "__text" in p
-                            else str(p)
-                        )
-                        for p in p_content
-                    ]
+                    [(str(p["__text"]) if isinstance(p, dict) and "__text" in p else str(p)) for p in p_content]
                 )
     return str(description_field)
 
 
-def create_link_list(
-    requirements: dict[str, Any], asvs_map: dict[str, Any], asvs_version: str
-) -> str:
+def create_link_list(requirements: dict[str, Any], asvs_map: dict[str, Any], asvs_version: str) -> str:
     link_list = ""
     asvs_requirements = requirements.get("owasp_asvs", [])
     if not asvs_requirements:
-        logging.debug(
-            "No ASVS requirements found in requirements: %s", str(requirements)
-        )
+        logging.debug("No ASVS requirements found in requirements: %s", str(requirements))
         return ""
     sorted_requirements = sorted(asvs_requirements)
     for idx, shortcode in enumerate(sorted_requirements):
@@ -143,22 +117,14 @@ def create_link_list(
 
 def createlink(data: dict[str, Any], shortcode: str, asvs_version: str) -> str:
     for i in data["Requirements"]:
-        name = (
-            str(i["Ordinal"]).rjust(2, "0")
-            + "-"
-            + i["Name"].lower().replace(" ", "-").replace(",", "")
-        )
+        name = str(i["Ordinal"]).rjust(2, "0") + "-" + i["Name"].lower().replace(" ", "-").replace(",", "")
 
         for item in i["Items"]:
             itemname = (
-                str(item["Ordinal"]).rjust(2, "0")
-                + "-"
-                + item["Name"].lower().replace(" ", "-").replace(",", "")
+                str(item["Ordinal"]).rjust(2, "0") + "-" + item["Name"].lower().replace(" ", "-").replace(",", "")
             )
             for subitem in item["Items"]:
-                if shortcode.removeprefix("V") == subitem["Shortcode"].removeprefix(
-                    "V"
-                ):
+                if shortcode.removeprefix("V") == subitem["Shortcode"].removeprefix("V"):
                     return f"[{shortcode}](/taxonomy/asvs-{asvs_version}/{name}/{itemname}#{subitem['Shortcode']})"
     return shortcode if shortcode else ""
 
@@ -237,9 +203,7 @@ def load_capec_to_asvs_mapping(filepath: Path) -> dict[int, dict[str, List[str]]
 
 
 def parse_arguments(input_args: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Convert CAPEC JSON to Cornucopia format"
-    )
+    parser = argparse.ArgumentParser(description="Convert CAPEC JSON to Cornucopia format")
     parser.add_argument(
         "-o",
         "--output-path",
@@ -316,9 +280,7 @@ def main() -> None:
     if not asvs_map:
         logging.error("Failed to load ASVS mapping data")
         return
-    capec_to_asvs_map = load_capec_to_asvs_mapping(
-        Path(convert_vars.args.capec_to_asvs)
-    )
+    capec_to_asvs_map = load_capec_to_asvs_mapping(Path(convert_vars.args.capec_to_asvs))
     if not capec_to_asvs_map:
         logging.error("Failed to load CAPEC to ASVS mapping")
         return

--- a/scripts/convert_capec_map_to_asvs_map.py
+++ b/scripts/convert_capec_map_to_asvs_map.py
@@ -38,15 +38,11 @@ def extract_asvs_to_capec_mappings(data: dict[str, Any]) -> dict[str, set[str]]:
     for suit in data["suits"]:
         _extract_asvs_mapping_from_suit(suit, asvs_to_capec_map)
 
-    logging.info(
-        "Extracted mappings for %d unique ASVS requirements", len(asvs_to_capec_map)
-    )
+    logging.info("Extracted mappings for %d unique ASVS requirements", len(asvs_to_capec_map))
     return asvs_to_capec_map
 
 
-def _extract_asvs_mapping_from_suit(
-    suit: dict[str, Any], asvs_to_capec_map: dict[str, set[str]]
-) -> None:
+def _extract_asvs_mapping_from_suit(suit: dict[str, Any], asvs_to_capec_map: dict[str, set[str]]) -> None:
     """Process a single suit and extract ASVS mappings from its cards."""
     if "cards" not in suit:
         return
@@ -55,9 +51,7 @@ def _extract_asvs_mapping_from_suit(
         _extract_asvs_mapping_from_card(card, asvs_to_capec_map)
 
 
-def _extract_asvs_mapping_from_card(
-    card: dict[str, Any], asvs_to_capec_map: dict[str, set[str]]
-) -> None:
+def _extract_asvs_mapping_from_card(card: dict[str, Any], asvs_to_capec_map: dict[str, set[str]]) -> None:
     """Process a single card and extract its ASVS mappings."""
     if "capec_map" not in card:
         return
@@ -100,9 +94,7 @@ def extract_capec_mappings(data: dict[str, Any]) -> dict[int, set[str]]:
     return capec_to_asvs_map
 
 
-def _extract_capec_mapping_from_suit(
-    suit: dict[str, Any], capec_to_asvs_map: dict[int, set[str]]
-) -> None:
+def _extract_capec_mapping_from_suit(suit: dict[str, Any], capec_to_asvs_map: dict[int, set[str]]) -> None:
     """Process a single suit and extract CAPEC mappings from its cards."""
     if "cards" not in suit:
         return
@@ -111,9 +103,7 @@ def _extract_capec_mapping_from_suit(
         _extract_capec_mapping_from_card(card, capec_to_asvs_map)
 
 
-def _extract_capec_mapping_from_card(
-    card: dict[str, Any], capec_to_asvs_map: dict[int, set[str]]
-) -> None:
+def _extract_capec_mapping_from_card(card: dict[str, Any], capec_to_asvs_map: dict[int, set[str]]) -> None:
     """Process a single card and extract its CAPEC mappings."""
     if "capec_map" not in card:
         return
@@ -202,9 +192,7 @@ def save_yaml_file(filepath: Path, data: Dict[str, Any]) -> bool:
     """Save data as YAML file."""
     try:
         with open(filepath, "w", encoding="utf-8") as f:
-            yaml.dump(
-                data, f, default_flow_style=False, sort_keys=False, allow_unicode=True
-            )
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
         logging.info("Successfully saved YAML file: %s", filepath)
         return True
     except Exception as e:
@@ -225,9 +213,7 @@ def set_logging() -> None:
 
 def parse_arguments(input_args: list[str]) -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Convert webapp-mappings YAML to CAPEC-to-ASVS mapping format"
-    )
+    parser = argparse.ArgumentParser(description="Convert webapp-mappings YAML to CAPEC-to-ASVS mapping format")
     parser.add_argument(
         "-i",
         "--input-path",
@@ -324,22 +310,16 @@ def main() -> None:
     if convert_vars.args.input_path:
         input_path = Path(convert_vars.args.input_path).resolve()
     else:
-        input_path = directory / ConvertVars.TEMPLATE_FILE_NAME.replace(
-            "TEMPLATE", "mappings"
-        ).replace("VERSION", str(convert_vars.args.version)).replace(
-            "EDITION", str(convert_vars.args.edition)
-        )
+        input_path = directory / ConvertVars.TEMPLATE_FILE_NAME.replace("TEMPLATE", "mappings").replace(
+            "VERSION", str(convert_vars.args.version)
+        ).replace("EDITION", str(convert_vars.args.edition))
 
-    capec_output_path = directory / ConvertVars.TEMPLATE_FILE_NAME.replace(
-        "TEMPLATE", "capec"
-    ).replace("VERSION", str(convert_vars.args.version)).replace(
-        "EDITION", str(convert_vars.args.edition)
-    )
-    asvs_output_path = directory / ConvertVars.TEMPLATE_FILE_NAME.replace(
-        "TEMPLATE", "asvs"
-    ).replace("VERSION", str(convert_vars.args.version)).replace(
-        "EDITION", str(convert_vars.args.edition)
-    )
+    capec_output_path = directory / ConvertVars.TEMPLATE_FILE_NAME.replace("TEMPLATE", "capec").replace(
+        "VERSION", str(convert_vars.args.version)
+    ).replace("EDITION", str(convert_vars.args.edition))
+    asvs_output_path = directory / ConvertVars.TEMPLATE_FILE_NAME.replace("TEMPLATE", "asvs").replace(
+        "VERSION", str(convert_vars.args.version)
+    ).replace("EDITION", str(convert_vars.args.edition))
 
     logging.info("Input file: %s", input_path)
     logging.info("Output file: %s", capec_output_path)
@@ -379,9 +359,7 @@ def main() -> None:
         sys.exit(1)
 
     logging.info("CAPEC-to-ASVS mapping conversion completed successfully")
-    logging.info(
-        "Total CAPEC codes processed: %d", len(output_data) - (1 if meta else 0)
-    )
+    logging.info("Total CAPEC codes processed: %d", len(output_data) - (1 if meta else 0))
 
     asvs_to_capec_map = extract_asvs_to_capec_mappings(data)
     # Pass enrichment data here

--- a/tests/scripts/capec_map_enricher_fuzzer.py
+++ b/tests/scripts/capec_map_enricher_fuzzer.py
@@ -8,9 +8,7 @@ from unittest.mock import patch
 
 # Add the root directory to sys.path to import scripts
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
-)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "scripts")))
 
 try:
     import scripts.capec_map_enricher as enricher
@@ -68,10 +66,7 @@ def test_main(data):
     for _ in range(fdp.ConsumeIntInRange(0, 5)):
         key = fdp.ConsumeIntInRange(1, 10000)
         fuzzed_yaml_data[key] = {
-            "owasp_asvs": [
-                fdp.ConsumeUnicodeNoSurrogates(16)
-                for _ in range(fdp.ConsumeIntInRange(0, 3))
-            ]
+            "owasp_asvs": [fdp.ConsumeUnicodeNoSurrogates(16) for _ in range(fdp.ConsumeIntInRange(0, 3))]
         }
         if fdp.ConsumeBool():
             fuzzed_yaml_data[key]["extra_field"] = fdp.ConsumeUnicodeNoSurrogates(32)
@@ -98,13 +93,9 @@ def test_main(data):
     try:
         # Mocking the file I/O to avoid hitting the disk and to feed fuzzed data
         # We also mock parse_arguments to avoid SystemExit from pathvalidate/argparse early on
-        with patch.object(
-            enricher, "load_json_file", return_value=fuzzed_json_data
-        ), patch.object(
+        with patch.object(enricher, "load_json_file", return_value=fuzzed_json_data), patch.object(
             enricher, "load_yaml_file", return_value=fuzzed_yaml_data
-        ), patch.object(
-            enricher, "save_yaml_file", return_value=fdp.ConsumeBool()
-        ), patch.object(
+        ), patch.object(enricher, "save_yaml_file", return_value=fdp.ConsumeBool()), patch.object(
             enricher, "parse_arguments", return_value=argparse.Namespace(**argp)
         ), patch(
             "sys.argv", ["capec_map_enricher.py"] + args

--- a/tests/scripts/capec_map_enricher_itest.py
+++ b/tests/scripts/capec_map_enricher_itest.py
@@ -25,12 +25,8 @@ class TestCapecMapEnricherIntegration(unittest.TestCase):
         self.base_path = Path(__file__).parent.parent.parent.resolve()
 
         # Set up test input file paths
-        self.test_capec_json = (
-            self.base_path / "tests" / "test_files" / "capec-3.9" / "3000.json"
-        )
-        self.test_capec_yaml = (
-            self.base_path / "tests" / "test_files" / "source" / "webapp-capec-3.0.yaml"
-        )
+        self.test_capec_json = self.base_path / "tests" / "test_files" / "capec-3.9" / "3000.json"
+        self.test_capec_yaml = self.base_path / "tests" / "test_files" / "source" / "webapp-capec-3.0.yaml"
 
         # Create temporary output directory
         self.temp_output_dir = tempfile.mkdtemp()
@@ -38,13 +34,9 @@ class TestCapecMapEnricherIntegration(unittest.TestCase):
 
         # Verify test input files exist
         if not self.test_capec_json.exists():
-            raise FileNotFoundError(
-                f"Test CAPEC JSON file not found: {self.test_capec_json}"
-            )
+            raise FileNotFoundError(f"Test CAPEC JSON file not found: {self.test_capec_json}")
         if not self.test_capec_yaml.exists():
-            raise FileNotFoundError(
-                f"Test CAPEC YAML file not found: {self.test_capec_yaml}"
-            )
+            raise FileNotFoundError(f"Test CAPEC YAML file not found: {self.test_capec_yaml}")
 
     def tearDown(self) -> None:
         """Clean up test output directory"""
@@ -82,9 +74,7 @@ class TestCapecMapEnricherIntegration(unittest.TestCase):
 
         # Verify we extracted some names
         self.assertIsInstance(capec_names, dict)
-        self.assertGreater(
-            len(capec_names), 0, "Should extract at least one CAPEC name"
-        )
+        self.assertGreater(len(capec_names), 0, "Should extract at least one CAPEC name")
 
         # Verify the structure
         for capec_id, name in capec_names.items():
@@ -101,9 +91,7 @@ class TestCapecMapEnricherIntegration(unittest.TestCase):
         expected_ids = [1, 5, 560]
 
         for capec_id in expected_ids:
-            self.assertIn(
-                capec_id, capec_names, f"CAPEC-{capec_id} should be in extracted names"
-            )
+            self.assertIn(capec_id, capec_names, f"CAPEC-{capec_id} should be in extracted names")
             self.assertIsInstance(capec_names[capec_id], str)
             self.assertGreater(len(capec_names[capec_id]), 0)
 
@@ -200,20 +188,12 @@ class TestCapecMapEnricherIntegration(unittest.TestCase):
         for capec_id in enriched.keys():
             self.assertIn(capec_id, reloaded)
             self.assertEqual(reloaded[capec_id]["name"], enriched[capec_id]["name"])
-            self.assertEqual(
-                reloaded[capec_id]["owasp_asvs"], enriched[capec_id]["owasp_asvs"]
-            )
+            self.assertEqual(reloaded[capec_id]["owasp_asvs"], enriched[capec_id]["owasp_asvs"])
 
     def test_output_to_test_files_directory(self):
         """Test saving output to the tests/test_files/output directory"""
         # Set up the expected output path
-        expected_output_path = (
-            self.base_path
-            / "tests"
-            / "test_files"
-            / "output"
-            / "edition-capec-latest.yaml"
-        )
+        expected_output_path = self.base_path / "tests" / "test_files" / "output" / "edition-capec-latest.yaml"
 
         # Create output directory if it doesn't exist
         expected_output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/capec_map_enricher_utest.py
+++ b/tests/scripts/capec_map_enricher_utest.py
@@ -12,9 +12,7 @@ enricher.enricher_vars = enricher.EnricherVars()
 
 class ConvertVars:
     OUTPUT_DIR: str = str(Path(__file__).parent.parent.resolve() / "test_files/output")
-    OUTPUT_FILE: str = str(
-        Path(__file__).parent.parent.resolve() / OUTPUT_DIR / "enriched_capec.yaml"
-    )
+    OUTPUT_FILE: str = str(Path(__file__).parent.parent.resolve() / OUTPUT_DIR / "enriched_capec.yaml")
 
 
 if "unittest.util" in __import__("sys").modules:
@@ -98,11 +96,7 @@ class TestExtractCapecNames(unittest.TestCase):
 
     def test_extract_capec_names_not_list(self):
         """Test with Attack_Pattern not being a list"""
-        data = {
-            "Attack_Pattern_Catalog": {
-                "Attack_Patterns": {"Attack_Pattern": "not a list"}
-            }
-        }
+        data = {"Attack_Pattern_Catalog": {"Attack_Patterns": {"Attack_Pattern": "not a list"}}}
 
         with self.assertLogs(logging.getLogger(), logging.WARNING) as log:
             result = enricher.extract_capec_names(data)
@@ -222,9 +216,7 @@ class TestLoadJsonFile(unittest.TestCase):
     def test_load_file_not_found(self, mock_file):
         """Test loading non-existent file"""
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = enricher.load_json_file(
-                Path(ConvertVars.OUTPUT_DIR + "/nonexistent.json")
-            )
+            result = enricher.load_json_file(Path(ConvertVars.OUTPUT_DIR + "/nonexistent.json"))
 
         self.assertEqual(result, {})
         self.assertIn("File not found", log.output[0])
@@ -233,9 +225,7 @@ class TestLoadJsonFile(unittest.TestCase):
     def test_load_invalid_json(self, mock_file):
         """Test loading file with invalid JSON"""
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = enricher.load_json_file(
-                Path(ConvertVars.OUTPUT_DIR + "/invalid.json")
-            )
+            result = enricher.load_json_file(Path(ConvertVars.OUTPUT_DIR + "/invalid.json"))
 
         self.assertEqual(result, {})
         self.assertIn("Error parsing JSON file", log.output[0])
@@ -266,9 +256,7 @@ class TestLoadYamlFile(unittest.TestCase):
     def test_load_yaml_file_not_found(self, mock_file):
         """Test loading non-existent YAML file"""
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = enricher.load_yaml_file(
-                Path(ConvertVars.OUTPUT_DIR + "/nonexistent.yaml")
-            )
+            result = enricher.load_yaml_file(Path(ConvertVars.OUTPUT_DIR + "/nonexistent.yaml"))
 
         self.assertEqual(result, {})
         self.assertIn("File not found", log.output[0])
@@ -295,9 +283,7 @@ class TestSaveYamlFile(unittest.TestCase):
         data = {1: {"name": "Test"}}
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = enricher.save_yaml_file(
-                Path(ConvertVars.OUTPUT_DIR + "/error.yaml"), data
-            )
+            result = enricher.save_yaml_file(Path(ConvertVars.OUTPUT_DIR + "/error.yaml"), data)
 
         self.assertFalse(result)
         self.assertIn("Error saving YAML file", log.output[0])

--- a/tests/scripts/convert_asvs_itest.py
+++ b/tests/scripts/convert_asvs_itest.py
@@ -33,9 +33,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
             / "asvs-5.0"
             / "OWASP_Application_Security_Verification_Standard_5.0.0_en.json"
         )
-        self.test_asvs_to_capec = (
-            self.base_path / "tests" / "test_files" / "source" / "webapp-asvs-3.0.yaml"
-        )
+        self.test_asvs_to_capec = self.base_path / "tests" / "test_files" / "source" / "webapp-asvs-3.0.yaml"
 
         # Create temporary output directory
         self.temp_output_dir = tempfile.mkdtemp()
@@ -43,13 +41,9 @@ class TestConvertASVSIntegration(unittest.TestCase):
 
         # Verify test files exist
         if not self.test_input_file.exists():
-            raise FileNotFoundError(
-                f"Test input file not found: {self.test_input_file}"
-            )
+            raise FileNotFoundError(f"Test input file not found: {self.test_input_file}")
         if not self.test_asvs_to_capec.exists():
-            raise FileNotFoundError(
-                f"Test ASVS to CAPEC mapping file not found: {self.test_asvs_to_capec}"
-            )
+            raise FileNotFoundError(f"Test ASVS to CAPEC mapping file not found: {self.test_asvs_to_capec}")
 
     def tearDown(self) -> None:
         """Clean up test output directory"""
@@ -64,9 +58,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
         self.assertIsInstance(data, dict)
         self.assertIn("Requirements", data)
         self.assertIn("Name", data)
-        self.assertEqual(
-            data["Name"], "Application Security Verification Standard Project"
-        )
+        self.assertEqual(data["Name"], "Application Security Verification Standard Project")
 
     def test_load_test_yaml_mapping(self):
         """Test loading the test ASVS to CAPEC YAML mapping file"""
@@ -147,16 +139,10 @@ class TestConvertASVSIntegration(unittest.TestCase):
 
         # Check that some directories were created
         output_dirs = [d for d in self.test_output_path.iterdir() if d.is_dir()]
-        self.assertGreater(
-            len(output_dirs), 0, "Should have created at least one directory"
-        )
+        self.assertGreater(len(output_dirs), 0, "Should have created at least one directory")
 
         # Check for level control directories
-        level_dirs = [
-            d
-            for d in output_dirs
-            if d.name.startswith("level-") and d.name.endswith("-controls")
-        ]
+        level_dirs = [d for d in output_dirs if d.name.startswith("level-") and d.name.endswith("-controls")]
         self.assertEqual(
             len(level_dirs),
             3,
@@ -193,22 +179,16 @@ class TestConvertASVSIntegration(unittest.TestCase):
 
         # Find a requirement directory (e.g., 01-encoding-and-sanitization)
         requirement_dirs = [
-            d
-            for d in self.test_output_path.iterdir()
-            if d.is_dir() and not d.name.startswith("level-")
+            d for d in self.test_output_path.iterdir() if d.is_dir() and not d.name.startswith("level-")
         ]
-        self.assertGreater(
-            len(requirement_dirs), 0, "Should have created requirement directories"
-        )
+        self.assertGreater(len(requirement_dirs), 0, "Should have created requirement directories")
 
         # Check first requirement directory
         first_req_dir = sorted(requirement_dirs)[0]
 
         # It should have subdirectories for items
         item_dirs = [d for d in first_req_dir.iterdir() if d.is_dir()]
-        self.assertGreater(
-            len(item_dirs), 0, "Requirement should have item subdirectories"
-        )
+        self.assertGreater(len(item_dirs), 0, "Requirement should have item subdirectories")
 
         # Check first item directory for index.md
         first_item_dir = sorted(item_dirs)[0]
@@ -243,9 +223,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
         # Look for pages with CAPEC mappings
         # Check the first requirement
         requirement_dirs = [
-            d
-            for d in self.test_output_path.iterdir()
-            if d.is_dir() and not d.name.startswith("level-")
+            d for d in self.test_output_path.iterdir() if d.is_dir() and not d.name.startswith("level-")
         ]
 
         found_capec_reference = False
@@ -269,9 +247,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
     def test_main_integration(self):
         """Test the main function with real test files"""
         # Create permanent output directory for this test
-        test_output_dir = (
-            self.base_path / "tests" / "test_files" / "output" / "asvs_integration_test"
-        )
+        test_output_dir = self.base_path / "tests" / "test_files" / "output" / "asvs_integration_test"
 
         # Clean up if exists
         if test_output_dir.exists():
@@ -293,9 +269,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
         asvs.convert_vars.args = asvs.parse_arguments(test_args)
 
         # Run main workflow (without calling main() to avoid sys.argv issues)
-        capec_version = asvs.get_valid_capec_version(
-            asvs.convert_vars.args.capec_version
-        )
+        capec_version = asvs.get_valid_capec_version(asvs.convert_vars.args.capec_version)
         asvs_version = asvs.get_valid_asvs_version(asvs.convert_vars.args.asvs_version)
         asvs.set_logging()
 
@@ -303,9 +277,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
             asvs.empty_folder(Path(asvs.convert_vars.args.output_path))
             asvs.create_folder(Path(asvs.convert_vars.args.output_path))
             data = asvs.load_json_file(Path(asvs.convert_vars.args.input_path))
-            asvs_map = asvs.load_asvs_to_capec_mapping(
-                Path(asvs.convert_vars.args.asvs_to_capec)
-            )
+            asvs_map = asvs.load_asvs_to_capec_mapping(Path(asvs.convert_vars.args.asvs_to_capec))
             asvs.create_asvs_pages(data, asvs_map, capec_version, asvs_version)
 
         # Verify logging
@@ -317,9 +289,7 @@ class TestConvertASVSIntegration(unittest.TestCase):
 
         # Verify some content was created
         output_items = list(test_output_dir.iterdir())
-        self.assertGreater(
-            len(output_items), 0, "Should have created output files/directories"
-        )
+        self.assertGreater(len(output_items), 0, "Should have created output files/directories")
 
         # Clean up
         if test_output_dir.exists():
@@ -405,9 +375,7 @@ class TestRealFileOperations(unittest.TestCase):
         (sub_folder / "file3.txt").write_text("content3")
 
         # Verify content exists
-        self.assertEqual(
-            len(list(test_folder.rglob("*"))), 4
-        )  # 2 files + 1 folder + 1 file in folder
+        self.assertEqual(len(list(test_folder.rglob("*"))), 4)  # 2 files + 1 folder + 1 file in folder
 
         # Empty the folder
         asvs.empty_folder(test_folder)

--- a/tests/scripts/convert_asvs_utest.py
+++ b/tests/scripts/convert_asvs_utest.py
@@ -50,9 +50,7 @@ class TestCreateLevelSummary(unittest.TestCase):
         mock_mkdir.assert_called_once_with(self.mock_output_path / "level-1-controls")
 
         # Verify file was opened for writing
-        mock_file.assert_called_once_with(
-            self.mock_output_path / "level-1-controls/index.md", "w", encoding="utf-8"
-        )
+        mock_file.assert_called_once_with(self.mock_output_path / "level-1-controls/index.md", "w", encoding="utf-8")
 
         # Get the file handle
         handle = mock_file()
@@ -128,9 +126,7 @@ class TestCreateLinkList(unittest.TestCase):
         result = asvs.create_link_list(requirements, "3.9")
 
         expected = (
-            "[120](/taxonomy/capec-3.9/120), "
-            "[126](/taxonomy/capec-3.9/126), "
-            "[152](/taxonomy/capec-3.9/152)"
+            "[120](/taxonomy/capec-3.9/120), " "[126](/taxonomy/capec-3.9/126), " "[152](/taxonomy/capec-3.9/152)"
         )
         self.assertEqual(result, expected)
 
@@ -161,10 +157,7 @@ class TestCreateLinkList(unittest.TestCase):
         requirements = {"capec_codes": ["152", "120", "126"]}
         result = asvs.create_link_list(requirements, "3.9")
 
-        expected = (
-            "[120](/taxonomy/capec-3.9/120), "
-            "[126](/taxonomy/capec-3.9/126), [152](/taxonomy/capec-3.9/152)"
-        )
+        expected = "[120](/taxonomy/capec-3.9/120), " "[126](/taxonomy/capec-3.9/126), [152](/taxonomy/capec-3.9/152)"
         self.assertEqual(result, expected)
 
 
@@ -177,9 +170,7 @@ class TestParseArguments(unittest.TestCase):
 
         self.assertEqual(Path(args.output_path), asvs.ConvertVars.DEFAULT_OUTPUT_PATH)
         self.assertEqual(Path(args.input_path), asvs.ConvertVars.DEFAULT_INPUT_PATH)
-        self.assertEqual(
-            Path(args.asvs_to_capec), asvs.ConvertVars.DEFAULT_ASVS_TO_CAPEC_INPUT_PATH
-        )
+        self.assertEqual(Path(args.asvs_to_capec), asvs.ConvertVars.DEFAULT_ASVS_TO_CAPEC_INPUT_PATH)
         self.assertEqual(args.capec_version, "3.9")
         self.assertFalse(args.debug)
 
@@ -480,16 +471,12 @@ class TestCreateLevelObj(unittest.TestCase):
             "L": "1",
         }
 
-        result = asvs._create_level_obj(
-            subitem, "01-encoding", "01-architecture", "5.0"
-        )
+        result = asvs._create_level_obj(subitem, "01-encoding", "01-architecture", "5.0")
 
         self.assertEqual(result["topic"], "01-encoding")
         self.assertEqual(result["cat"], "01-architecture")
         self.assertEqual(result["name"], "V1.1.1")
-        self.assertEqual(
-            result["link"], "/taxonomy/asvs-5.0/01-encoding/01-architecture#V1.1.1"
-        )
+        self.assertEqual(result["link"], "/taxonomy/asvs-5.0/01-encoding/01-architecture#V1.1.1")
         self.assertEqual(result["description"], "Verify that input is decoded")
 
 
@@ -591,15 +578,11 @@ class TestProcessRequirementItem(unittest.TestCase):
         item = {
             "Ordinal": 1,
             "Name": "Architecture",
-            "Items": [
-                {"Shortcode": "V1.1.1", "Description": "Test requirement", "L": "1"}
-            ],
+            "Items": [{"Shortcode": "V1.1.1", "Description": "Test requirement", "L": "1"}],
         }
         L1, L2, L3 = [], [], []
 
-        asvs._process_requirement_item(
-            item, "01-encoding", {}, "3.9", L1, L2, L3, "5.0"
-        )
+        asvs._process_requirement_item(item, "01-encoding", {}, "3.9", L1, L2, L3, "5.0")
 
         # Verify directory was created
         mock_mkdir.assert_called_once()
@@ -698,11 +681,7 @@ class TestCreateAsvsPages(unittest.TestCase):
         mkdir_calls = [str(call_args[0][0]) for call_args in mock_mkdir.call_args_list]
 
         # Should include level control directories
-        level_dirs = [
-            call
-            for call in mkdir_calls
-            if "level-" in str(call) and "-controls" in str(call)
-        ]
+        level_dirs = [call for call in mkdir_calls if "level-" in str(call) and "-controls" in str(call)]
         self.assertEqual(len(level_dirs), 3)  # L1, L2, L3
 
     @patch("builtins.open", new_callable=mock_open)

--- a/tests/scripts/convert_capec_itest.py
+++ b/tests/scripts/convert_capec_itest.py
@@ -25,9 +25,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
 
         self.base_path = Path(__file__).parent.parent.parent.resolve()
 
-        self.test_input_file = (
-            self.base_path / "tests" / "test_files" / "capec-3.9" / "3000.json"
-        )
+        self.test_input_file = self.base_path / "tests" / "test_files" / "capec-3.9" / "3000.json"
         self.test_asvs_mapping = (
             self.base_path
             / "tests"
@@ -35,25 +33,17 @@ class TestConvertCAPECIntegration(unittest.TestCase):
             / "asvs-5.0"
             / "OWASP_Application_Security_Verification_Standard_5.0.0_en.json"
         )
-        self.test_capec_to_asvs = (
-            self.base_path / "tests" / "test_files" / "source" / "webapp-capec-3.0.yaml"
-        )
+        self.test_capec_to_asvs = self.base_path / "tests" / "test_files" / "source" / "webapp-capec-3.0.yaml"
 
         self.temp_output_dir = tempfile.mkdtemp()
         self.test_output_path = Path(self.temp_output_dir)
 
         if not self.test_input_file.exists():
-            raise FileNotFoundError(
-                f"Test input file not found: {self.test_input_file}"
-            )
+            raise FileNotFoundError(f"Test input file not found: {self.test_input_file}")
         if not self.test_asvs_mapping.exists():
-            raise FileNotFoundError(
-                f"Test ASVS mapping file not found: {self.test_asvs_mapping}"
-            )
+            raise FileNotFoundError(f"Test ASVS mapping file not found: {self.test_asvs_mapping}")
         if not self.test_capec_to_asvs.exists():
-            raise FileNotFoundError(
-                f"Test CAPEC to ASVS mapping file not found: {self.test_capec_to_asvs}"
-            )
+            raise FileNotFoundError(f"Test CAPEC to ASVS mapping file not found: {self.test_capec_to_asvs}")
 
     def tearDown(self) -> None:
         """Clean up test output directory"""
@@ -95,13 +85,9 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         capec_to_asvs_map = capec.load_capec_to_asvs_mapping(self.test_capec_to_asvs)
         capec.create_capec_pages(data, capec_to_asvs_map, asvs_map, "5.0")
 
-        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"][
-            "Attack_Pattern"
-        ]
+        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"]["Attack_Pattern"]
 
-        self.assertGreater(
-            len(attack_patterns), 0, "Should have at least one attack pattern"
-        )
+        self.assertGreater(len(attack_patterns), 0, "Should have at least one attack pattern")
 
         first_pattern = attack_patterns[0]
         first_id = str(first_pattern["_ID"])
@@ -110,12 +96,8 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         pattern_dir = self.test_output_path / first_id
         index_file = pattern_dir / "index.md"
 
-        self.assertTrue(
-            pattern_dir.exists(), f"Directory for CAPEC-{first_id} should exist"
-        )
-        self.assertTrue(
-            index_file.exists(), f"index.md for CAPEC-{first_id} should exist"
-        )
+        self.assertTrue(pattern_dir.exists(), f"Directory for CAPEC-{first_id} should exist")
+        self.assertTrue(index_file.exists(), f"index.md for CAPEC-{first_id} should exist")
 
         content = index_file.read_text(encoding="utf-8")
         self.assertIn(f"CAPEC™ {first_id}", content)
@@ -127,9 +109,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         """Test that all attack patterns in test data are converted"""
 
         data = capec.load_json_file(self.test_input_file)
-        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"][
-            "Attack_Pattern"
-        ]
+        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"]["Attack_Pattern"]
 
         capec.convert_vars.args = argparse.Namespace(
             output_path=self.test_output_path,
@@ -149,9 +129,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
             pattern_id = str(pattern["_ID"])
             index_file = self.test_output_path / pattern_id / "index.md"
 
-            self.assertTrue(
-                index_file.exists(), f"index.md should exist for CAPEC-{pattern_id}"
-            )
+            self.assertTrue(index_file.exists(), f"index.md should exist for CAPEC-{pattern_id}")
 
     def test_created_file_content_structure(self):
         """Test that created markdown files have correct structure"""
@@ -172,9 +150,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         capec_to_asvs_map = capec.load_capec_to_asvs_mapping(self.test_capec_to_asvs)
         capec.create_capec_pages(data, capec_to_asvs_map, asvs_map, "5.0")
 
-        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"][
-            "Attack_Pattern"
-        ]
+        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"]["Attack_Pattern"]
         pattern = attack_patterns[0]
         pattern_id = str(pattern["_ID"])
         pattern_name = pattern["_Name"]
@@ -184,9 +160,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
 
         lines = content.split("\n")
 
-        self.assertTrue(
-            lines[0].startswith("# CAPEC™ "), "First line should be title with CAPEC-"
-        )
+        self.assertTrue(lines[0].startswith("# CAPEC™ "), "First line should be title with CAPEC-")
         self.assertIn(pattern_name, lines[0])
 
         self.assertIn("## Description", content)
@@ -265,9 +239,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), logging.INFO):
             capec.create_capec_pages(data, capec_to_asvs_map, asvs_map, "5.0")
 
-        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"][
-            "Attack_Pattern"
-        ]
+        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"]["Attack_Pattern"]
 
         for pattern in attack_patterns:
             pattern_id = str(pattern["_ID"])
@@ -278,9 +250,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         """Test that different description formats in test data are parsed correctly"""
 
         data = capec.load_json_file(self.test_input_file)
-        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"][
-            "Attack_Pattern"
-        ]
+        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"]["Attack_Pattern"]
 
         for pattern in attack_patterns:
             description = pattern.get("Description", "")
@@ -411,11 +381,7 @@ class TestConvertCAPECIntegration(unittest.TestCase):
         if capec_5_file.exists():
             content = capec_5_file.read_text(encoding="utf-8")
             # Should not have ASVS section if mapping is empty
-            lines_with_asvs = [
-                line
-                for line in content.split("\n")
-                if "## Related ASVS Requirements" in line
-            ]
+            lines_with_asvs = [line for line in content.split("\n") if "## Related ASVS Requirements" in line]
             # Either no section, or empty section
             self.assertTrue(len(lines_with_asvs) == 0 or "ASVS (5.0):" not in content)
 
@@ -426,9 +392,7 @@ class TestConvertCAPECWithOutputDirectory(unittest.TestCase):
     def setUp(self) -> None:
         """Set up test environment"""
         self.base_path = Path(__file__).parent.parent.parent.resolve()
-        self.test_input_file = (
-            self.base_path / "tests" / "test_files" / "capec-3.9" / "3000.json"
-        )
+        self.test_input_file = self.base_path / "tests" / "test_files" / "capec-3.9" / "3000.json"
         self.test_asvs_mapping = (
             self.base_path
             / "tests"
@@ -436,9 +400,7 @@ class TestConvertCAPECWithOutputDirectory(unittest.TestCase):
             / "asvs-5.0"
             / "OWASP_Application_Security_Verification_Standard_5.0.0_en.json"
         )
-        self.test_capec_to_asvs = (
-            self.base_path / "tests" / "test_files" / "source" / "webapp-capec-3.0.yaml"
-        )
+        self.test_capec_to_asvs = self.base_path / "tests" / "test_files" / "source" / "webapp-capec-3.0.yaml"
 
         # Use the actual test output directory (create if doesn't exist)
         self.test_output_base = self.base_path / "tests" / "test_files" / "output"
@@ -475,9 +437,7 @@ class TestConvertCAPECWithOutputDirectory(unittest.TestCase):
 
         capec.create_capec_pages(data, capec_to_asvs_map, asvs_map, "5.0")
 
-        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"][
-            "Attack_Pattern"
-        ]
+        attack_patterns = data["Attack_Pattern_Catalog"]["Attack_Patterns"]["Attack_Pattern"]
         first_pattern_id = str(attack_patterns[0]["_ID"])
 
         output_file = self.test_output_path / first_pattern_id / "index.md"

--- a/tests/scripts/convert_capec_map_to_asvs_map_itest.py
+++ b/tests/scripts/convert_capec_map_to_asvs_map_itest.py
@@ -25,26 +25,16 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
         self.base_path = Path(__file__).parent.parent.parent.resolve()
 
         # Set up test input file path
-        self.test_input_file = (
-            self.base_path
-            / "tests"
-            / "test_files"
-            / "source"
-            / "webapp-mappings-3.0.yaml"
-        )
+        self.test_input_file = self.base_path / "tests" / "test_files" / "source" / "webapp-mappings-3.0.yaml"
 
         # Create temporary output directory
         self.temp_output_dir = tempfile.mkdtemp()
-        self.test_capec_output_file = (
-            Path(self.temp_output_dir) / "webapp-capec-3.0.yaml"
-        )
+        self.test_capec_output_file = Path(self.temp_output_dir) / "webapp-capec-3.0.yaml"
         self.test_asvs_output_file = Path(self.temp_output_dir) / "webapp-asvs-3.0.yaml"
 
         # Verify test input file exists
         if not self.test_input_file.exists():
-            raise FileNotFoundError(
-                f"Test input file not found: {self.test_input_file}"
-            )
+            raise FileNotFoundError(f"Test input file not found: {self.test_input_file}")
 
     def tearDown(self) -> None:
         """Clean up test output directory"""
@@ -70,18 +60,12 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
 
         # Verify we extracted some mappings
         self.assertIsInstance(capec_mapping, dict)
-        self.assertGreater(
-            len(capec_mapping), 0, "Should extract at least one CAPEC mapping"
-        )
+        self.assertGreater(len(capec_mapping), 0, "Should extract at least one CAPEC mapping")
 
         # Verify the structure of extracted data
         for capec_code, asvs_set in capec_mapping.items():
-            self.assertIsInstance(
-                capec_code, int, f"CAPEC code {capec_code} should be int"
-            )
-            self.assertIsInstance(
-                asvs_set, set, f"ASVS set for {capec_code} should be a set"
-            )
+            self.assertIsInstance(capec_code, int, f"CAPEC code {capec_code} should be int")
+            self.assertIsInstance(asvs_set, set, f"ASVS set for {capec_code} should be a set")
 
     def test_extract_asvs_to_capec_mappings_from_test_data(self):
         """Test extracting ASVS to CAPEC mappings from real test data"""
@@ -92,23 +76,15 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
 
         # Verify we extracted some mappings
         self.assertIsInstance(asvs_mapping, dict)
-        self.assertGreater(
-            len(asvs_mapping), 0, "Should extract at least one ASVS mapping"
-        )
+        self.assertGreater(len(asvs_mapping), 0, "Should extract at least one ASVS mapping")
 
         # Verify the structure of extracted data
         for asvs_req, capec_set in asvs_mapping.items():
-            self.assertIsInstance(
-                asvs_req, str, f"ASVS requirement {asvs_req} should be string"
-            )
-            self.assertIsInstance(
-                capec_set, set, f"CAPEC set for {asvs_req} should be a set"
-            )
+            self.assertIsInstance(asvs_req, str, f"ASVS requirement {asvs_req} should be string")
+            self.assertIsInstance(capec_set, set, f"CAPEC set for {asvs_req} should be a set")
             # Each CAPEC code in the set should be an integer
             for capec_code in capec_set:
-                self.assertIsInstance(
-                    capec_code, str, f"CAPEC code {capec_code} should be int"
-                )
+                self.assertIsInstance(capec_code, str, f"CAPEC code {capec_code} should be int")
 
     def test_convert_to_output_format_with_test_data(self):
         """Test converting extracted mappings to output format"""
@@ -180,9 +156,7 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
         self.assertGreater(len(asvs_mapping), 0)
 
         # Convert to output format with capec_codes parameter
-        output_data_asvs = capec_map.convert_to_output_format(
-            asvs_mapping, parameter="capec_codes"
-        )
+        output_data_asvs = capec_map.convert_to_output_format(asvs_mapping, parameter="capec_codes")
 
         # Save ASVS output
         success = capec_map.save_yaml_file(self.test_asvs_output_file, output_data_asvs)
@@ -210,9 +184,7 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
         expected_capec_codes = [54, 116, 143, 144]
 
         for code in expected_capec_codes:
-            self.assertIn(
-                code, capec_mapping, f"CAPEC code {code} should be in mappings"
-            )
+            self.assertIn(code, capec_mapping, f"CAPEC code {code} should be in mappings")
 
     def test_specific_asvs_requirements_in_test_data(self):
         """Test that ASVS requirements from test data are extracted correctly"""
@@ -250,12 +222,8 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
     def test_output_to_expected_location(self):
         """Test saving both output files to the expected test location"""
         # Set up the expected output paths
-        expected_capec_output_path = (
-            self.base_path / "tests" / "test_files" / "output" / "webapp-capec-3.0.yaml"
-        )
-        expected_asvs_output_path = (
-            self.base_path / "tests" / "test_files" / "output" / "webapp-asvs-3.0.yaml"
-        )
+        expected_capec_output_path = self.base_path / "tests" / "test_files" / "output" / "webapp-capec-3.0.yaml"
+        expected_asvs_output_path = self.base_path / "tests" / "test_files" / "output" / "webapp-asvs-3.0.yaml"
 
         # Create output directory if it doesn't exist
         expected_capec_output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -279,9 +247,7 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
 
         # Process ASVS mappings
         asvs_mapping = capec_map.extract_asvs_to_capec_mappings(data)
-        output_data_asvs = capec_map.convert_to_output_format(
-            asvs_mapping, parameter="capec_codes"
-        )
+        output_data_asvs = capec_map.convert_to_output_format(asvs_mapping, parameter="capec_codes")
 
         # Save ASVS to expected location
         success = capec_map.save_yaml_file(expected_asvs_output_path, output_data_asvs)
@@ -347,9 +313,7 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
 
         # Extract and convert ASVS mappings
         asvs_mapping = capec_map.extract_asvs_to_capec_mappings(data)
-        output_data_asvs = capec_map.convert_to_output_format(
-            asvs_mapping, parameter="capec_codes"
-        )
+        output_data_asvs = capec_map.convert_to_output_format(asvs_mapping, parameter="capec_codes")
 
         # Save ASVS output
         success = capec_map.save_yaml_file(self.test_asvs_output_file, output_data_asvs)
@@ -370,9 +334,7 @@ class TestConvertCAPECMapToASVSMapIntegration(unittest.TestCase):
 
         # Test ASVS output
         asvs_mapping = capec_map.extract_asvs_to_capec_mappings(data)
-        output_data_asvs = capec_map.convert_to_output_format(
-            asvs_mapping, parameter="capec_codes"
-        )
+        output_data_asvs = capec_map.convert_to_output_format(asvs_mapping, parameter="capec_codes")
         capec_map.save_yaml_file(self.test_asvs_output_file, output_data_asvs)
         reloaded_asvs_data = capec_map.load_yaml_file(self.test_asvs_output_file)
         self.assertEqual(reloaded_asvs_data, output_data_asvs)

--- a/tests/scripts/convert_capec_map_to_asvs_map_utest.py
+++ b/tests/scripts/convert_capec_map_to_asvs_map_utest.py
@@ -12,9 +12,7 @@ capec_map.convert_vars = capec_map.ConvertVars()
 
 class ConvertVars:
     OUTPUT_DIR: str = str(Path(__file__).parent.parent.resolve() / "/test_files/output")
-    OUTPUT_FILE: str = str(
-        Path(__file__).parent.parent.resolve() / OUTPUT_DIR / "capec_to_asvs_map.yaml"
-    )
+    OUTPUT_FILE: str = str(Path(__file__).parent.parent.resolve() / OUTPUT_DIR / "capec_to_asvs_map.yaml")
 
 
 if "unittest.util" in __import__("sys").modules:
@@ -27,19 +25,7 @@ class TestExtractAsvsToCapecMappings(unittest.TestCase):
 
     def test_extract_simple_asvs_mapping(self):
         """Test extracting a simple ASVS to CAPEC mapping"""
-        data = {
-            "suits": [
-                {
-                    "cards": [
-                        {
-                            "capec_map": {
-                                54: {"owasp_asvs": ["4.3.2", "13.2.2", "13.4.1"]}
-                            }
-                        }
-                    ]
-                }
-            ]
-        }
+        data = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2", "13.2.2", "13.4.1"]}}}]}]}
         result = capec_map.extract_asvs_to_capec_mappings(data)
 
         self.assertIn("4.3.2", result)
@@ -112,19 +98,7 @@ class TestExtractCapecMappings(unittest.TestCase):
 
     def test_extract_simple_capec_mapping(self):
         """Test extracting a simple CAPEC mapping"""
-        data = {
-            "suits": [
-                {
-                    "cards": [
-                        {
-                            "capec_map": {
-                                54: {"owasp_asvs": ["4.3.2", "13.2.2", "13.4.1"]}
-                            }
-                        }
-                    ]
-                }
-            ]
-        }
+        data = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2", "13.2.2", "13.4.1"]}}}]}]}
         result = capec_map.extract_capec_mappings(data)
 
         self.assertIn(54, result)
@@ -268,9 +242,7 @@ class TestConvertToOutputFormat(unittest.TestCase):
     def test_convert_with_capec_codes_parameter(self):
         """Test converting ASVS to CAPEC mapping with capec_codes parameter"""
         asvs_mapping = {"4.3.2": {54, 116}, "13.2.2": {54}}
-        result = capec_map.convert_to_output_format(
-            asvs_mapping, parameter="capec_codes"
-        )
+        result = capec_map.convert_to_output_format(asvs_mapping, parameter="capec_codes")
 
         self.assertIn("4.3.2", result)
         self.assertIn("capec_codes", result["4.3.2"])
@@ -296,9 +268,7 @@ class TestLoadYamlFile(unittest.TestCase):
     def test_load_file_not_found(self, mock_file):
         """Test loading non-existent file"""
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = capec_map.load_yaml_file(
-                Path(ConvertVars.OUTPUT_DIR + "nonexistent.yaml")
-            )
+            result = capec_map.load_yaml_file(Path(ConvertVars.OUTPUT_DIR + "nonexistent.yaml"))
 
         self.assertEqual(result, {})
         self.assertIn("File not found", log.output[0])
@@ -308,9 +278,7 @@ class TestLoadYamlFile(unittest.TestCase):
     def test_load_yaml_error(self, mock_yaml_load, mock_file):
         """Test loading file with YAML error"""
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = capec_map.load_yaml_file(
-                Path(ConvertVars.OUTPUT_DIR + "invalid.yaml")
-            )
+            result = capec_map.load_yaml_file(Path(ConvertVars.OUTPUT_DIR + "invalid.yaml"))
 
         self.assertEqual(result, {})
         self.assertIn("Error loading YAML file", log.output[0])
@@ -345,9 +313,7 @@ class TestSaveYamlFile(unittest.TestCase):
         data = {"key": "value"}
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
-            result = capec_map.save_yaml_file(
-                Path(ConvertVars.OUTPUT_DIR + "error.yaml"), data
-            )
+            result = capec_map.save_yaml_file(Path(ConvertVars.OUTPUT_DIR + "error.yaml"), data)
 
         self.assertFalse(result)
         self.assertIn("Error saving YAML file", log.output[0])
@@ -477,9 +443,7 @@ class TestMainFunction(unittest.TestCase):
     @patch("scripts.convert_capec_map_to_asvs_map.load_yaml_file")
     @patch("scripts.convert_capec_map_to_asvs_map.parse_arguments")
     @patch("sys.exit")
-    def test_main_successful_execution(
-        self, mock_exit, mock_parse_args, mock_load, mock_save
-    ):
+    def test_main_successful_execution(self, mock_exit, mock_parse_args, mock_load, mock_save):
         """Test successful main execution"""
         # Setup mocks
         mock_parse_args.return_value = argparse.Namespace(
@@ -490,9 +454,7 @@ class TestMainFunction(unittest.TestCase):
             asvs_json=None,
             debug=False,
         )
-        mock_load.return_value = {
-            "suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]
-        }
+        mock_load.return_value = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]}
         mock_save.return_value = True
 
         capec_map.main()
@@ -540,9 +502,7 @@ class TestMainFunction(unittest.TestCase):
             asvs_json=None,
             debug=False,
         )
-        mock_load.return_value = {
-            "suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]
-        }
+        mock_load.return_value = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]}
         mock_save.return_value = False
 
         with self.assertLogs(logging.getLogger(), logging.ERROR):
@@ -559,9 +519,7 @@ class TestMainFunction(unittest.TestCase):
     @patch("scripts.convert_capec_map_to_asvs_map.load_yaml_file")
     @patch("scripts.convert_capec_map_to_asvs_map.parse_arguments")
     @patch("sys.exit")
-    def test_main_with_asvs_json(
-        self, mock_exit, mock_parse_args, mock_load_yaml, mock_load_json, mock_save
-    ):
+    def test_main_with_asvs_json(self, mock_exit, mock_parse_args, mock_load_yaml, mock_load_json, mock_save):
         """Test main execution with asvs_json argument"""
         mock_parse_args.return_value = argparse.Namespace(
             input_path=Path("input.yaml"),
@@ -585,9 +543,7 @@ class TestMainFunction(unittest.TestCase):
             ],
         }
         mock_load_json.return_value = {
-            "Requirements": [
-                {"Shortcode": "V4.3.2", "Description": "Test description", "L": "L1"}
-            ]
+            "Requirements": [{"Shortcode": "V4.3.2", "Description": "Test description", "L": "L1"}]
         }
         mock_save.return_value = True
 
@@ -614,9 +570,7 @@ class TestMainFunction(unittest.TestCase):
             asvs_json="bad_asvs.json",
             debug=False,
         )
-        mock_load_yaml.return_value = {
-            "suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]
-        }
+        mock_load_yaml.return_value = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]}
         mock_load_json.return_value = {}
         mock_save.return_value = True
 
@@ -640,9 +594,7 @@ class TestMainFunction(unittest.TestCase):
             asvs_json=None,
             debug=False,
         )
-        mock_load.return_value = {
-            "suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]
-        }
+        mock_load.return_value = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]}
         mock_save.return_value = True
 
         capec_map.main()
@@ -655,9 +607,7 @@ class TestMainFunction(unittest.TestCase):
     @patch("scripts.convert_capec_map_to_asvs_map.load_yaml_file")
     @patch("scripts.convert_capec_map_to_asvs_map.parse_arguments")
     @patch("sys.exit")
-    def test_main_asvs_save_fails(
-        self, mock_exit, mock_parse_args, mock_load, mock_save
-    ):
+    def test_main_asvs_save_fails(self, mock_exit, mock_parse_args, mock_load, mock_save):
         """Test main when the second save (ASVS output) fails"""
         mock_parse_args.return_value = argparse.Namespace(
             input_path=Path("input.yaml"),
@@ -667,9 +617,7 @@ class TestMainFunction(unittest.TestCase):
             asvs_json=None,
             debug=False,
         )
-        mock_load.return_value = {
-            "suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]
-        }
+        mock_load.return_value = {"suits": [{"cards": [{"capec_map": {54: {"owasp_asvs": ["4.3.2"]}}}]}]}
         # First save succeeds, second save fails
         mock_save.side_effect = [True, False]
 
@@ -723,11 +671,7 @@ class TestExtractAsvsDetails(unittest.TestCase):
 
     def test_extract_simple_requirement(self):
         """Test extracting a single requirement"""
-        data = {
-            "Requirements": [
-                {"Shortcode": "V1.1.1", "Description": "Test req", "L": "L1"}
-            ]
-        }
+        data = {"Requirements": [{"Shortcode": "V1.1.1", "Description": "Test req", "L": "L1"}]}
         result = capec_map.extract_asvs_details(data)
         self.assertEqual(result, {"1.1.1": {"description": "Test req", "level": "L1"}})
 
@@ -746,25 +690,13 @@ class TestExtractAsvsDetails(unittest.TestCase):
 
     def test_extract_nested_structure(self):
         """Test extracting from nested structure"""
-        data = {
-            "chapter": {
-                "sections": [
-                    {
-                        "items": [
-                            {"Shortcode": "V3.3.3", "Description": "Nested", "L": "L3"}
-                        ]
-                    }
-                ]
-            }
-        }
+        data = {"chapter": {"sections": [{"items": [{"Shortcode": "V3.3.3", "Description": "Nested", "L": "L3"}]}]}}
         result = capec_map.extract_asvs_details(data)
         self.assertEqual(result, {"3.3.3": {"description": "Nested", "level": "L3"}})
 
     def test_extract_shortcode_without_v_prefix(self):
         """Test extracting requirement without V prefix"""
-        data = {
-            "Requirements": [{"Shortcode": "4.4.4", "Description": "No V", "L": "L1"}]
-        }
+        data = {"Requirements": [{"Shortcode": "4.4.4", "Description": "No V", "L": "L1"}]}
         result = capec_map.extract_asvs_details(data)
         self.assertEqual(result, {"4.4.4": {"description": "No V", "level": "L1"}})
 
@@ -800,9 +732,7 @@ class TestConvertToOutputFormatWithEnrichment(unittest.TestCase):
         """Test converting with enrichment data"""
         capec_map_data = {"1.1.1": {"4.3.2"}}
         enrichment = {"1.1.1": {"description": "Test desc", "level": "L1"}}
-        result = capec_map.convert_to_output_format(
-            capec_map_data, parameter="capec_codes", enrichment_data=enrichment
-        )
+        result = capec_map.convert_to_output_format(capec_map_data, parameter="capec_codes", enrichment_data=enrichment)
         self.assertIn("1.1.1", result)
         self.assertEqual(result["1.1.1"]["description"], "Test desc")
         self.assertEqual(result["1.1.1"]["level"], "L1")
@@ -812,9 +742,7 @@ class TestConvertToOutputFormatWithEnrichment(unittest.TestCase):
         """Test converting when enrichment data is missing for some keys"""
         capec_map_data = {"1.1.1": {"4.3.2"}, "2.2.2": {"5.5.5"}}
         enrichment = {"1.1.1": {"description": "Only first", "level": "L1"}}
-        result = capec_map.convert_to_output_format(
-            capec_map_data, parameter="capec_codes", enrichment_data=enrichment
-        )
+        result = capec_map.convert_to_output_format(capec_map_data, parameter="capec_codes", enrichment_data=enrichment)
         self.assertIn("description", result["1.1.1"])
         self.assertNotIn("description", result["2.2.2"])
 

--- a/tests/scripts/convert_capec_utest.py
+++ b/tests/scripts/convert_capec_utest.py
@@ -76,9 +76,7 @@ class TestValidateJsonData(unittest.TestCase):
         """Test validation with valid data structure"""
         data = {
             "Attack_Pattern_Catalog": {
-                "Attack_Patterns": {
-                    "Attack_Pattern": [{"_ID": "1", "_Name": "Test Pattern"}]
-                },
+                "Attack_Patterns": {"Attack_Pattern": [{"_ID": "1", "_Name": "Test Pattern"}]},
                 "Categories": {
                     "Category": [
                         {
@@ -154,11 +152,7 @@ class TestValidateJsonData(unittest.TestCase):
 
     def test_validate_json_data_attack_pattern_not_list(self):
         """Test validation when Attack_Pattern is not a list"""
-        data = {
-            "Attack_Pattern_Catalog": {
-                "Attack_Patterns": {"Attack_Pattern": "not a list"}
-            }
-        }
+        data = {"Attack_Pattern_Catalog": {"Attack_Patterns": {"Attack_Pattern": "not a list"}}}
         with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
             result = capec.validate_json_data(data)
         self.assertFalse(result)
@@ -191,9 +185,7 @@ class TestLoadJsonFile(unittest.TestCase):
         mock_file = mock_open(read_data="invalid json content {")
 
         with patch("builtins.open", mock_file):
-            with patch(
-                "json.load", side_effect=json.JSONDecodeError("Invalid", "doc", 0)
-            ):
+            with patch("json.load", side_effect=json.JSONDecodeError("Invalid", "doc", 0)):
                 with self.assertLogs(logging.getLogger(), logging.ERROR) as log:
                     result = capec.load_json_file(Path("/test/file.json"))
 
@@ -372,9 +364,7 @@ class TestCreateCapecPages(unittest.TestCase):
 
         with patch.object(Path, "parent") as mock_parent:
             mock_parent.resolve.return_value = Path("/mock/directory")
-            capec.create_capec_pages(
-                test_data, test_capec_to_asvs_map, test_asvs_map, "5.0"
-            )
+            capec.create_capec_pages(test_data, test_capec_to_asvs_map, test_asvs_map, "5.0")
 
         # Verify create_folder was called
         mock_create_folder.assert_called()
@@ -450,9 +440,7 @@ class TestCreateCapecPages(unittest.TestCase):
 
         with patch.object(Path, "parent") as mock_parent:
             mock_parent.resolve.return_value = Path("/mock/directory")
-            capec.create_capec_pages(
-                test_data, test_capec_to_asvs_map, test_asvs_map, "5.0"
-            )
+            capec.create_capec_pages(test_data, test_capec_to_asvs_map, test_asvs_map, "5.0")
 
         # Verify create_folder was called twice (once for each pattern)
         self.assertEqual(mock_create_folder.call_count, 3)
@@ -462,9 +450,7 @@ class TestCreateCapecPages(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open)
     @patch("scripts.convert_capec.create_folder")
-    def test_create_capec_pages_complex_description(
-        self, mock_create_folder, mock_file
-    ):
+    def test_create_capec_pages_complex_description(self, mock_create_folder, mock_file):
         """Test creating CAPEC pages with complex description format"""
         # Setup
         test_output_path = Path("/test/output")
@@ -479,11 +465,7 @@ class TestCreateCapecPages(unittest.TestCase):
                         {
                             "_ID": "456",
                             "_Name": "Complex Pattern",
-                            "Description": {
-                                "Description": {
-                                    "p": {"__text": "Complex description text"}
-                                }
-                            },
+                            "Description": {"Description": {"p": {"__text": "Complex description text"}}},
                         }
                     ]
                 },
@@ -516,9 +498,7 @@ class TestCreateCapecPages(unittest.TestCase):
 
         with patch.object(Path, "parent") as mock_parent:
             mock_parent.resolve.return_value = Path("/mock/directory")
-            capec.create_capec_pages(
-                test_data, test_capec_to_asvs_map, test_asvs_map, "5.0"
-            )
+            capec.create_capec_pages(test_data, test_capec_to_asvs_map, test_asvs_map, "5.0")
 
         # Get the written content
         handle = mock_file()
@@ -682,9 +662,7 @@ class TestCreatelink(unittest.TestCase):
                         {
                             "Ordinal": 1,
                             "Name": "General Authorization Design",
-                            "Items": [
-                                {"Shortcode": "V8.1.1", "Text": "Test requirement"}
-                            ],
+                            "Items": [{"Shortcode": "V8.1.1", "Text": "Test requirement"}],
                         }
                     ],
                 }
@@ -867,9 +845,7 @@ class TestCapecPagesWithAsvsMapping(unittest.TestCase):
 
         with patch.object(Path, "parent") as mock_parent:
             mock_parent.resolve.return_value = Path("/mock/directory")
-            capec.create_capec_pages(
-                test_data, test_capec_to_asvs_map, test_asvs_map, "5.0"
-            )
+            capec.create_capec_pages(test_data, test_capec_to_asvs_map, test_asvs_map, "5.0")
 
         handle = mock_file()
         written_content = "".join(call.args[0] for call in handle.write.call_args_list)

--- a/tests/scripts/convert_fuzzer.py
+++ b/tests/scripts/convert_fuzzer.py
@@ -64,9 +64,7 @@ def test_main(data):
 
     try:
         with patch.object(argparse, "ArgumentParser") as mock_parser:
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -97,9 +95,7 @@ def test_main(data):
                 "outputfile": "",
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -130,9 +126,7 @@ def test_main(data):
                 "outputfile": "",
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -163,9 +157,7 @@ def test_main(data):
                 "outputfile": "",
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -196,9 +188,7 @@ def test_main(data):
                 "outputfile": "",
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -229,9 +219,7 @@ def test_main(data):
                 "outputfile": "",
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -264,9 +252,7 @@ def test_main(data):
                 "outputfile": outputfile,
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()
@@ -297,9 +283,7 @@ def test_main(data):
                 "outputfile": "",
             }
 
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**argp)
             with test.assertLogs(logging.getLogger(), logging.DEBUG) as l6:
                 with patch("sys.argv", args):
                     c.main()

--- a/tests/scripts/convert_itest.py
+++ b/tests/scripts/convert_itest.py
@@ -71,9 +71,7 @@ class TestMain(unittest.TestCase):
     def test_main(self):
 
         with patch.object(argparse, "ArgumentParser") as mock_parser:
-            mock_parser.return_value.parse_args.return_value = argparse.Namespace(
-                **self.argp
-            )
+            mock_parser.return_value.parse_args.return_value = argparse.Namespace(**self.argp)
             with self.assertLogs(logging.getLogger(), logging.INFO) as l6:
                 with patch("sys.argv", self.args):
                     c.main()

--- a/tests/scripts/convert_utest.py
+++ b/tests/scripts/convert_utest.py
@@ -17,9 +17,7 @@ from typing import List, Dict, Any, Tuple
 import scripts.convert as c
 
 c.convert_vars = c.ConvertVars()
-c.convert_vars.BASE_PATH = os.path.split(os.path.dirname(os.path.realpath(c.__file__)))[
-    0
-]
+c.convert_vars.BASE_PATH = os.path.split(os.path.dirname(os.path.realpath(c.__file__)))[0]
 
 
 if "unittest.util" in __import__("sys").modules:
@@ -66,11 +64,7 @@ class MultiLingualSupportIsValidStringArgument(unittest.TestCase):
             )
         )
         # Arabic
-        self.assertTrue(
-            c.is_valid_string_argument(
-                "ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ "
-            )
-        )
+        self.assertTrue(c.is_valid_string_argument("ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ "))
         # European
         self.assertTrue(
             c.is_valid_string_argument(
@@ -224,10 +218,7 @@ class TestGetValidLanguagesChoices(unittest.TestCase):
 
 class TestSetCanConvertToPdf(unittest.TestCase):
     def test_set_can_convert_to_pdf(self) -> None:
-        want_can_convert_in = (
-            sys.platform.lower().find("win") != -1
-            or sys.platform.lower().find("darwin") != -1
-        )
+        want_can_convert_in = sys.platform.lower().find("win") != -1 or sys.platform.lower().find("darwin") != -1
 
         c.set_can_convert_to_pdf()
         got_can_convert = c.convert_vars.can_convert_to_pdf
@@ -400,9 +391,7 @@ class TestGetTemplateForEdition(unittest.TestCase):
 
     def test_get_template_for_edition_file_not_exist(self) -> None:
         template_docx_filename = os.path.normpath(
-            os.path.join(
-                "resources", "templates", "owasp_cornucopia_template_template.docx"
-            )
+            os.path.join("resources", "templates", "owasp_cornucopia_template_template.docx")
         )
         c.convert_vars.args.inputfile = template_docx_filename
         layout = "guide"
@@ -410,8 +399,7 @@ class TestGetTemplateForEdition(unittest.TestCase):
         edition = "webapp"
         want_template_doc = "None"
         want_error_log_messages = [
-            f"ERROR:root:Source file not found: {template_docx_filename}. "
-            "Please ensure file exists and try again."
+            f"ERROR:root:Source file not found: {template_docx_filename}. " "Please ensure file exists and try again."
         ]
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as ll:
@@ -422,9 +410,7 @@ class TestGetTemplateForEdition(unittest.TestCase):
 
 class TestRenameOutputFile(unittest.TestCase):
     def setUp(self) -> None:
-        c.convert_vars.args = argparse.Namespace(
-            outputfile=c.convert_vars.DEFAULT_OUTPUT_FILENAME
-        )
+        c.convert_vars.args = argparse.Namespace(outputfile=c.convert_vars.DEFAULT_OUTPUT_FILENAME)
         self.input_meta_data = {
             "edition": "webapp",
             "component": "cards",
@@ -436,35 +422,23 @@ class TestRenameOutputFile(unittest.TestCase):
         c.convert_vars.args.outputfile = ""
 
     def test_rename_output_file_short(self) -> None:
-        c.convert_vars.args.outputfile = os.path.join(
-            "output", "cornucopia_edition_ver_layout_lang.docx"
-        )
+        c.convert_vars.args.outputfile = os.path.join("output", "cornucopia_edition_ver_layout_lang.docx")
         file_extension = ".docx"
         template = "bridge"
         layout = "guide"
-        want_filename = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "cornucopia_webapp_3.0_guide_en.docx"
-        )
+        want_filename = os.path.join(c.convert_vars.BASE_PATH, "output", "cornucopia_webapp_3.0_guide_en.docx")
 
-        got_filename = c.rename_output_file(
-            file_extension, template, layout, self.input_meta_data
-        )
+        got_filename = c.rename_output_file(file_extension, template, layout, self.input_meta_data)
         self.assertEqual(want_filename, got_filename)
 
     def test_rename_output_file_no_extension(self) -> None:
-        c.convert_vars.args.outputfile = (
-            "output" + os.sep + "cornucopia_edition_ver_layout_lang"
-        )
+        c.convert_vars.args.outputfile = "output" + os.sep + "cornucopia_edition_ver_layout_lang"
         file_extension = ".idml"
         template = "bridge"
         layout = "guide"
-        want_filename = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "cornucopia_webapp_3.0_guide_en.idml"
-        )
+        want_filename = os.path.join(c.convert_vars.BASE_PATH, "output", "cornucopia_webapp_3.0_guide_en.idml")
 
-        got_filename = c.rename_output_file(
-            file_extension, template, layout, self.input_meta_data
-        )
+        got_filename = c.rename_output_file(file_extension, template, layout, self.input_meta_data)
         self.assertEqual(want_filename, got_filename)
 
     def test_rename_output_file_using_defaults(self) -> None:
@@ -478,9 +452,7 @@ class TestRenameOutputFile(unittest.TestCase):
             "owasp_cornucopia_webapp_3.0_guide_bridge_en.docx",
         )
 
-        got_filename = c.rename_output_file(
-            file_extension, template, layout, self.input_meta_data
-        )
+        got_filename = c.rename_output_file(file_extension, template, layout, self.input_meta_data)
         self.assertEqual(want_filename, got_filename)
 
     def test_rename_output_file_blank(self) -> None:
@@ -494,9 +466,7 @@ class TestRenameOutputFile(unittest.TestCase):
             "owasp_cornucopia_webapp_3.0_guide_bridge_en.docx",
         )
 
-        got_filename = c.rename_output_file(
-            file_extension, template, layout, self.input_meta_data
-        )
+        got_filename = c.rename_output_file(file_extension, template, layout, self.input_meta_data)
         self.assertEqual(want_filename, got_filename)
 
     def test_rename_output_file_template(self) -> None:
@@ -510,9 +480,7 @@ class TestRenameOutputFile(unittest.TestCase):
             "owasp_cornucopia_webapp_3.0_guide_bridge_en.docx",
         )
 
-        got_filename = c.rename_output_file(
-            file_extension, template, layout, self.input_meta_data
-        )
+        got_filename = c.rename_output_file(file_extension, template, layout, self.input_meta_data)
         self.assertEqual(want_filename, got_filename)
 
 
@@ -558,9 +526,7 @@ class TestValidMeta(unittest.TestCase):
             "-> languages section in the mappings file"
         )
         with self.assertLogs(logging.getLogger(), logging.WARNING) as ll:
-            valid: bool = c.valid_meta(
-                self.meta, "fr", "webapp", "3.0", "bridge", "cards"
-            )
+            valid: bool = c.valid_meta(self.meta, "fr", "webapp", "3.0", "bridge", "cards")
         self.assertFalse(valid)
         self.assertIn(want_logging_error_message, " ".join(ll.output))
 
@@ -611,9 +577,7 @@ class TestGetMetaData(unittest.TestCase):
         input_data = self.test_data.copy()
         del input_data["meta"]
         want_data: Dict[str, str] = {}
-        want_logging_error_message = [
-            "ERROR:root:Could not find meta tag in the language data."
-        ]
+        want_logging_error_message = ["ERROR:root:Could not find meta tag in the language data."]
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as ll:
             got_data = c.get_meta_data(input_data)
@@ -623,9 +587,7 @@ class TestGetMetaData(unittest.TestCase):
 
 class TestGetLanguageData(unittest.TestCase):
     def setUp(self) -> None:
-        test_source_yaml = os.path.join(
-            c.convert_vars.BASE_PATH, "tests", "test_files", "source", "*.yaml"
-        )
+        test_source_yaml = os.path.join(c.convert_vars.BASE_PATH, "tests", "test_files", "source", "*.yaml")
         self.input_yaml_files = glob.glob(test_source_yaml)
         self.input_language = "en"
         self.test_data: Dict[str, Any] = {
@@ -696,19 +658,13 @@ class TestGetLanguageData(unittest.TestCase):
         want_first_suit_first_card_keys = self.test_data["suits"][0]["cards"][0].keys()
         want_first_suit_first_card_value = self.test_data["suits"][0]["cards"][0]["id"]
 
-        got_suits = c.get_language_data(self.input_yaml_files, self.input_language)[
-            "suits"
-        ]
+        got_suits = c.get_language_data(self.input_yaml_files, self.input_language)["suits"]
         got_first_suit_keys = got_suits[0].keys()
         self.assertEqual(want_first_suit_keys, got_first_suit_keys)
         got_first_suit_first_card_keys = got_suits[0]["cards"][0].keys()
-        self.assertEqual(
-            want_first_suit_first_card_keys, got_first_suit_first_card_keys
-        )
+        self.assertEqual(want_first_suit_first_card_keys, got_first_suit_first_card_keys)
         got_first_suit_first_card_value = got_suits[0]["cards"][0]["id"]
-        self.assertEqual(
-            want_first_suit_first_card_value, got_first_suit_first_card_value
-        )
+        self.assertEqual(want_first_suit_first_card_value, got_first_suit_first_card_value)
 
     def test_get_language_data_translation_es_first_suit_first_card(self) -> None:
         want_first_suit_keys = self.test_data["suits"][0].keys()
@@ -719,13 +675,9 @@ class TestGetLanguageData(unittest.TestCase):
         got_first_suit_keys = got_suits[0].keys()
         self.assertEqual(want_first_suit_keys, got_first_suit_keys)
         got_first_suit_first_card_keys = got_suits[0]["cards"][0].keys()
-        self.assertEqual(
-            want_first_suit_first_card_keys, got_first_suit_first_card_keys
-        )
+        self.assertEqual(want_first_suit_first_card_keys, got_first_suit_first_card_keys)
         got_first_suit_first_card_value = got_suits[0]["cards"][0]["id"]
-        self.assertEqual(
-            want_first_suit_first_card_value, got_first_suit_first_card_value
-        )
+        self.assertEqual(want_first_suit_first_card_value, got_first_suit_first_card_value)
 
     def test_get_mapping_data_for_edition(self) -> None:
         want_meta = {
@@ -737,9 +689,7 @@ class TestGetLanguageData(unittest.TestCase):
             "layouts": ["cards", "leaflet", "guide"],
             "templates": ["bridge_qr", "bridge", "tarot", "tarot_qr"],
         }
-        got_data = c.get_mapping_data_for_edition(
-            self.input_yaml_files, self.input_language, "3.0", "webapp"
-        )
+        got_data = c.get_mapping_data_for_edition(self.input_yaml_files, self.input_language, "3.0", "webapp")
         self.assertEqual(want_meta, got_data["meta"])
 
     def test_get_mapping_data_for_edition_first_suit_first_card(self) -> None:
@@ -942,9 +892,7 @@ class TestGetLanguageData(unittest.TestCase):
             },
         }
 
-        got_suits = c.get_mapping_data_for_edition(
-            self.input_yaml_files, self.input_language
-        )["suits"]
+        got_suits = c.get_mapping_data_for_edition(self.input_yaml_files, self.input_language)["suits"]
         got_first_suit_keys = got_suits[0].keys()
         self.assertEqual(want_first_suit_keys, got_first_suit_keys)
         got_first_suit_first_card = got_suits[0]["cards"][0]
@@ -953,9 +901,7 @@ class TestGetLanguageData(unittest.TestCase):
 
 class TestGetLanguageDataFor1dot30(unittest.TestCase):
     def setUp(self) -> None:
-        test_source_yaml = os.path.join(
-            c.convert_vars.BASE_PATH, "tests", "test_files", "source", "*.yaml"
-        )
+        test_source_yaml = os.path.join(c.convert_vars.BASE_PATH, "tests", "test_files", "source", "*.yaml")
         self.input_yaml_files = glob.glob(test_source_yaml)
         self.input_language = "en"
         self.input_version = "3.0"
@@ -1013,9 +959,7 @@ class TestGetLanguageDataFor1dot30(unittest.TestCase):
             "version": "3.0",
         }
 
-        got_data = c.get_language_data(
-            self.input_yaml_files, self.input_language, self.input_version
-        )
+        got_data = c.get_language_data(self.input_yaml_files, self.input_language, self.input_version)
         self.assertEqual(want_meta, got_data["meta"])
 
     def test_get_language_data_translation_en_first_suit_first_card(self) -> None:
@@ -1023,19 +967,13 @@ class TestGetLanguageDataFor1dot30(unittest.TestCase):
         want_first_suit_first_card_keys = self.test_data["suits"][0]["cards"][0].keys()
         want_first_suit_first_card_value = self.test_data["suits"][0]["cards"][0]["id"]
 
-        got_suits = c.get_language_data(
-            self.input_yaml_files, self.input_language, self.input_version
-        )["suits"]
+        got_suits = c.get_language_data(self.input_yaml_files, self.input_language, self.input_version)["suits"]
         got_first_suit_keys = got_suits[0].keys()
         self.assertEqual(want_first_suit_keys, got_first_suit_keys)
         got_first_suit_first_card_keys = got_suits[0]["cards"][0].keys()
-        self.assertEqual(
-            want_first_suit_first_card_keys, got_first_suit_first_card_keys
-        )
+        self.assertEqual(want_first_suit_first_card_keys, got_first_suit_first_card_keys)
         got_first_suit_first_card_value = got_suits[0]["cards"][0]["id"]
-        self.assertEqual(
-            want_first_suit_first_card_value, got_first_suit_first_card_value
-        )
+        self.assertEqual(want_first_suit_first_card_value, got_first_suit_first_card_value)
 
     def test_get_language_data_translation_es_first_suit_first_card(self) -> None:
         input_language = "es"
@@ -1043,19 +981,13 @@ class TestGetLanguageDataFor1dot30(unittest.TestCase):
         want_first_suit_first_card_keys = self.test_data["suits"][0]["cards"][0].keys()
         want_first_suit_first_card_value = self.test_data["suits"][0]["cards"][0]["id"]
 
-        got_suits = c.get_language_data(
-            self.input_yaml_files, input_language, self.input_version
-        )["suits"]
+        got_suits = c.get_language_data(self.input_yaml_files, input_language, self.input_version)["suits"]
         got_first_suit_keys = got_suits[0].keys()
         self.assertEqual(want_first_suit_keys, got_first_suit_keys)
         got_first_suit_first_card_keys = got_suits[0]["cards"][0].keys()
-        self.assertEqual(
-            want_first_suit_first_card_keys, got_first_suit_first_card_keys
-        )
+        self.assertEqual(want_first_suit_first_card_keys, got_first_suit_first_card_keys)
         got_first_suit_first_card_value = got_suits[0]["cards"][0]["id"]
-        self.assertEqual(
-            want_first_suit_first_card_value, got_first_suit_first_card_value
-        )
+        self.assertEqual(want_first_suit_first_card_value, got_first_suit_first_card_value)
 
     def test_get_mapping_data_for_edition_asvs4(self) -> None:
         want_meta = {
@@ -1067,9 +999,7 @@ class TestGetLanguageDataFor1dot30(unittest.TestCase):
             "templates": ["bridge_qr", "bridge", "tarot", "tarot_qr"],
             "languages": ["en", "es"],
         }
-        got_data = c.get_mapping_data_for_edition(
-            self.input_yaml_files, self.input_language, self.input_version
-        )
+        got_data = c.get_mapping_data_for_edition(self.input_yaml_files, self.input_language, self.input_version)
         self.assertEqual(want_meta, got_data["meta"])
 
     def test_get_mapping_data_for_edition_first_suit_first_card_asvs4(self) -> None:
@@ -1272,9 +1202,9 @@ class TestGetLanguageDataFor1dot30(unittest.TestCase):
             },
         }
 
-        got_suits = c.get_mapping_data_for_edition(
-            self.input_yaml_files, self.input_language, self.input_version
-        )["suits"]
+        got_suits = c.get_mapping_data_for_edition(self.input_yaml_files, self.input_language, self.input_version)[
+            "suits"
+        ]
         got_first_suit_keys = got_suits[0].keys()
         self.assertEqual(want_first_suit_keys, got_first_suit_keys)
         got_first_suit_first_card = got_suits[0]["cards"][0]
@@ -1390,13 +1320,9 @@ class TestGetFilesFromOfType(unittest.TestCase):
 
     def test_get_files_from_of_type_source_docx_files(self) -> None:
         c.convert_vars.args = argparse.Namespace(debug=False)
-        path = os.path.join(
-            c.convert_vars.BASE_PATH, "tests", "test_files", "resources", "templates"
-        )
+        path = os.path.join(c.convert_vars.BASE_PATH, "tests", "test_files", "resources", "templates")
         ext = "docx"
-        want_files = [
-            path + os.sep + "owasp_cornucopia_webapp_ver_guide_bridge_lang.docx"
-        ]
+        want_files = [path + os.sep + "owasp_cornucopia_webapp_ver_guide_bridge_lang.docx"]
 
         got_files = c.get_files_from_of_type(path, ext)
         self.assertEqual(len(want_files), len(got_files))
@@ -1409,8 +1335,7 @@ class TestGetFilesFromOfType(unittest.TestCase):
         ext = "ext"
         want_files: typing.List[str] = []
         want_logging_error_message = [
-            "ERROR:root:No language files found in folder: "
-            + str(os.path.join(c.convert_vars.BASE_PATH, "source"))
+            "ERROR:root:No language files found in folder: " + str(os.path.join(c.convert_vars.BASE_PATH, "source"))
         ]
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as ll:
@@ -1601,9 +1526,7 @@ class TestConvertDocxToPdf(unittest.TestCase):
             "test_files",
             "owasp_cornucopia_webapp_ver_guide_bridge_lang.docx",
         )
-        want_pdf_filename = os.path.join(
-            c.convert_vars.BASE_PATH, "tests", "test_files", "test.pdf"
-        )
+        want_pdf_filename = os.path.join(c.convert_vars.BASE_PATH, "tests", "test_files", "test.pdf")
         # The message varies by platform - Windows/Mac get MS Word suggestion, Linux doesn't
         base_msg = (
             f"WARNING:root:Error. A temporary file {input_docx_filename} was created in the output folder "
@@ -1671,36 +1594,24 @@ class TestGetMappingForEdition(unittest.TestCase):
             "${VE_VE3_owasp_cre}": "{'owasp_asvs': ['848-711', '743-237', '042-550', '031-447', '532-878', '314-131', '036-725']}",  # noqa: E501
         }
 
-        got_mapping_dict = c.get_mapping_for_edition(
-            input_yaml_files, "3.0", "en", "webapp", "bridge", "cards"
-        )
+        got_mapping_dict = c.get_mapping_for_edition(input_yaml_files, "3.0", "en", "webapp", "bridge", "cards")
         self.assertDictEqual(want_mapping_dict, got_mapping_dict)
 
     def test_get_mapping_for_edition_empty(self) -> None:
-        input_yaml_files = [
-            os.path.join(self.BASE_PATH, "source", "webapp-cards-3.0-en.yaml")
-        ]
+        input_yaml_files = [os.path.join(self.BASE_PATH, "source", "webapp-cards-3.0-en.yaml")]
         want_mapping_dict: Dict[str, str] = {}
 
         with self.assertLogs(logging.getLogger(), logging.WARN) as ll:
-            got_mapping_dict = c.get_mapping_for_edition(
-                input_yaml_files, "3.0", "en", "webapp", "bridge", "cards"
-            )
+            got_mapping_dict = c.get_mapping_for_edition(input_yaml_files, "3.0", "en", "webapp", "bridge", "cards")
         self.assertIn("WARNING:root:No mapping file found", " ".join(ll.output))
         self.assertDictEqual(want_mapping_dict, got_mapping_dict)
 
     def test_get_mapping_for_edition_wrong_file_type(self) -> None:
-        input_yaml_files = [
-            os.path.join(
-                self.BASE_PATH, "resources", "originals", "owasp_cornucopia_en.docx"
-            )
-        ]
+        input_yaml_files = [os.path.join(self.BASE_PATH, "resources", "originals", "owasp_cornucopia_en.docx")]
         want_mapping_dict: Dict[str, str] = {}
 
         with self.assertLogs(logging.getLogger(), logging.WARN) as ll:
-            got_mapping_dict = c.get_mapping_for_edition(
-                input_yaml_files, "3.0", "en", "webapp", "bridge", "cards"
-            )
+            got_mapping_dict = c.get_mapping_for_edition(input_yaml_files, "3.0", "en", "webapp", "bridge", "cards")
         self.assertIn("WARNING:root:No mapping file found", " ".join(ll.output))
         self.assertDictEqual(want_mapping_dict, got_mapping_dict)
 
@@ -1733,9 +1644,7 @@ class TestcreateEditionFromTemplate(unittest.TestCase):
             os.remove(self.temp_file)
 
     def test_create_edition_from_template_none_valid_input(self) -> None:
-        self.want_file = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "owasp_cornucopia_webapp_invalid.docx"
-        )
+        self.want_file = os.path.join(c.convert_vars.BASE_PATH, "output", "owasp_cornucopia_webapp_invalid.docx")
         if os.path.isfile(self.want_file):
             os.remove(self.want_file)
 
@@ -1748,18 +1657,14 @@ class TestcreateEditionFromTemplate(unittest.TestCase):
         )
 
     def test_create_edition_from_template_wrong_base_path(self) -> None:
-        c.convert_vars.BASE_PATH = (
-            os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
-            + "invalidpath"
-        )
+        c.convert_vars.BASE_PATH = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0] + "invalidpath"
         if os.path.isfile(self.want_file):
             os.remove(self.want_file)
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as l2:
             c.create_edition_from_template("invalid", "invalid", "invalid", "invalid")
         self.assertIn(
-            "ERROR:root:No language files found in folder: "
-            + str(os.path.join(c.convert_vars.BASE_PATH, "source")),
+            "ERROR:root:No language files found in folder: " + str(os.path.join(c.convert_vars.BASE_PATH, "source")),
             " ".join(l2.output),
         )
 
@@ -1863,9 +1768,7 @@ class TestcreateEditionFromTemplate(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), logging.INFO) as ll:
             c.create_edition_from_template("guide", "es")
         self.assertIn("INFO:root:New file saved:", " ".join(ll.output))
-        self.assertIn(
-            "owasp_cornucopia_webapp_3.0_guide_bridge_es.odt", " ".join(ll.output)
-        )
+        self.assertIn("owasp_cornucopia_webapp_3.0_guide_bridge_es.odt", " ".join(ll.output))
 
         self.assertTrue(os.path.isfile(want_file))
 
@@ -1882,18 +1785,12 @@ class TestcreateEditionFromTemplate(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), logging.INFO) as ll:
             c.create_edition_from_template("cards", "en")
         self.assertIn("INFO:root:New file saved:", " ".join(ll.output))
-        self.assertIn(
-            "owasp_cornucopia_webapp_3.0_cards_bridge_en.idml", " ".join(ll.output)
-        )
+        self.assertIn("owasp_cornucopia_webapp_3.0_cards_bridge_en.idml", " ".join(ll.output))
         self.assertTrue(os.path.isfile(self.want_file))
 
     def test_create_edition_from_template_es_specify_output(self) -> None:
-        c.convert_vars.args.outputfile = os.path.join(
-            "output", "cornucopia_cards_es.idml"
-        )
-        self.want_file = os.path.join(
-            c.convert_vars.BASE_PATH, c.convert_vars.args.outputfile
-        )
+        c.convert_vars.args.outputfile = os.path.join("output", "cornucopia_cards_es.idml")
+        self.want_file = os.path.join(c.convert_vars.BASE_PATH, c.convert_vars.args.outputfile)
         if os.path.isfile(self.want_file):
             os.remove(self.want_file)
 
@@ -1978,9 +1875,7 @@ class TestSaveDocxFile(unittest.TestCase):
             "owasp_cornucopia_en_static.docx",
         )
         input_doc = docx.Document(filename)
-        self.want_file = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "owasp_cornucopia_en_static.docx"
-        )
+        self.want_file = os.path.join(c.convert_vars.BASE_PATH, "output", "owasp_cornucopia_en_static.docx")
         if os.path.isfile(self.want_file):
             os.remove(self.want_file)
 
@@ -2006,9 +1901,7 @@ Development Environments in July 2012.",
         }
         self.b = c.convert_vars.BASE_PATH
         c.convert_vars.BASE_PATH = os.path.join(self.b, "tests", "test_files")
-        self.input_xml_file = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml"
-        )
+        self.input_xml_file = os.path.join(c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml")
         if not os.path.exists(os.path.dirname(self.input_xml_file)):
             os.makedirs(os.path.dirname(self.input_xml_file))
         if os.path.isfile(self.input_xml_file):
@@ -2058,9 +1951,7 @@ Development Environments in July 2012.",
         }
         self.b = c.convert_vars.BASE_PATH
         c.convert_vars.BASE_PATH = os.path.join(self.b, "tests", "test_files")
-        self.input_xml_file = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml"
-        )
+        self.input_xml_file = os.path.join(c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml")
         if not os.path.exists(os.path.dirname(self.input_xml_file)):
             os.makedirs(os.path.dirname(self.input_xml_file))
         if os.path.isfile(self.input_xml_file):
@@ -2102,9 +1993,7 @@ class TestReplaceTextInXmlFile(unittest.TestCase):
         }
         self.b = c.convert_vars.BASE_PATH
         c.convert_vars.BASE_PATH = os.path.join(self.b, "tests", "test_files")
-        self.input_xml_file = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml"
-        )
+        self.input_xml_file = os.path.join(c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml")
         if not os.path.exists(os.path.dirname(self.input_xml_file)):
             os.makedirs(os.path.dirname(self.input_xml_file))
         if os.path.isfile(self.input_xml_file):
@@ -2140,9 +2029,7 @@ class TestReplaceTextInXmlFileFail(unittest.TestCase):
         self.input_dict = {}
         self.b = c.convert_vars.BASE_PATH
         c.convert_vars.BASE_PATH = os.path.join(self.b, "tests", "test_files")
-        self.input_xml_file = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml"
-        )
+        self.input_xml_file = os.path.join(c.convert_vars.BASE_PATH, "output", "temp", "Stories", "Story_u8fb5.xml")
         if not os.path.exists(os.path.dirname(self.input_xml_file)):
             os.makedirs(os.path.dirname(self.input_xml_file))
         if os.path.isfile(self.input_xml_file):
@@ -2163,9 +2050,7 @@ class TestReplaceTextInXmlFileFail(unittest.TestCase):
 </ParagraphStyleRange>"""
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as ll:
-            c.replace_text_in_xml_file(
-                self.input_xml_file, list(self.input_dict.items())
-            )
+            c.replace_text_in_xml_file(self.input_xml_file, list(self.input_dict.items()))
         self.assertIn(
             "ERROR:root:Failed to parse XML file",
             ll.output.pop(),
@@ -2194,24 +2079,16 @@ class Test1(unittest.TestCase):
 
     def test_get_replacement_value_from_dict_exact(self) -> None:
         input_text = "${VE_VE2_desc}"
-        want_data = (
-            "You have invented a new attack against Data Validation and Encoding"
-        )
+        want_data = "You have invented a new attack against Data Validation and Encoding"
 
-        got_data = c.get_replacement_value_from_dict(
-            input_text, self.replacement_values
-        )
+        got_data = c.get_replacement_value_from_dict(input_text, self.replacement_values)
         self.assertEqual(want_data, got_data)
 
     def test_get_replacement_value_from_dict_spaced(self) -> None:
         input_text = " ${VE_VE2_desc} "
-        want_data = (
-            " You have invented a new attack against Data Validation and Encoding "
-        )
+        want_data = " You have invented a new attack against Data Validation and Encoding "
 
-        got_data = c.get_replacement_value_from_dict(
-            input_text, self.replacement_values
-        )
+        got_data = c.get_replacement_value_from_dict(input_text, self.replacement_values)
         self.assertEqual(want_data, got_data)
 
 
@@ -2382,9 +2259,7 @@ class TestZipDir(unittest.TestCase):
     def setUp(self) -> None:
         self.b = c.convert_vars.BASE_PATH
         c.convert_vars.BASE_PATH = os.path.join(self.b, "tests", "test_files")
-        self.input_filename = os.path.join(
-            c.convert_vars.BASE_PATH, "output", "test.zip"
-        )
+        self.input_filename = os.path.join(c.convert_vars.BASE_PATH, "output", "test.zip")
 
     def tearDown(self) -> None:
         if os.path.isfile(self.input_filename):

--- a/tests/scripts/smoke_tests.py
+++ b/tests/scripts/smoke_tests.py
@@ -43,9 +43,7 @@ class CopiSmokeTests(unittest.TestCase):
             200,
             f"Homepage returned status {response.status_code}",
         )
-        self.assertIn(
-            "copi", response.text.lower(), "Homepage should contain 'copi' text"
-        )
+        self.assertIn("copi", response.text.lower(), "Homepage should contain 'copi' text")
 
     def test_02_cards_route_accessible(self) -> None:
         """Test that the cards route is accessible"""
@@ -62,9 +60,7 @@ class CopiSmokeTests(unittest.TestCase):
         response = self._make_request(self.BASE_URL)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(
-            "<script" in response.text
-            or "app.js" in response.text
-            or "phoenix" in response.text.lower(),
+            "<script" in response.text or "app.js" in response.text or "phoenix" in response.text.lower(),
             "JavaScript should be loaded on the page",
         )
 

--- a/tests/test_files/gen_mappings.py
+++ b/tests/test_files/gen_mappings.py
@@ -22,9 +22,7 @@ def make_cre_link(cre_id: str, frontend: bool = False) -> str:
         return f"{opencre_rest_url}/id/{cre_id}"
 
 
-def produce_webapp_mappings(
-    source_file: Dict[Any, Any], standards_to_add: list[str]
-) -> Dict[Any, Any]:
+def produce_webapp_mappings(source_file: Dict[Any, Any], standards_to_add: list[str]) -> Dict[Any, Any]:
     base = {
         "meta": {
             "edition": "webapp",
@@ -42,8 +40,8 @@ def produce_webapp_mappings(
                 for standard in standards_to_add:
                     for link in cre_object.get("links"):
                         if link.get("document").get("name") == standard:
-                            source_file["suits"][indx]["cards"][card_indx][standard] = (
-                                link.get("document").get("sectionID")
+                            source_file["suits"][indx]["cards"][card_indx][standard] = link.get("document").get(
+                                "sectionID"
                             )
             else:
                 print(f"could not find CRE {cre}, status code {response.status_code}")
@@ -72,9 +70,7 @@ def main() -> None:
         help="Where to find the file mapping cornucopia to CREs",
         required=True,
     )
-    parser.add_argument(
-        "-t", "--target", help="Path where to store the result", required=True
-    )
+    parser.add_argument("-t", "--target", help="Path where to store the result", required=True)
     parser.add_argument(
         "-s",
         "--staging",


### PR DESCRIPTION
Fixes #2603

The card route loader previously used hardcoded version mappings:

* webapp → 2.2
* mobileapp → 1.1
* other → 1.0

This PR replaces the hardcoded logic with `DeckService.getLatestVersion(edition)`, aligning it with the implementation already used in `src/routes/edition/[edition]/+page.server.ts`.

This removes hardcoded version handling and ensures both routes resolve edition versions consistently.
