### PR TITLE
docs(AA7): improve scenario, STRIDE mapping and mitigation guidance

### DIFF
--- a/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA7/explanation.md
+++ b/cornucopia.owasp.org/data/cards/mobileapp-cards-1.1-en/authentication-&-authorization/AA7/explanation.md
@@ -1,11 +1,23 @@
 ## Scenario: Abdullah can bypass authentication by altering the usual process sequence or flow, or by undertaking the process in incorrect order, or by manipulating date and time values used by the app, or by using valid features for unintended purposes
 
+Consider Abdullah suspects his sibling Tim is secretly chatting late at night instead of studying. Determined to expose him to their parents, Abdullah attempts to access Tim’s chat app. Instead of using valid credentials, he bypasses authentication by manipulating the app’s logic and flow.
+
 ### Example
+The app relies on client-side checks and assumes the authentication flow is followed correctly. Abdullah exploits this by modifying flags (e.g., `isLoggedIn = true`), triggering states out of sequence, manipulating time-based checks, and misusing valid features like deep links. Since there is no proper enforcement of authentication, he gains access to Tim’s chats.
+
 
 ## Threat Modeling
 
 ### STRIDE
+This scenario falls under the **Tampering** and **Information Disclosure** categories of STRIDE. Abdullah performs Tampering by modifying the application's user interface to bypass authentication, leading to Information Disclosure.
 
 ### What can go wrong?
+* Sensitive data may get disclosed.
+* The user can lose access to services.
+* The user's identity can be stolen.
 
-### What are we going to do about it?
+### What are we going to do about it? 
+* **Do not rely only on local authentication frameworks:** Always perform a secondary check on the server-side.
+* **Enforce Android Confirmation:** Set `setConfirmationRequired` to `true` on Android to ensure user presence.
+* **Secure Keychain Access:** Verify that access control flags are properly configured for keychain items (iOS) or Keystore (Android).
+* **Configure Biometrics correctly:** Ensure biometric authentication is implemented according to the latest device documentation and security standards.

--- a/cornucopia.owasp.org/data/website/pages/about/en/index.md
+++ b/cornucopia.owasp.org/data/website/pages/about/en/index.md
@@ -85,6 +85,7 @@ Cornucopia is developed, maintained, updated and promoted by a worldwide team of
 - Timo Goosen
 - Anthony Harrison
 - Martin Haslinger
+- Isha Parmar
 - John Herrlin
 - Jerry Hoff
 - Toby Irvine


### PR DESCRIPTION
Fixes #2108 

## Summary
This PR refines the AA7 (Authentication & Authorization) card by improving the scenario, example, STRIDE mapping, and mitigation guidance.

## Changes
- Updated scenario to clearly describe authentication bypass via manipulation of application flow  
- Improved example to focus on a single, realistic attack path  
- Aligned wording with project standards ("proper enforcement of authentication")  
- Refined STRIDE mapping to Tampering → Information Disclosure  
- Simplified impact and mitigation sections for clarity  

## Result
- Cleaner and more focused AA7 card  
- Better alignment with existing Cornucopia content  
- Improved readability and technical accuracy  