### PR TITLE
Add ASVS and CAPEC webapp API endpoints for v3.0

### DIFF
--- a/cornucopia.owasp.org/script/headers.js
+++ b/cornucopia.owasp.org/script/headers.js
@@ -93,6 +93,16 @@ function main() {
   Access-Control-Allow-Origin: *
   ! Content-Type
   Content-Type: application/json
+/api/asvs/webapp/3.0
+  ! Access-Control-Allow-Origin
+  Access-Control-Allow-Origin: *
+  ! Content-Type
+  Content-Type: application/json
+/api/capec/webapp/3.0
+  ! Access-Control-Allow-Origin
+  Access-Control-Allow-Origin: *
+  ! Content-Type
+  Content-Type: application/json
 `;
 
   const headersFile = path.join(buildDir, '_headers');

--- a/cornucopia.owasp.org/src/lib/services/asvsService.ts
+++ b/cornucopia.owasp.org/src/lib/services/asvsService.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import yaml from "js-yaml";
+import path from "path";
+
+const __dirname = path.resolve(path.dirname(''));
+
+export interface AsvsEntry {
+    capec_codes: string[];
+    description: string;
+    level: string;
+}
+
+export interface AsvsData {
+    [key: string]: AsvsEntry;
+}
+
+export class AsvsService {
+    private static asvsData: Map<string, AsvsData> = new Map();
+    private static path: string = '/../source/';
+
+    public static getAsvsData(edition: string, version: string): AsvsData {
+        const key = `${edition}-${version}`;
+
+        if (this.asvsData.has(key)) {
+            return this.asvsData.get(key)!;
+        }
+
+        try {
+            const yamlData = fs.readFileSync(
+                `${__dirname}${this.path}${edition}-asvs-${version}.yaml`,
+                'utf8'
+            );
+            const data = yaml.load(yamlData, { schema: yaml.FAILSAFE_SCHEMA }) as AsvsData;
+            this.asvsData.set(key, data);
+            return data;
+        } catch (e) {
+            console.error(`Failed to load ASVS data for ${edition}-${version}:`, e);
+            return {};
+        }
+    }
+
+    public static clear(): void {
+        this.asvsData.clear();
+    }
+}

--- a/cornucopia.owasp.org/src/routes/api/asvs/[edition]/[version]/+server.ts
+++ b/cornucopia.owasp.org/src/routes/api/asvs/[edition]/[version]/+server.ts
@@ -1,0 +1,34 @@
+import { json, error, type RequestHandler } from '@sveltejs/kit';
+import { DeckService } from '$lib/services/deckService';
+import { AsvsService } from '$lib/services/asvsService';
+
+export const prerender = true;
+
+export const GET: RequestHandler = ({ params }) => {
+    const edition = params.edition;
+    const version = params.version;
+
+    if (!edition || !DeckService.hasEdition(edition)) {
+        throw error(404, 'Edition not found. Only: ' + DeckService.getLatestEditions().join(', ') + ' are supported.');
+    }
+
+    if (!version || !DeckService.hasVersion(edition, version)) {
+        throw error(404, 'Version not found for edition ' + edition + '. Only: ' + DeckService.getVersions(edition).join(', ') + ' are supported.');
+    }
+
+    const data = AsvsService.getAsvsData(edition, version);
+
+    if (!data || Object.keys(data).length === 0) {
+        throw error(500, 'No ASVS data found.');
+    }
+
+    return json({
+        meta: {
+            edition,
+            component: 'asvs',
+            language: 'ALL',
+            version
+        },
+        ...data
+    });
+};

--- a/cornucopia.owasp.org/src/routes/api/capec/[edition]/[version]/+server.ts
+++ b/cornucopia.owasp.org/src/routes/api/capec/[edition]/[version]/+server.ts
@@ -1,0 +1,34 @@
+import { json, error, type RequestHandler } from '@sveltejs/kit';
+import { DeckService } from '$lib/services/deckService';
+import { CapecService } from '$lib/services/capecService';
+
+export const prerender = true;
+
+export const GET: RequestHandler = ({ params }) => {
+    const edition = params.edition;
+    const version = params.version;
+
+    if (!edition || !DeckService.hasEdition(edition)) {
+        throw error(404, 'Edition not found. Only: ' + DeckService.getLatestEditions().join(', ') + ' are supported.');
+    }
+
+    if (!version || !DeckService.hasVersion(edition, version)) {
+        throw error(404, 'Version not found for edition ' + edition + '. Only: ' + DeckService.getVersions(edition).join(', ') + ' are supported.');
+    }
+
+    const data = CapecService.getCapecData(edition, version);
+
+    if (!data || Object.keys(data).length === 0) {
+        throw error(500, 'No CAPEC data found.');
+    }
+
+    return json({
+        meta: {
+            edition,
+            component: 'capec',
+            language: 'ALL',
+            version
+        },
+        ...data
+    });
+};

--- a/cornucopia.owasp.org/static/api/openapi.yaml
+++ b/cornucopia.owasp.org/static/api/openapi.yaml
@@ -111,6 +111,74 @@ paths:
                         cre:
                           - CRE-1
                           - CRE-2
+  
+  /asvs/webapp/{version}:
+    get:
+      summary: Get Webapp ASVS data by version
+      description: |
+        Get the OWASP Cornucopia Website App Edition ASVS data
+        by version.
+      parameters:
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: ["3.0"]
+      responses:
+        '200':
+          description: Website App ASVS data
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                example:
+                  summary: Example Website App ASVS response
+                  value:
+                    meta:
+                      edition: webapp
+                      component: asvs
+                      language: ALL
+                      version: "3.0"
+                    1.1.1:
+                      capec_codes: []
+                      description: Architecture analysis performed for the application
+                      level: 1
+
+  /capec/webapp/{version}:
+    get:
+      summary: Get Webapp CAPEC data by version
+      description: |
+        Get the OWASP Cornucopia Website App Edition CAPEC data
+        by version.
+      parameters:
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: ["3.0"]
+      responses:
+        '200':
+          description: Website App CAPEC data
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                example:
+                  summary: Example Website App CAPEC response
+                  value:
+                    meta:
+                      edition: webapp
+                      component: capec
+                      language: ALL
+                      version: "3.0"
+                    1:
+                      name: Accessing Functionality Not Properly Constrained by ACLs
+                      owasp_asvs:
+                        - 4.1.4
 
   /cre/mobileapp/{lang}:
     get:

--- a/cornucopia.owasp.org/svelte.config.js
+++ b/cornucopia.owasp.org/svelte.config.js
@@ -260,6 +260,8 @@ export default {
 				'/api/cre/mobileapp/en',
 				'/api/cre/mobileapp/hi',
                 '/api/cre/mobileapp/uk',
+				'/api/asvs/webapp/3.0',
+                '/api/capec/webapp/3.0',
 				'/edition/mobileapp/PC2/1.1/en',
 				'/edition/mobileapp/PC2/1.1/uk',
                 '/edition/mobileapp/PC2/1.1/hi',


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-day or even
∞ ban from interacting with the project depending on recurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
This PR adds support for exposing Webapp v3.0 ASVS and CAPEC data through new API endpoints.
The goal is to make the existing YAML data for ASVS and CAPEC accessible via the API, similar to how other data is currently exposed.
Added two new endpoints:

- GET /api/asvs/webapp/{version} that returns ASVS data
- GET /api/capec/webapp/{version} that returns CAPEC data

These endpoints read from the existing source YAML files - webapp-asvs-3.0.yaml and webapp-capec-3.0.yaml
### Changes made:

- Added asvsService and capecService to load and cache YAML data.
- Created new API routes under /api/asvs/... and /api/capec/...
- Updated API exposure configuration to include these routes.
- Kept existing endpoints unchanged.

This follows the current API structure and keeps the implementation consistent with existing services.
Resolved or fixed issue: none

<img width="1920" height="961" alt="Screenshot (689)" src="https://github.com/user-attachments/assets/918fdff6-7b55-44a4-b8c9-0089eb7a9edb" />

<img width="1920" height="975" alt="Screenshot (690)" src="https://github.com/user-attachments/assets/c09bef7c-e762-486a-b0db-9a2cc2fe9eac" />

### AI Tool Disclosure
- [ ] My contribution does not include any AI-generated content
- [X] My contribution includes AI-generated content, as disclosed below:
    - AI Tool: Claude
    - LLM and version: Claude Sonnet 4.6
    - Prompt: Used for guidance on implementation approach  and debugging issues. All code and final changes were written, reviewed, and adapted manually.

### Affirmation
- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
