### PR TITLE
Fix: Resolve SvelteKit Worker crashes in Website ZAP Scan Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 build
 .svelte-kit
+.git

--- a/.github/workflows/zap-nightly-scan-website.yml
+++ b/.github/workflows/zap-nightly-scan-website.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build website Docker image
-        run: docker build -t cornucopia-website -f cornucopia.owasp.org/Dockerfile .
+        run: docker build -t cornucopia-website -f cornucopia.owasp.org/Dockerfile cornucopia.owasp.org
 
       - name: Start website container
         run: |

--- a/.github/workflows/zap-nightly-scan-website.yml
+++ b/.github/workflows/zap-nightly-scan-website.yml
@@ -19,8 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build website Docker image
-        working-directory: cornucopia.owasp.org
-        run: docker build -t cornucopia-website .
+        run: docker build -t cornucopia-website -f cornucopia.owasp.org/Dockerfile .
 
       - name: Start website container
         run: |

--- a/cornucopia.owasp.org/Dockerfile
+++ b/cornucopia.owasp.org/Dockerfile
@@ -1,16 +1,21 @@
 FROM node:iron-alpine3.21@sha256:957dbf2afb4f22d9e2b94b981e242cbb796965cd3d9cc02d436e2a05fa0ec300 AS builder
 
+# Context is now the repository root to allow copying the source folder.
+WORKDIR /source
+COPY source .
+
 WORKDIR /app
 
 # Install dependencies
-COPY package.json ./
+COPY cornucopia.owasp.org/package.json ./
 RUN npm install -g pnpm@v10.3.0 --save-exact
 RUN pnpm install
 
 # Copy source code
-COPY . .
+COPY cornucopia.owasp.org .
 
 # Build the application
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm run build
 
 # Production stage
@@ -20,7 +25,7 @@ FROM nginx:alpine3.21@sha256:b471bb609adc83f73c2d95148cf1bd683408739a3c09c0afc66
 COPY --from=builder /app/build /usr/share/nginx/html
 
 # Copy custom Nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY cornucopia.owasp.org/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 

--- a/cornucopia.owasp.org/Dockerfile
+++ b/cornucopia.owasp.org/Dockerfile
@@ -7,9 +7,12 @@ COPY source .
 WORKDIR /app
 
 # Install dependencies
+# V15.2: Copy the lockfile before install so dependency resolution is deterministic
+# and Docker can safely cache the dependency layer.
 COPY cornucopia.owasp.org/package.json ./
+COPY cornucopia.owasp.org/pnpm-lock.yaml ./
 RUN npm install -g pnpm@v10.3.0 --save-exact
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 # Copy source code
 COPY cornucopia.owasp.org .

--- a/cornucopia.owasp.org/Dockerfile
+++ b/cornucopia.owasp.org/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:iron-alpine3.21@sha256:957dbf2afb4f22d9e2b94b981e242cbb796965cd3d9cc02d436e2a05fa0ec300 AS builder
 
-# Context is now the repository root to allow copying the source folder.
-WORKDIR /source
-COPY source .
-
 WORKDIR /app
 
 # Install dependencies
@@ -14,7 +10,12 @@ COPY cornucopia.owasp.org/pnpm-lock.yaml ./
 RUN npm install -g pnpm@v10.3.0 --save-exact
 RUN pnpm install --frozen-lockfile
 
-# Copy source code
+# Followed copilot suggestion 2: Copy source data AFTER dependency install
+WORKDIR /source
+COPY source .
+
+WORKDIR /app
+# Copy the frontend application code
 COPY cornucopia.owasp.org .
 
 # Build the application

--- a/cornucopia.owasp.org/svelte.config.js
+++ b/cornucopia.owasp.org/svelte.config.js
@@ -19,6 +19,7 @@ export default {
 			$domain: "src/domain",
 		},
 		prerender: {
+			concurrency: 1,
 			handleHttpError: ({ path, referrer, message }) => {
 				console.log(message);
 				console.log(referrer);


### PR DESCRIPTION
## Description
This fixes the failing `ZAP Nightly Scan - Cornucopia Website` Action. 

The website's Docker build was crashing during SvelteKit static prerendering because `DeckService` couldn't find the card YAML files. The Docker build context was pinned to the `cornucopia.owasp.org` directory, so it couldn't access the parent `/source/` directory where the content actually lives, resulting in unhandled `500` server errors inside the Node workers.

## Changes
- **Updated Docker Context**: Trigger the Docker build from the repo root in `zap-nightly-scan-website.yml` so it has access to the whole repository.
- **Fixed `Dockerfile` Paths**: Added a step to explicitly copy the `source/` folder into the image and adjusted the inner build paths.
- **Workflow Stability**: Increased `NODE_OPTIONS` max space and reduced SvelteKit `concurrency` to `1` to prevent any Docker Out-Of-Memory spikes on GitHub's Action runners.

### Closes: #2764 

### AI Usage
Used AI assistance to debug the prerender failures and patch the Docker context. Configuration, memory limitations, and the resulting Docker integration were verified manually. No AI-generated noise or unnecessary comments are present.