### PR TITLE
Fix: prevent joining games already in progress

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/player_live/form_component.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/form_component.ex
@@ -89,6 +89,20 @@ defmodule CopiWeb.PlayerLive.FormComponent do
   end
 
   defp save_player(socket, :new, player_params) do
+    game_id = socket.assigns.player.game_id
+    game = Cornucopia.get_game!(game_id)
+
+    if game.started_at do
+      {:noreply,
+       socket
+       |> put_flash(:error, "This game has already started. You cannot join a game in progress.")
+       |> push_navigate(to: ~p"/games/#{game_id}")}
+    else
+      save_new_player(socket, player_params)
+    end
+  end
+
+  defp save_new_player(socket, player_params) do
     ip = socket.assigns[:client_ip] || {127, 0, 0, 1}
 
     case RateLimiter.check_rate(ip, :player_creation) do

--- a/copi.owasp.org/lib/copi_web/live/player_live/index.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/index.ex
@@ -23,9 +23,16 @@ defmodule CopiWeb.PlayerLive.Index do
 
   defp apply_action(socket, :new, %{"game_id" => game_id}) do
     game = socket.assigns.game
-    socket
-    |> assign(:page_title, "You're joining the game: #{game.name}")
-    |> assign(:player, %Player{game_id: game_id})
+
+    if game.started_at do
+      socket
+      |> put_flash(:error, "This game has already started. You cannot join a game in progress.")
+      |> push_navigate(to: ~p"/games/#{game_id}")
+    else
+      socket
+      |> assign(:page_title, "You're joining the game: #{game.name}")
+      |> assign(:player, %Player{game_id: game_id})
+    end
   end
 
   defp apply_action(socket, :index, _params) do


### PR DESCRIPTION
## Summary

Fixes #2521

- Players could join a game after it had started by navigating directly to `/games/:game_id/players/new`, allowing them to watch the game in real time and vote on cards without being dealt any cards themselves.
- Added a `started_at` check in `PlayerLive.Index.apply_action(:new, ...)` to redirect users away from the join form if the game has already started.
- Added a defense-in-depth `started_at` check in `PlayerLive.FormComponent.save_player(:new, ...)` to reject player creation even if the form was loaded before the game started (race condition).

## Changes

- `copi.owasp.org/lib/copi_web/live/player_live/index.ex` — check `game.started_at` in `apply_action(:new, ...)` and redirect with error flash
- `copi.owasp.org/lib/copi_web/live/player_live/form_component.ex` — re-fetch game in `save_player(:new, ...)` and reject if `started_at` is set

## Test plan

- [ ] Create a game, add 3+ players, start the game
- [ ] Try navigating to `/games/:game_id/players/new` — should be redirected to the game page with an error flash
- [ ] Verify existing join flow still works for games that have not started
- [ ] Verify edge case: open join form, then start game in another tab, then submit join form — should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)