### PR TITLE
Fix: authorization check in toggle_vote to prevent cross-game voting

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -131,26 +131,36 @@ defmodule CopiWeb.PlayerLive.Show do
 
     {:ok, dealt_card} = DealtCard.find(dealt_card_id)
 
-    vote = get_vote(dealt_card, player)
+    game_card_ids =
+      game.players
+      |> Enum.flat_map(fn p -> p.dealt_cards end)
+      |> Enum.map(fn dc -> dc.id end)
 
-    if vote do
-      Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-      Copi.Repo.delete!(vote)
+    if dealt_card.id not in game_card_ids do
+      Logger.warning("Unauthorized vote attempt: player_id: #{player.id}, dealt_card_id: #{dealt_card_id} does not belong to game_id: #{game.id}")
+      {:noreply, socket}
     else
-      Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-      case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
-        {:ok, _vote} ->
-          Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-        {:error, changeset} ->
-          Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+      vote = get_vote(dealt_card, player)
+
+      if vote do
+        Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+        Copi.Repo.delete!(vote)
+      else
+        Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+        case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
+          {:ok, _vote} ->
+            Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+          {:error, changeset} ->
+            Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+        end
       end
+
+      {:ok, updated_game} = Game.find(game.id)
+
+      CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
+
+      {:noreply, assign(socket, :game, updated_game)}
     end
-
-    {:ok, updated_game} = Game.find(game.id)
-
-    CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
-
-    {:noreply, assign(socket, :game, updated_game)}
   end
 
   def topic(game_id) do

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -286,5 +286,39 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, updated_dealt2} = Copi.Cornucopia.DealtCard.find(to_string(dealt.id))
       assert length(updated_dealt2.votes) == 0
     end
+
+    test "toggle_vote rejects vote on a dealt card from another game", %{conn: conn, player: player} do
+      game_id = player.game_id
+      {:ok, game} = Cornucopia.Game.find(game_id)
+
+      Copi.Repo.update!(
+        Ecto.Changeset.change(game, started_at: DateTime.truncate(DateTime.utc_now(), :second))
+      )
+
+      # Create a second game with its own player and dealt card
+      {:ok, other_game} = Cornucopia.create_game(%{name: "other game"})
+      {:ok, other_player} = Cornucopia.create_player(%{name: "Other Player", game_id: other_game.id})
+
+      {:ok, card} =
+        Cornucopia.create_card(%{
+          category: "C", value: "TV2", description: "D", edition: "webapp",
+          version: "2.2", external_id: "TV_CROSS1", language: "en", misc: "m",
+          owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
+          capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
+        })
+
+      other_dealt = Copi.Repo.insert!(%Copi.Cornucopia.DealtCard{
+        player_id: other_player.id, card_id: card.id, played_in_round: 1
+      })
+
+      {:ok, show_live, _html} = live(conn, "/games/#{game_id}/players/#{player.id}")
+
+      # Attempt to vote on a dealt card from the other game — should be rejected
+      render_click(show_live, "toggle_vote", %{"dealt_card_id" => to_string(other_dealt.id)})
+      :timer.sleep(100)
+
+      {:ok, unchanged_dealt} = Copi.Cornucopia.DealtCard.find(to_string(other_dealt.id))
+      assert length(unchanged_dealt.votes) == 0
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Adds an authorization check in the `toggle_vote` event handler in `player_live/show.ex` to verify that the `dealt_card_id` belongs to a player in the current game before allowing the vote
- If the dealt card does not belong to the current game, the vote is silently rejected and a warning is logged
- Adds a test that creates two separate games and confirms that voting on a card from another game is rejected

## Details

The `toggle_vote` handler previously fetched a dealt card using only the `dealt_card_id` from the event payload without any authorization check. A player could forge the `dealt_card_id` in browser devtools to cast votes on cards from any game.

The fix collects all dealt card IDs from the current game's players (already preloaded on the socket) and checks membership before proceeding with the vote logic. This follows the same pattern as the approach suggested in the issue.

Fixes #2520

## Test plan
- [x] Existing `toggle_vote` test (add/remove vote on own game's card) still passes
- [x] New test: `toggle_vote rejects vote on a dealt card from another game` — creates a second game with a dealt card and confirms that voting on it from game 1 results in zero votes on that card

🤖 Generated with [Claude Code](https://claude.com/claude-code)