### PR TITLE
add targeted test for mappingService missing mapping scenario

### DIFF
--- a/cornucopia.owasp.org/src/lib/services/mappingService.test.ts
+++ b/cornucopia.owasp.org/src/lib/services/mappingService.test.ts
@@ -1,14 +1,44 @@
-import {expect, describe, it} from 'vitest';
+import { expect, describe, it, vi, afterEach } from 'vitest';
+import { DeckService } from './deckService';
 import { MappingService } from './mappingService';
 
 describe('MappingService tests', () => {
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        MappingService.clear();
+    });
+
     it("should return card mapping data.", async () => {
         expect((new MappingService()).getCardMappingForLatestEdtions()).toBeDefined();
         MappingService.clear();
         expect((new MappingService()).getCardMappingForAllVersions().get('webapp-2.2')).toBeDefined();
         expect((new MappingService()).getCardMappingForAllVersions().get('webapp-3.0')).toBeDefined();
         expect((new MappingService()).getCardMappingForAllVersions().get('mobileapp-1.1')).toBeDefined();
-        MappingService.clear();
+    }); 
 
+    it('should handle missing mapping file gracefully', () => {
+        const service = new MappingService();
+        expect(service.getCardMapping('invalid-edition', '0.0')).toBeUndefined();
+    });
+
+    it('should return empty or default mapping for unknown data', () => {
+        const service = new MappingService();
+        expect(service.getCardMapping('webapp', 'invalid-version')).toBeUndefined();
+    });
+
+    it('should skip missing mapping files', () => {
+        const service = new MappingService();
+        const decks = DeckService.getDecks();
+
+        service.getCardMappingForAllVersions();
+
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.spyOn(DeckService, 'getDecks').mockReturnValue([
+            ...decks,
+            { edition: 'missing', version: '9.9', lang: ['en'] }
+        ]);
+
+        expect(service.getCardMappingForAllVersions().get('missing-9.9')).toBeUndefined();
     });
 });


### PR DESCRIPTION
### Description

Adds a targeted test to improve branch coverage for MappingService.

The new test simulates a scenario where a mapping file is missing for a known deck, ensuring that the try/catch path in getCardMappingForAllVersions() is properly exercised and handled gracefully.

### **Changes**
	•	Covers try/catch branch for missing mapping files
	•	Improves branch coverage
	•	No production code changes

### **Scope Note**
This PR focuses only on MappingService coverage.
Coverage improvements for the CRE API will be handled separately to keep changes minimal and well-scoped.

### **Motivation**
This edge case was previously untested and could lead to silent failures if not handled correctly. Adding this test ensures robustness when mapping files are missing.
All changes were verified manually to ensure they align with the existing implementation and do not introduce unintended behavior.

Resolved or fixed issue: #2807

⸻
**AI Tool Disclosure**
	•	My contribution includes AI-generated content, as disclosed below:
	•	AI Tools: ChatGPT, VS Code Codex
	•	LLMs and versions: GPT-5.3 (ChatGPT), Codex (VS Code)
	•	Prompts: Guidance on identifying uncovered branches and writing minimal, targeted test cases

⸻
**Affirmation**
	•	My code follows the CONTRIBUTING.md guidelines