### PR TITLE
Fixed Duplicate Constants

### DIFF
--- a/cornucopia.owasp.org/src/lib/services/deckServiceConsts.ts
+++ b/cornucopia.owasp.org/src/lib/services/deckServiceConsts.ts
@@ -1,0 +1,6 @@
+/**
+ * Constants for deck versions used throughout the application
+ */
+export const VERSION_WEBAPP = "webapp";
+export const VERSION_MOBILEAPP = "mobileapp";
+export const VERSION_COMPANION = "companion";

--- a/cornucopia.owasp.org/src/routes/cards/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/cards/+page.svelte
@@ -9,6 +9,7 @@
     import { readLang, readTranslation } from '$lib/stores/stores';
     import type { Suit } from "../../domain/suit/suit.js";
     import { SvelteMap } from 'svelte/reactivity';
+    import { VERSION_WEBAPP, VERSION_MOBILEAPP, VERSION_COMPANION } from "$lib/services/deckServiceConsts";
 
     interface Props {
         data: PageData;
@@ -23,10 +24,6 @@
     let suits = $derived(data.suits);
     let mappingData = $derived(data.mappingData);
 
-    //TODO move these constants to a more sensible location
-    const VERSION_WEBAPP = "webapp"
-    const VERSION_MOBILEAPP = "mobileapp"
-    const VERSION_COMPANION = "companion";
 
     let mobileappSuits = $derived.by(() => {
         const langSuits = suits?.get(`${VERSION_MOBILEAPP}-${$lang}`);

--- a/cornucopia.owasp.org/src/routes/edition/[edition]/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/edition/[edition]/+page.svelte
@@ -10,6 +10,7 @@
     import type { Suit } from "$domain/suit/suit.js";
     import { SvelteMap } from 'svelte/reactivity';
     import { goto } from "$app/navigation";
+    import { VERSION_WEBAPP, VERSION_MOBILEAPP, VERSION_COMPANION } from "$lib/services/deckServiceConsts";
 
 
     interface Props {
@@ -20,10 +21,6 @@
     const lang = readLang();
     let t = readTranslation();
     
-    //TODO move these constants to a more sensible location
-    const VERSION_WEBAPP = "webapp"
-    const VERSION_MOBILEAPP = "mobileapp"
-    const VERSION_COMPANION = "companion"
 
     // Derived values that update when data changes
     let content = $derived(data.content.get($lang) || data.content.get('en'));


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-day or even
∞ ban from interacting with the project depending on recurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->

##

### 1. __Created Shared Constants File__

- __File__: `cornucopia.owasp.org/src/lib/services/deckServiceConsts.ts`

- __Contents__:

  ```typescript
  export const VERSION_WEBAPP = "webapp";
  export const VERSION_MOBILEAPP = "mobileapp";
  export const VERSION_COMPANION = "companion";
  ```

### 2. __Updated Both Target Files__

__File 1__: `cornucopia.owasp.org/src/routes/edition/[edition]/+page.svelte`

-  Added import: `import { VERSION_WEBAPP, VERSION_MOBILEAPP, VERSION_COMPANION } from "$lib/services/deckServiceConsts"`
-  Removed duplicate constants and TODO comment
-  All references now use imported constants

__File 2__: `cornucopia.owasp.org/src/routes/cards/+page.svelte`

-  Added import: `import { VERSION_WEBAPP, VERSION_MOBILEAPP, VERSION_COMPANION } from "$lib/services/deckServiceConsts"`
-  Removed duplicate constants and TODO comment
-  All references now use imported constants

The refactoring is complete and both files now use the shared constants from `DeckServiceConsts` as requested. All duplicate constants and TODO comments have been successfully removed.

Resolved or fixed issue: #2493 

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
