### PR TITLE
fix: update companion edition card colors per issue #2851

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/cardPreview.svelte
+++ b/cornucopia.owasp.org/src/lib/components/cardPreview.svelte
@@ -39,10 +39,18 @@
         if (['CRM', 'CM', 'WC'].includes(id)) suit = suit + '-mobile';
         return cardColor?.get(suit) ?? "default";
     }
+
+    function getLeftRibbonClass(suit: string, id: string, value: string)
+    {
+        const base = getSuitColor(suit, id);
+        if (!base) return base;
+        if (['J', 'Q', 'K'].includes(value)) return base + ' left-royal';
+        return base;
+    }
 </script>
 
 <div class="card-render">
-    <div class="left {getSuitColor(card?.suit, card?.suitId)}">
+    <div class="left {getLeftRibbonClass(card?.suit, card?.suitId, card?.value)}">
         <span class="property-card-suit{previewStyle}">{card?.suitName}</span>
     </div>
     <div class="right {getRoyalSuitColor(card?.suit, card?.suitId, card?.value)}">
@@ -160,7 +168,6 @@
     .left
     {
         width: 15%;
-        background: rgb(2,0,36);
         background: linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(255,255,255,0.3) 100%);
     }
 
@@ -262,67 +269,67 @@
         color: rgb(10,58,94);
     }
     
-    .agentic-ai {
-        background-color: #dbdbdb;
+    .left.agentic-ai {
+        background: linear-gradient(180deg, #3b2c42, #3b2c4280);
     }
-    .automated-threats {
-        background-color: #dbdbdb;
+    .left.automated-threats {
+        background: linear-gradient(180deg, #d56859, #d5685980);
     }
-    .cloud {
-        background-color: #dbdbdb;
+    .left.cloud {
+        background: linear-gradient(180deg, #D289B8, #D289B880);
     }
-    .devops {
-        background-color: #dbdbdb;
+    .left.devops {
+        background: linear-gradient(180deg, #a87441, #a8744180);
     }
-    .frontend {
-        background-color: #dbdbdb;
+    .left.frontend {
+        background: linear-gradient(180deg, #806A62, #806A6280);
     }
-    .large-language-models {
-        background-color: #dbdbdb;
+    .left.large-language-models {
+        background: linear-gradient(180deg, #a13763, #a1376380);
     }
     .social-engineering {
         background-color: #dbdbdb;
     }
 
     .agentic-ai-text {
-        color: #dbdbdb;
+        color: #3b2c42;
     }
     .automated-threats-text {
-        color: #dbdbdb;
+        color: #d56859;
     }
     .cloud-text {
-        color: #dbdbdb;
+        color: #d289b8;
     }
     .devops-text {
-        color: #dbdbdb;
+        color: #a87441;
     }
     .frontend-text {
-        color: #dbdbdb;
+        color: #806A62;
     }
     .large-language-models-text {
-        color: #dbdbdb;
+        color: #a13763;
     }
     .social-engineering-text {
         color: #dbdbdb;
     }
 
     .agentic-ai-royal {
-        background-color: #e8e8e8;
+        background-color: #3b2c4280;
     }
     .automated-threats-royal {
-        background-color: #e8e8e8;
+        background-color: #d5685980;
     }
     .cloud-royal {
-        background-color: #e8e8e8;
+        background-color: #D289B880;
     }
     .devops-royal {
-        background-color: #e8e8e8;
+        background-color: #a8744180;
     }
     .frontend-royal {
-        background-color: #e8e8e8;
+        background-color: #806A6280;
     }
     .large-language-models-royal {
-        background-color: #e8e8e8;
+        background-color: #a1376380;
     }
     .social-engineering-royal {
         background-color: #e8e8e8;
@@ -416,3 +423,4 @@
         }
     }
 </style>
+


### PR DESCRIPTION
Closes #2851

Hii! So basically the companion edition cards were all showing up grey regardless of which suite they belonged to — not ideal when each suite is supposed to have its own distinct color identity.

I've gone through each suite and applied the correct colors as specified in the companion PDF:

- The left ribbon on all cards now has a nice top-to-bottom gradient using the suite's color
- For face cards (J, Q, K), the card background also picks up the suite color at 50% opacity to give them that premium feel

Suites updated: CLD, FRE, LLM, DVO, AAI, and BOT.

Only touched `cardPreview.svelte` — no logic changes, purely visual. Let me know if anything looks off!
### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
