### PR TITLE
Security: GitHub source link opens in new tab without `noopener`

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/viewSourceOnGithub.svelte
+++ b/cornucopia.owasp.org/src/lib/components/viewSourceOnGithub.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <div>
-    <a target="_blank" {href}>
+    <a target="_blank" rel="noopener noreferrer" {href}>
         <img alt="Github logo" title="Github logo" src="/icons/github.png"/>
         <span>View source on GitHub</span>
     </a>


### PR DESCRIPTION
## Summary

Security: GitHub source link opens in new tab without `noopener`

## Problem

**Severity**: `Low` | **File**: `cornucopia.owasp.org/src/lib/components/viewSourceOnGithub.svelte:L24`

The `View source on GitHub` anchor uses `target="_blank"` but does not set `rel="noopener noreferrer"`. This allows reverse-tabnabbing in browsers/environments where opener isolation is not guaranteed.

## Solution

Add `rel="noopener noreferrer"` to the anchor element whenever using `target="_blank"`.

## Changes

- `cornucopia.owasp.org/src/lib/components/viewSourceOnGithub.svelte` (modified)