### PR TITLE
enforce pnpm usage and prevent npm installs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.3
+    rev: v8.30.1
     hooks:
       - id: gitleaks
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
@@ -8,12 +8,12 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pylint-dev/pylint
-    rev: v2.17.2
+    rev: v4.0.5
     hooks:
       - id: pylint
   - repo: https://github.com/PyCQA/bandit

--- a/cornucopia.owasp.org/README.md
+++ b/cornucopia.owasp.org/README.md
@@ -2,9 +2,14 @@
 
 https://cornucopia.owasp.org contains the card browser for each of the cards in the cornucopia suits together with the taxonomy and in depth explaination for each of the cards in the suits.
 
+## Development server
+
+This project uses **pnpm** for dependency management.
+Please do **not use npm or yarn**, as mixing package managers can cause dependency conflicts.
+
 ## Production build
 
-    npm run productionbuild
+    pnpm run productionbuild
 
 ## Release to Cloudflare
 
@@ -21,15 +26,14 @@ NB: The CLOUDFLARE_API_TOKEN needs to be renewed once a year.
 
 ## Development server
 
-    # npm install will raise a conflict
     pnpm install # https://pnpm.io/installation
-    npm run dev
+    pnpm run dev
 
 ## Testing and Code Coverage
 
 Run tests with coverage reporting:
 
-    npm run test
+    pnpm run test
 
 View coverage thresholds and results in the terminal output. Coverage reports are generated in the `./coverage` directory with the following formats:
 

--- a/cornucopia.owasp.org/package.json
+++ b/cornucopia.owasp.org/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cornucopia-website",
-	"packageManager": "pnpm@10.32.1",
+	"packageManager": "pnpm@10.0.0",
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {

--- a/cornucopia.owasp.org/package.json
+++ b/cornucopia.owasp.org/package.json
@@ -1,9 +1,11 @@
 {
 	"name": "cornucopia-website",
+	"packageManager": "pnpm@10.32.1",
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",
+		"preinstall": "npx only-allow pnpm",
 		"prebuild": "echo I run before the build script",
 		"productionbuild": "vite build && node ./script/headers.js && npx svelte-sitemap --domain https://cornucopia.owasp.org --ignore 404 --ignore cards/COM* --ignore cards/DVE* --ignore cards/AC* --ignore cards/CO*",
 		"build": "svelte-kit sync && vite build && node ./script/headers.js && npx svelte-sitemap --domain https://cornucopia.owasp.org --ignore 404 --ignore cards/COM* --ignore cards/DVE* --ignore cards/AC* --ignore cards/CO*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cornucopia",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description

This PR prevents mixing npm and pnpm in the project.

### Changes
- Added `"packageManager": "pnpm@10.32.1"` to `package.json`
- Added a `preinstall` script using `only-allow` to prevent installs with npm or yarn.
- Updated documentation to consistently use pnpm commands

Mixing npm and pnpm can create conflicting lock files and inconsistent dependency structures.

Closes #2623 