### PR TITLE
Use DeckService.getLatestVersion() instead of hardcoded version in ca…

### DIFF
--- a/cornucopia.owasp.org/src/routes/edition/[edition]/[card]/+page.server.ts
+++ b/cornucopia.owasp.org/src/routes/edition/[edition]/[card]/+page.server.ts
@@ -7,7 +7,7 @@ import { CapecService } from "$lib/services/capecService";
 
 export const load = (({ params }) => {
     const edition =  params?.edition;
-    const version =  edition == 'webapp' ? '2.2' : edition == 'mobileapp' ? '1.1' : '1.0';
+    const version = DeckService.getLatestVersion(edition);
     let asvsVersion: string = "4.0.3";
     if (params.version === '3.0') asvsVersion = '5.0';
     if (!DeckService.hasEdition(edition)) error(


### PR DESCRIPTION
This PR updates the version resolution in:

src/routes/edition/[edition]/[card]/+page.server.ts

Previously, the version was hardcoded based on the edition. This change replaces it with:

DeckService.getLatestVersion(edition)

to align with the approach already used in:

src/routes/edition/[edition]/+page.server.ts

This keeps version logic centralized and consistent across routes.

Changes are limited to the relevant file only.