### PR TITLE
Fix Vote schema empty changeset validation

### DIFF
--- a/copi.owasp.org/lib/copi/cornucopia/vote.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/vote.ex
@@ -12,7 +12,7 @@ defmodule Copi.Cornucopia.Vote do
   @doc false
   def changeset(vote, attrs) do
     vote
-    |> cast(attrs, [])
-    |> validate_required([])
+    |> cast(attrs, [:dealt_card_id, :player_id])
+    |> validate_required([:dealt_card_id, :player_id])
   end
 end

--- a/copi.owasp.org/test/copi/cornucopia/vote_test.exs
+++ b/copi.owasp.org/test/copi/cornucopia/vote_test.exs
@@ -1,0 +1,22 @@
+defmodule Copi.Cornucopia.VoteTest do
+  use Copi.DataCase
+
+  alias Copi.Cornucopia.Vote
+
+  describe "votes" do
+    @valid_attrs %{player_id: Ecto.ULID.generate(), dealt_card_id: 1}
+    @invalid_attrs %{player_id: nil, dealt_card_id: nil}
+
+    test "changeset with valid attributes" do
+      changeset = Vote.changeset(%Vote{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "changeset with invalid attributes" do
+      changeset = Vote.changeset(%Vote{}, @invalid_attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).player_id
+      assert "can't be blank" in errors_on(changeset).dealt_card_id
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Updated `Vote.changeset/2` to cast and validate `[:dealt_card_id, :player_id]` instead of empty lists
- Added unit tests for the Vote changeset (valid and invalid attributes), following the existing `ContinueVoteTest` pattern

Closes #2557

## Test plan
- [ ] `mix test test/copi/cornucopia/vote_test.exs` passes (changeset accepts valid attrs, rejects nil values)
- [ ] Existing test suite continues to pass (`mix test`)
- [ ] Manual verification: voting in a live game session still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)