### PR TITLE
apply copilot translation fixes after verifying using google AI searc…

### DIFF
--- a/source/webapp-cards-3.0-fr.yaml
+++ b/source/webapp-cards-3.0-fr.yaml
@@ -318,7 +318,7 @@ suits:
     id: "CR7"
     value: "7"
     url: "https://cornucopia.owasp.org/cards/CR7"
-    desc: "Gunter peut intercepter ou modifier des données chiffrées et/ou hachées en transit parce que le protocole est mal déployé, ou faiblement configuré, ou les certificats sont invalides, or les certificats ne sont pas fiables, ou la connexion peut être dégradée plus faible ou en communication non chiffrée"
+    desc: "Gunter peut intercepter ou modifier des données chiffrées et/ou hachées en transit parce que le protocole est mal déployé, ou faiblement configuré, ou les certificats sont invalides, ou les certificats ne sont pas fiables, ou la connexion peut être dégradée plus faible ou en communication non chiffrée"
   -
     id: "CR8"
     value: "8"
@@ -398,7 +398,7 @@ suits:
     id: "C9"
     value: "9"
     url: "https://cornucopia.owasp.org/cards/C9"
-    desc: "Mike peut mal utilisé une application en utilisant une fonction valide trop rapidement, ou trop fréquemment, or d'une autre façon que ce qui a été prévu, ou consomme les ressources de l'application, ou cause des situations de compétition, ou sur-utilise une fonctionnalité"
+    desc: "Mike peut mal utiliser une application en utilisant une fonction valide trop rapidement, ou trop fréquemment, ou d'une autre façon que ce qui a été prévu, ou consomme les ressources de l'application, ou cause des situations de compétition, ou sur-utilise une fonctionnalité"
   -
     id: "CX"
     value: "10"


### PR DESCRIPTION
### Description

Fixes minor translation errors in the French webapp cards (`webapp-cards-3.0-fr.yaml`), there are exactly 3 changes, 1 for CR7 and 2 for C9. I used [`webapp-cards-3.0-en.yaml`](https://github.com/OWASP/cornucopia/blob/master/source/webapp-cards-3.0-en.yaml)  as the english reference:

1. **CR7** – Replaced the English word `or` with the correct French `ou` in the `desc` field.
2. **C9** – Corrected `mal utilisé` to `mal utiliser` , and replaced the English `or` with the French `ou`.

Each change was verified using Google Search AI (Gemini) as instructed in issue #2706.

- Resolved or fixed issue: #2706

---

### Verification Conversation (Google Search AI / Gemini)
Me: Please answer me in English going forward.

When translating from English:

Gunter can intercept or modify encrypted and/or hashed data in transit because the protocol is poorly deployed, or weakly configured, or certificates are invalid, or certificates are not trusted, or the connection can be degraded to a weaker or un-encrypted communication

to French

Gunter peut intercepter ou modifier des données chiffrées et/ou hachées en transit parce que le protocole est mal déployé, ou faiblement configuré, ou les certificats sont invalides, or les certificats ne sont pas fiables, ou la connexion peut être dégradée plus faible ou en communication non chiffrée

Why is the following a better translation into French?

Gunter peut intercepter ou modifier des données chiffrées et/ou hachées en transit parce que le protocole est mal déployé, ou faiblement configuré, ou les certificats sont invalides, ou les certificats ne sont pas fiables, ou la connexion peut être dégradée plus faible ou en communication non chiffrée

Answer: The version you highlighted is better because it corrects a language swap (Anglicism) and improves the grammatical flow.
Here is the breakdown of why it’s superior:
Correction of "or" to "ou": In your first version, you used the English word "or" ("or les certificats ne sont pas fiables"). The second version correctly uses the French "ou", maintaining linguistic consistency [1].
Parallelism: By using "ou" consistently throughout the list, the sentence follows standard French syntax for a series of conditions [1].
A Note on Further Improvement:
While the second version is better, the phrase "dégradée plus faible" is still slightly awkward in French. A more natural, technical translation for "degraded to a weaker... communication" would be:
"...ou la connexion peut être rétrogradée vers une communication plus faible ou non chiffrée."
Would you like me to refine the technical terminology for the rest of the sentence, or should we focus on the grammatical structure?




Me: When translating from English:

Mike can misuse an application by using a valid feature too fast, or too frequently, or other way that is not intended, or consumes the application's resources, or causes race conditions, or over-utilizes a feature

to French

Mike peut mal utilisé une application en utilisant une fonction valide trop rapidement, ou trop fréquemment, or d'une autre façon que ce qui a été prévu, ou consomme les ressources de l'application, ou cause des situations de compétition, ou sur-utilise une fonctionnalité

Why is the following a better translation into French?

Mike peut mal utiliser une application en utilisant une fonction valide trop rapidement, ou trop fréquemment, ou d'une autre façon que ce qui a été prévu, ou consomme les ressources de l'application, ou cause des situations de compétition, ou sur-utilise une fonctionnalité

Answer: The second version is better because it corrects two specific errors: grammar and language consistency.
Here is why it is an improvement:
Verb Conjugation: The first version uses "mal utilisé" (past participle). The second version correctly uses the infinitive "mal utiliser". In French, when two verbs follow each other (like peut + utiliser), the second verb must be in the infinitive.
Language Correction: Just like in your previous example, the first version accidentally kept the English word "or" ("or d'une autre façon"). The second version replaces it with the correct French "ou".
A Quick Tip for Flow:
To make the second half of the sentence even smoother, you could align the verbs. Since the sentence starts with Mike using a feature "en utilisant" (by using), the subsequent actions should ideally follow that form:
"...ou en consommant les ressources... ou en causant des situations de compétition..."
Do you want to look at more examples of verb agreement, or would you like to move on to technical idioms in French?






### AI Tool Disclosure
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `GitHub Copilot, Google Search AI`
    - LLMs and versions: `Copilot (initial language review per #2686), Gemini (Google Search AI, used for verification)`
    - Prompts: `Used Google Search AI to verify each Copilot fix by asking why the suggested French translation is better than the existing one, following the method described in issue #2706.`

---

### Affirmation
- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines