### PR TITLE
Fix crash on empty YAML files in convert.py

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -636,8 +636,8 @@ def get_mapping_data_for_edition(
     with open(mappingfile, "r", encoding="utf-8") as f:
         try:
             data = yaml.safe_load(f)
-            # Handle empty/null YAML files
-            if data is None:
+            # Handle empty/null YAML files and validate it's a dict
+            if not isinstance(data, dict):
                 data = {}
         except yaml.YAMLError as e:
             logging.info(f"Error loading yaml file: {mappingfile}. Error = {e}")
@@ -740,8 +740,8 @@ def get_language_data(
     with open(language_file, "r", encoding="utf-8") as f:
         try:
             data = yaml.safe_load(f)
-            # Handle empty/null YAML files
-            if data is None:
+            # Handle empty/null YAML files and validate it's a dict
+            if not isinstance(data, dict):
                 data = {}
         except yaml.YAMLError as e:
             logging.error(f"Error loading yaml file: {language_file}. Error = {e}")


### PR DESCRIPTION
- Add null checks after yaml.safe_load() calls
- Prevent AttributeError when data is None
- Handle both empty files and explicit null content
- Protect build system from crashing on empty YAML files

Fixes issue where empty YAML files in source/ directory would cause: AttributeError: 'NoneType' object has no attribute 'keys'