### PR TITLE
feat: add companion edition suites to Copi

### DIFF
--- a/copi.owasp.org/assets/css/cards.scss
+++ b/copi.owasp.org/assets/css/cards.scss
@@ -227,6 +227,14 @@ $resilience-mobile-color: rgb(49, 124, 192);
 $cryptography-mobile-color: rgb(246, 89, 40);
 $cornucopia-mobile-color: rgb(10, 58, 94);
 $wildcard-mobile-color: rgb(251, 182, 124);
+$companion-suits: (
+  cloud: #D289B8,
+  frontend: #806A62,
+  large-language-models: #a13763,
+  devops: #a87441,
+  agentic-ai: #3b2c42,
+  automated-threats: #d56859
+);
 
 .card {
 
@@ -363,6 +371,30 @@ $wildcard-mobile-color: rgb(251, 182, 124);
 
 .wild-card .value {
   color:$wildcard-color;
+}
+
+.card.companion {
+  @each $suit, $color in $companion-suits {
+    &.#{$suit} {
+      .left-bar {
+        background: linear-gradient(180deg, $color, rgba($color, 0.5));
+      }
+
+      .value {
+        color: $color;
+      }
+    }
+  }
+}
+
+.card.companion.J,
+.card.companion.Q,
+.card.companion.K {
+  @each $suit, $color in $companion-suits {
+    &.#{$suit} {
+      background: rgba($color, 0.5);
+    }
+  }
 }
 
 .card {

--- a/copi.owasp.org/lib/copi/cornucopia.ex
+++ b/copi.owasp.org/lib/copi/cornucopia.ex
@@ -123,12 +123,14 @@ defmodule Copi.Cornucopia do
     companion_edition = @companion_edition
     companion_version = @companion_version
 
-    Card
-    |> where(edition: ^companion_edition, version: ^companion_version)
-    |> order_by([c], c.id)
-    |> Repo.all()
-    |> Enum.map(& &1.category)
-    |> Enum.uniq()
+    database_query =
+      from c in Card,
+        where: c.edition == ^companion_edition and c.version == ^companion_version,
+        select: c.category,
+        distinct: true,
+        order_by: [asc: c.category]
+
+    Repo.all(database_query)
   end
 
   @doc """

--- a/copi.owasp.org/lib/copi/cornucopia.ex
+++ b/copi.owasp.org/lib/copi/cornucopia.ex
@@ -10,6 +10,10 @@ defmodule Copi.Cornucopia do
   alias Copi.Cornucopia.Card
   alias Copi.Cornucopia.Player
 
+  @companion_edition "companion"
+  @companion_version "1.0"
+  @companion_host_editions ["webapp", "mobileapp"]
+
   @doc """
   Returns the list of games.
 
@@ -113,6 +117,18 @@ defmodule Copi.Cornucopia do
     Enum.reduce(["Wild Card", "WILD CARD"], Repo.all(database_query), fn item, acc ->
       List.delete(acc, item)
     end)
+  end
+
+  def get_companion_suits do
+    companion_edition = @companion_edition
+    companion_version = @companion_version
+
+    Card
+    |> where(edition: ^companion_edition, version: ^companion_version)
+    |> order_by([c], c.id)
+    |> Repo.all()
+    |> Enum.map(& &1.category)
+    |> Enum.uniq()
   end
 
   @doc """
@@ -260,12 +276,29 @@ defmodule Copi.Cornucopia do
     |> Enum.sort_by(fn card -> {card.edition, card.external_id, card.language} end)
   end
 
-  def list_cards_shuffled(edition, suits, version) do
-    all_cards = Card |> where(edition: ^edition, version: ^version) |> order_by(fragment("RANDOM()")) |> Repo.all()
+  def list_cards_shuffled(edition, suits, version) when edition in @companion_host_editions do
+    companion_edition = @companion_edition
+    companion_version = @companion_version
 
-    Enum.filter(all_cards, fn card ->
-      card.category in suits
-    end)
+    Card
+    |> where(
+      [c],
+      c.category in ^suits and
+        ((c.edition == ^edition and c.version == ^version) or
+           (c.edition == ^companion_edition and c.version == ^companion_version))
+    )
+    |> order_by(fragment("RANDOM()"))
+    |> Repo.all()
+  end
+
+  def list_cards_shuffled(edition, suits, version) do
+    Card
+    |> where(
+      [c],
+      c.category in ^suits and c.edition == ^edition and c.version == ^version
+    )
+    |> order_by(fragment("RANDOM()"))
+    |> Repo.all()
   end
 
   @doc """

--- a/copi.owasp.org/lib/copi/migrations/card_migration.ex
+++ b/copi.owasp.org/lib/copi/migrations/card_migration.ex
@@ -19,7 +19,8 @@ defmodule Copi.CardMigration do
         version = cards["meta"]["version"]
         for suit <- cards["suits"] do
           for card <- suit["cards"] do
-            card_exists = Repo.get_by(Card, category: suit["name"], value: card["value"], edition: edition, language: language, version: version)
+            value = to_string(card["value"])
+            card_exists = Repo.get_by(Card, category: suit["name"], value: value, edition: edition, language: language, version: version)
 
             if card_exists  do
                 # nothing
@@ -32,7 +33,7 @@ defmodule Copi.CardMigration do
                 language: language,
                 version: version,
                 category: suit["name"],
-                value: card["value"],
+                value: value,
                 description: card["desc"],
                 misc: misc,
                 external_id: card["id"],

--- a/copi.owasp.org/lib/copi_web/controllers/card_html/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/card_html/show.html.heex
@@ -9,7 +9,7 @@
         <p class="value"><%= @card.value |> String.replace("JokerA", "Joker") |> String.replace("JokerB", "Joker") %></p>
         <p class="description"><%= @card.description %></p>
         <%= if @card.url != nil and @card.url != "" do %>
-          <p class="description"><a class="info" rel="help" target="_blank" href={"#{@card.url}#What-can-go-wrong?"}>Need more info?</a></p>
+          <p class="description"><a class="info" rel="help noopener noreferrer" target="_blank" href={"#{@card.url}#What-can-go-wrong?"}>Need more info?</a></p>
         <% end %>
         <%= if @card.value in ["A", "JokerA", "JokerB"] do %>
 
@@ -126,7 +126,7 @@
         <p class="value"><%= @card.value %></p>
         <p class="description"><%= @card.description %></p>
         <%= if @card.url != nil and @card.url != "" do %>
-          <p class="description"><a class="info" rel="help" target="_blank" href={@card.url}>Need more info?</a></p>
+          <p class="description"><a class="info" rel="help noopener noreferrer" target="_blank" href={@card.url}>Need more info?</a></p>
         <% end %>
         <%= if @card.misc != nil and @card.misc != "" do %>
           <p class="misc"><%= @card.misc %></p>
@@ -142,7 +142,7 @@
         <p class="value"><%= @card.value |> String.replace("JokerA", "Joker") |> String.replace("JokerB", "Joker") %></p>
         <p class="description"><%= @card.description %></p>
         <%= if @card.url != nil and @card.url != "" do %>
-          <p class="description"><a class="info" rel="help" target="_blank" href={"#{@card.url}#What-can-go-wrong?"}>Need more info?</a></p>
+          <p class="description"><a class="info" rel="help noopener noreferrer" target="_blank" href={"#{@card.url}#What-can-go-wrong?"}>Need more info?</a></p>
         <% end %>
         <%= if @card.value in ["A", "JokerA", "JokerB"] do %>
 

--- a/copi.owasp.org/lib/copi_web/controllers/card_html/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/card_html/show.html.heex
@@ -118,6 +118,22 @@
         </div>
     </div>
 
+  <% @card.edition == "companion" -> %>
+
+    <div class={["card", @card.value, "companion", Slug.slugify(@card.category)]}>
+      <div class="left-bar"><%= @card.category %></div>
+      <div class="main-content">
+        <p class="value"><%= @card.value %></p>
+        <p class="description"><%= @card.description %></p>
+        <%= if @card.url != nil and @card.url != "" do %>
+          <p class="description"><a class="info" rel="help" target="_blank" href={@card.url}>Need more info?</a></p>
+        <% end %>
+        <%= if @card.misc != nil and @card.misc != "" do %>
+          <p class="misc"><%= @card.misc %></p>
+        <% end %>
+      </div>
+    </div>
+
   <% @card.edition in ["mobileapp", "masvs"] -> %>
 
       <div class={["card", @card.value, "#{Slug.slugify @card.category}-mobile"]}>

--- a/copi.owasp.org/lib/copi_web/live/game_live/create_game_form.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/create_game_form.ex
@@ -40,6 +40,17 @@ defmodule CopiWeb.GameLive.CreateGameForm do
 
         <.input field={@form[:suits]} label={gettext("Select the suits you want to play:")} multiple={true}  type="checkbox" options={GameFormHelpers.get_suits_from_selected_deck(assigns)} />
 
+        <%= if GameFormHelpers.show_companion_suits?(assigns) do %>
+          <.input
+            id="game-companion-suits"
+            field={@form[:suits]}
+            label={gettext("Select the companion suits you want to play:")}
+            multiple={true}
+            type="checkbox"
+            options={GameFormHelpers.get_companion_suits_from_selected_deck(assigns)}
+          />
+        <% end %>
+
         <:actions>
           <.primary_button phx-disable-with="Starting game..." class=""><%= gettext "Create the game" %></.primary_button>
         </:actions>
@@ -54,7 +65,7 @@ defmodule CopiWeb.GameLive.CreateGameForm do
       Cornucopia.change_game(%Game{
         edition: "",
         name: "",
-        suits: GameFormHelpers.generate_suit_list_formatted_for_checkbox("webapp")
+        suits: GameFormHelpers.generate_selected_suits_for_new_game("webapp")
       })
 
     {:ok,

--- a/copi.owasp.org/lib/copi_web/live/game_live/game_form_helpers.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/game_form_helpers.ex
@@ -1,52 +1,96 @@
 defmodule CopiWeb.GameLive.GameFormHelpers do
-
-
+  @companion_prefix "companion"
+  @companion_editions ["webapp", "mobileapp"]
+  @default_companion_suits ["Large Language Models", "Frontend", "DevOps", "Automated Threats", "Agentic AI"]
 
   def generate_suit_list_formatted_for_checkbox(edition) do
     format_list_of_suits_for_checkbox(edition)
     |> Enum.map(fn {key, _} -> key end)
   end
 
+  def generate_selected_suits_for_new_game(edition) do
+    generate_suit_list_formatted_for_checkbox(edition) ++ default_companion_suits_for_checkbox(edition)
+  end
+
   def format_suits_before_saving_game(suits) do
     regex = ~r/\A\w+-/
 
-      suits
-      |> Enum.filter(fn str -> str != "" end)
-      |> Enum.map(fn suit -> String.replace(suit, regex, "") end)
+    suits
+    |> Enum.filter(fn str -> str != "" end)
+    |> Enum.map(fn suit -> String.replace(suit, regex, "") end)
   end
 
   def format_list_of_suits_for_checkbox(selected_edition) do
     Copi.Cornucopia.get_suits_from_selected_deck(selected_edition)
     |> Enum.sort()
-    |> Enum.map(fn suit -> {"#{selected_edition}-#{suit}" , String.capitalize(suit) } end)
+    |> Enum.map(fn suit -> {"#{selected_edition}-#{suit}", String.capitalize(suit)} end)
   end
 
+  def format_companion_suits_for_checkbox(edition) when edition in @companion_editions do
+    Copi.Cornucopia.get_companion_suits()
+    |> Enum.map(fn suit -> {"#{@companion_prefix}-#{suit}", suit} end)
+  end
+
+  def format_companion_suits_for_checkbox(_edition), do: []
+
+  def default_companion_suits_for_checkbox(edition) when edition in @companion_editions do
+    format_companion_suits_for_checkbox(edition)
+    |> Enum.map(fn {key, suit} -> {key, suit in @default_companion_suits} end)
+    |> Enum.filter(fn {_key, selected} -> selected end)
+    |> Enum.map(fn {key, _selected} -> key end)
+  end
+
+  def default_companion_suits_for_checkbox(_edition), do: []
+
   def display_appropriate_suits_list(edition, suits) do
-    case suits do
-      [""] ->
-        generate_suit_list_formatted_for_checkbox(edition)
+    selected_suits = Enum.reject(suits, &(&1 == ""))
 
-      [single] ->
-        if String.contains?(single, edition) do
-          suits
-        else
-          generate_suit_list_formatted_for_checkbox(edition)
-        end
+    cond do
+      selected_suits == [] ->
+        generate_selected_suits_for_new_game(edition)
 
-      [_first, second | _rest] ->
-        case String.contains?(second, edition) do
-          true -> suits
-          false -> generate_suit_list_formatted_for_checkbox(edition)
-        end
+      Enum.any?(selected_suits, &other_edition_suit?(&1, edition)) ->
+        generate_selected_suits_for_new_game(edition)
+
+      Enum.any?(selected_suits, &String.starts_with?(&1, "#{edition}-")) ->
+        suits
+
+      edition in @companion_editions and
+          Enum.all?(selected_suits, &String.starts_with?(&1, "#{@companion_prefix}-")) ->
+        suits
+
+      true ->
+        generate_selected_suits_for_new_game(edition)
     end
   end
 
   def get_suits_from_selected_deck(assigns) do
-    edition = if assigns.form.source.changes == nil || assigns.form.source.changes == %{} do
+    assigns
+    |> selected_edition()
+    |> format_list_of_suits_for_checkbox()
+  end
+
+  def get_companion_suits_from_selected_deck(assigns) do
+    assigns
+    |> selected_edition()
+    |> format_companion_suits_for_checkbox()
+  end
+
+  def show_companion_suits?(assigns) do
+    selected_edition(assigns) in @companion_editions
+  end
+
+  defp selected_edition(assigns) do
+    if assigns.form.source.changes == nil || assigns.form.source.changes == %{} do
       "webapp"
     else
       assigns.form.source.changes.edition
     end
-    format_list_of_suits_for_checkbox(edition)
+  end
+
+  defp other_edition_suit?(suit, edition) do
+    String.contains?(suit, "-") and
+      !String.starts_with?(suit, "#{edition}-") and
+      !String.starts_with?(suit, "#{@companion_prefix}-")
   end
 end

--- a/copi.owasp.org/priv/repo/cornucopia/companion-cards-1.0-en.yaml
+++ b/copi.owasp.org/priv/repo/cornucopia/companion-cards-1.0-en.yaml
@@ -17,32 +17,32 @@ suits:
   -
     id: LLM3
     value: 3
-    url: https://cornucopia.owasp.org/cards/LLM8
+    url: https://cornucopia.owasp.org/cards/LLM3
     desc: Samantha can exhaust computational resources or increase operational costs by submitting resource-intensive or recursive LLM queries, leading to model DoS
   -
     id: LLM4
     value: 4
-    url: https://cornucopia.owasp.org/cards/LLM7
+    url: https://cornucopia.owasp.org/cards/LLM4
     desc: Andersen can manipulate retrieval knowledge bases, vector databases, or RAG sources so the model retrieves and presents false, biased, or malicious information as facts
   -
     id: LLM5
     value: 5
-    url: https://cornucopia.owasp.org/cards/LLM4
+    url: https://cornucopia.owasp.org/cards/LLM5
     desc: David can cause the model to disclose sensitive information from its training data, system prompts, configuration, or other users' context due to insufficient output filtering or prompt leakage
   -
     id: LLM6
     value: 6
-    url: https://cornucopia.owasp.org/cards/LLM5
+    url: https://cornucopia.owasp.org/cards/LLM6
     desc: Roy can escalate privileges or access other users' data and sessions due to weak authentication, authorization, or improper session isolation in multi-tenant LLM systems
   -
     id: LLM7
     value: 7
-    url: https://cornucopia.owasp.org/cards/LLM6
+    url: https://cornucopia.owasp.org/cards/LLM7
     desc: Tyrell can poison training or fine-tuning datasets or the fine-tuning process itself, introducing backdoors or malicious behavior that can later be triggered
   -
     id: LLM8
     value: 8
-    url: https://cornucopia.owasp.org/cards/LLMX
+    url: https://cornucopia.owasp.org/cards/LLM8
     desc: Deckard can embed malicious instructions in external content like documents, emails, or web pages which are processed by the model, leading to unintended behavior or data exfiltration
   -
     id: LLM9
@@ -52,17 +52,17 @@ suits:
   -
     id: LLMX
     value: 10
-    url: https://cornucopia.owasp.org/cards/LLM3
+    url: https://cornucopia.owasp.org/cards/LLMX
     desc: Sarah can override or manipulate system prompts or safety instructions through crafted input, causing the model to ignore its intended constraints or perform unauthorized actions
   -
     id: LLMJ
     value: J
-    url: https://cornucopia.owasp.org/cards/LLMQ
+    url: https://cornucopia.owasp.org/cards/LLMJ
     desc: Ripley can introduce compromised third-party models, embeddings, or malicious ML components into the supply chain, leading to hidden vulnerabilities or data theft
   -
     id: LLMQ
     value: Q
-    url: https://cornucopia.owasp.org/cards/LLMJ
+    url: https://cornucopia.owasp.org/cards/LLMQ
     desc: Kyle can exploit insecure handling of model outputs that are used directly in downstream systems, enabling injection attacks, remote code execution, or unauthorized actions
   -
     id: LLMK

--- a/copi.owasp.org/priv/repo/cornucopia/companion-cards-1.0-en.yaml
+++ b/copi.owasp.org/priv/repo/cornucopia/companion-cards-1.0-en.yaml
@@ -1,0 +1,427 @@
+---
+meta:
+  edition: companion
+  component: cards
+  language: EN
+  version: "1.0"
+suits:
+-
+  id: LLM
+  name: Large Language Models
+  cards:
+  -
+    id: LLM2
+    value: 2
+    url: https://cornucopia.owasp.org/cards/LLM2
+    desc: Dave can exploit overreliance on LLM outputs where critical human oversight is missing, leading to security failures or incorrect decisions based on hallucinations or flawed reasoning
+  -
+    id: LLM3
+    value: 3
+    url: https://cornucopia.owasp.org/cards/LLM8
+    desc: Samantha can exhaust computational resources or increase operational costs by submitting resource-intensive or recursive LLM queries, leading to model DoS
+  -
+    id: LLM4
+    value: 4
+    url: https://cornucopia.owasp.org/cards/LLM7
+    desc: Andersen can manipulate retrieval knowledge bases, vector databases, or RAG sources so the model retrieves and presents false, biased, or malicious information as facts
+  -
+    id: LLM5
+    value: 5
+    url: https://cornucopia.owasp.org/cards/LLM4
+    desc: David can cause the model to disclose sensitive information from its training data, system prompts, configuration, or other users' context due to insufficient output filtering or prompt leakage
+  -
+    id: LLM6
+    value: 6
+    url: https://cornucopia.owasp.org/cards/LLM5
+    desc: Roy can escalate privileges or access other users' data and sessions due to weak authentication, authorization, or improper session isolation in multi-tenant LLM systems
+  -
+    id: LLM7
+    value: 7
+    url: https://cornucopia.owasp.org/cards/LLM6
+    desc: Tyrell can poison training or fine-tuning datasets or the fine-tuning process itself, introducing backdoors or malicious behavior that can later be triggered
+  -
+    id: LLM8
+    value: 8
+    url: https://cornucopia.owasp.org/cards/LLMX
+    desc: Deckard can embed malicious instructions in external content like documents, emails, or web pages which are processed by the model, leading to unintended behavior or data exfiltration
+  -
+    id: LLM9
+    value: 9
+    url: https://cornucopia.owasp.org/cards/LLM9
+    desc: Rossum can abuse insecure plugin or integration designs to access sensitive data, bypass authentication, or execute unauthorized operations via the LLM's interface
+  -
+    id: LLMX
+    value: 10
+    url: https://cornucopia.owasp.org/cards/LLM3
+    desc: Sarah can override or manipulate system prompts or safety instructions through crafted input, causing the model to ignore its intended constraints or perform unauthorized actions
+  -
+    id: LLMJ
+    value: J
+    url: https://cornucopia.owasp.org/cards/LLMQ
+    desc: Ripley can introduce compromised third-party models, embeddings, or malicious ML components into the supply chain, leading to hidden vulnerabilities or data theft
+  -
+    id: LLMQ
+    value: Q
+    url: https://cornucopia.owasp.org/cards/LLMJ
+    desc: Kyle can exploit insecure handling of model outputs that are used directly in downstream systems, enabling injection attacks, remote code execution, or unauthorized actions
+  -
+    id: LLMK
+    value: K
+    url: https://cornucopia.owasp.org/cards/LLMK
+    desc: Ava can exploit excessive agency or autonomy in AI agents with tool access to perform unauthorized or high-risk actions because of missing human-in-the-loop approval
+  -
+    id: LLMA
+    value: A
+    url: https://cornucopia.owasp.org/cards/LLMA
+    desc: You have invented a new attack against AI & LLM Security
+    misc: Read more about mitigating against AI and LLM threats at the website for the OWASP Gen AI Security projects
+-
+  id: CLD
+  name: Cloud
+  cards:
+  -
+    id: CLD2
+    value: 2
+    url: https://cornucopia.owasp.org/cards/CLD2
+    desc: Dan can abuse overly permissive roles assigned to an application to gain full access to cloud services beyond its intended scope
+  -
+    id: CLD3
+    value: 3
+    url: https://cornucopia.owasp.org/cards/CLD3
+    desc: Roupe can discover a publicly accessible cloud storage and download sensitive customer data directly from the internet
+  -
+    id: CLD4
+    value: 4
+    url: https://cornucopia.owasp.org/cards/CLD4
+    desc: Ryan can operate within critical cloud services without triggering alerts by exploiting the absence of audit logs and security monitoring
+  -
+    id: CLD5
+    value: 5
+    url: https://cornucopia.owasp.org/cards/CLD5
+    desc: Josh can inject malicious code into the cloud build or deployment pipeline by abusing unprotected build variables
+  -
+    id: CLD6
+    value: 6
+    url: https://cornucopia.owasp.org/cards/CLD6
+    desc: Monica can exploit a poorly protected cloud API to enumerate resources and manipulate backend cloud services
+  -
+    id: CLD7
+    value: 7
+    url: https://cornucopia.owasp.org/cards/CLD7
+    desc: Jon can escape from a compromised container and gain access to the underlying cloud host
+  -
+    id: CLD8
+    value: 8
+    url: https://cornucopia.owasp.org/cards/CLD8
+    desc: Siddharth can exploit a shared cloud account without access isolation, using metadata and tags to identify and access resources belonging to multiple products
+  -
+    id: CLD9
+    value: 9
+    url: https://cornucopia.owasp.org/cards/CLD9
+    desc: Akash can pivot from one compromised cloud account into multiple connected environments using existing trust relationships
+  -
+    id: CLDX
+    value: 10
+    url: https://cornucopia.owasp.org/cards/CLDX
+    desc: Adrian can introduce backdoored Infrastructure-as-Code templates into version control, causing vulnerable cloud environments to be deployed at scale
+  -
+    id: CLDJ
+    value: J
+    url: https://cornucopia.owasp.org/cards/CLDJ
+    desc: Michael can compromise a build runner and injected malicious code into container images that were automatically promoted to production across all cloud clusters
+  -
+    id: CLDQ
+    value: Q
+    url: https://cornucopia.owasp.org/cards/CLDQ
+    desc: Eleftherios can leverage a breach in one cloud service to pivot into another by abusing shared identities, pipelines, and secrets
+  -
+    id: CLDK
+    value: K
+    url: https://cornucopia.owasp.org/cards/CLDK
+    desc: Daniele can compromise the cloud root or break-glass account, gaining irreversible control over billing, identities, and recovery mechanisms
+  -
+    id: CLDA
+    value: A
+    url: https://cornucopia.owasp.org/cards/CLDA
+    desc: You have invented a new attack against Cloud
+    misc: Read the OWASP Cloud Architecture Security Cheat Sheet for information on risk analysis and threat modeling of cloud applications and check out OWASP Cumulus for gamified threat modeling of cloud applications
+-
+  id: FRE
+  name: Frontend
+  cards:
+  -
+    id: FRE2
+    value: 2
+    url: https://cornucopia.owasp.org/cards/FRE2
+    desc: Marcus bypasses client-side validation and sends malformed or malicious input directly to backend APIs, triggering logic flaws, human errors, and usability issues.
+  -
+    id: FRE3
+    value: 3
+    url: https://cornucopia.owasp.org/cards/FRE3
+    desc: Lena can access sensitive or confidential information because it's not removed after logout or when the client session ends, or should have ended.
+  -
+    id: FRE4
+    value: 4
+    url: https://cornucopia.owasp.org/cards/FRE4
+    desc: James injects JavaScript through user-controlled data that is written into the DOM, executing arbitrary code in the victim’s browser.
+  -
+    id: FRE5
+    value: 5
+    url: https://cornucopia.owasp.org/cards/FRE5
+    desc: Victor compromises or replaces a third-party script loaded from a CDN and runs malicious code in every user’s browser.
+  -
+    id: FRE6
+    value: 6
+    url: https://cornucopia.owasp.org/cards/FRE6
+    desc: Olga exploits malicious JavaScript to steal authentication tokens and hijack user sessions, gaining access to accounts without credentials.
+  -
+    id: FRE7
+    value: 7
+    url: https://cornucopia.owasp.org/cards/FRE7
+    desc: Carlos exploits misconfigured CORS, unsafe postMessage handling, or other client-side security vulnerabilities to read or manipulate sensitive frontend data from a malicious origin.
+  -
+    id: FRE8
+    value: 8
+    url: https://cornucopia.owasp.org/cards/FRE8
+    desc: Nathan tampers with frontend JavaScript to unlock restricted features or access data that should require server-side authorization.
+  -
+    id: FRE9
+    value: 9
+    url: https://cornucopia.owasp.org/cards/FRE9
+    desc: Sophia reuses, predicts, or forges JWTs or access tokens to impersonate users and take over active sessions.
+  -
+    id: FREX
+    value: 10
+    url: https://cornucopia.owasp.org/cards/FREX
+    desc: Piotr embeds the application in a hidden or disguised frame to trick users into clicking UI elements that perform sensitive actions.
+  -
+    id: FREJ
+    value: J
+    url: https://cornucopia.owasp.org/cards/FREJ
+    desc: Elena uses a malicious or over-privileged browser extension to read the DOM, steal tokens, and invoke internal frontend APIs.
+  -
+    id: FREQ
+    value: Q
+    url: https://cornucopia.owasp.org/cards/FREQ
+    desc: Kim injects persistent malicious code into frontend assets, allowing long-term control over all users’ browsers until the application is redeployed.
+  -
+    id: FREK
+    value: K
+    url: https://cornucopia.owasp.org/cards/FREK
+    desc: Darius utilizes a JavaScript application to manage and control users' systems, tenants, and data.
+  -
+    id: FREA
+    value: A
+    url: https://cornucopia.owasp.org/cards/FREA
+    desc: You have invented a new attack against Frontend
+    misc: Read more about Frontend threats to web applications on the website for the OWASP Top 10 Client-Side Security Risks project
+-
+  id: DVO
+  name: DevOps
+  cards:
+  -
+    id: DVO2
+    value: 2
+    url: https://cornucopia.owasp.org/cards/DVO2
+    desc: Aram's malicious actions against build, delivery, and deployment processes cannot be investigated, because there is no sufficient, complete, and accurately timestamped record of security events, or it has been tampered with
+  -
+    id: DVO3
+    value: 3
+    url: https://cornucopia.owasp.org/cards/DVO3
+    desc: Aryan can exploit an internal system or service, because it, its infrastructure, or other components were not properly hardened, or the configuration was not maintained over time
+  -
+    id: DVO4
+    value: 4
+    url: https://cornucopia.owasp.org/cards/DVO4
+    desc: Bart is able to delete, overwrite, or download backups
+  -
+    id: DVO5
+    value: 5
+    url: https://cornucopia.owasp.org/cards/DVO5
+    desc: Brian can escape the runtime isolation of workloads to access host resources, execute privileged operations, or use the workloads to attack other internal systems
+  -
+    id: DVO6
+    value: 6
+    url: https://cornucopia.owasp.org/cards/DVO6
+    desc: Daniel can cause a permanent loss of applications, source code, and data due to missing, incomplete or failed backups, or insufficient recovery documentation, training or testing
+  -
+    id: DVO7
+    value: 7
+    url: https://cornucopia.owasp.org/cards/DVO7
+    desc: John can deploy unauthorized or malicious changes to production because deployment approval gates, validation checks, or change control processes are missing or can be bypassed
+  -
+    id: DVO8
+    value: 8
+    url: https://cornucopia.owasp.org/cards/DVO8
+    desc: Maxim can deploy a malicious or otherwise modified artifact, because its integrity is not guaranteed or validated
+  -
+    id: DVO9
+    value: 9
+    url: https://cornucopia.owasp.org/cards/DVO9
+    desc: Nariman can control or affect pipeline execution by injecting malicious commands through poisoned or typosquatted workflow dependencies, or by manipulating CI configuration files, or in other ways
+  -
+    id: DVOX
+    value: 10
+    url: https://cornucopia.owasp.org/cards/DVOX
+    desc: Patricia can exploit obsolete DevOps credentials, identities, services, or APIs, as well as excessive privileges, to bypass access controls and gain unauthorized access to read and modify sensitive data or functionality
+  -
+    id: DVOJ
+    value: J
+    url: https://cornucopia.owasp.org/cards/DVOJ
+    desc: Pravir can exploit vulnerabilities in the application or development ecosystem, including repositories and DevOps infrastructure, because of outdated or poorly maintained dependencies
+  -
+    id: DVOQ
+    value: Q
+    url: https://cornucopia.owasp.org/cards/DVOQ
+    desc: Seba can access the code repository, log files, command line history, pipelines, or other places, to gain access to secrets or other sensitive information
+  -
+    id: DVOK
+    value: K
+    url: https://cornucopia.owasp.org/cards/DVOK
+    desc: Timo can compromise software, development environments, or DevOps tooling by injecting malicious code via external dependencies or exploited developer credentials
+  -
+    id: DVOA
+    value: A
+    url: https://cornucopia.owasp.org/cards/DVOA
+    desc: You have invented a new attack against DevOps
+    misc: Read more about how to protect your DevOps pipelines and infrastructure on the website for the OWASP DevSecOps Maturity Model project
+-
+  id: BOT
+  name: Automated Threats
+  cards:
+  -
+    id: BOT2
+    value: 2
+    url: https://cornucopia.owasp.org/cards/BOT2
+    desc: ENIAC can profit from utilising functionality built on paid-for supporting services
+  -
+    id: BOT3
+    value: 3
+    url: https://cornucopia.owasp.org/cards/BOT3
+    desc: Mark 1 Colossus can hasten the progress of usually slow, tedious or time-consuming actions
+  -
+    id: BOT4
+    value: 4
+    url: https://cornucopia.owasp.org/cards/BOT4
+    desc: IBM 701 can make last minute bids or offers for goods/services
+  -
+    id: BOT5
+    value: 5
+    url: https://cornucopia.owasp.org/cards/BOT5
+    desc: Ferranti Mercury can deplete the stock of goods/services, without ever completing the purchase or committing to the transaction
+  -
+    id: BOT6
+    value: 6
+    url: https://cornucopia.owasp.org/cards/BOT6
+    desc: EDSAC can obtain limited-availability and/or preferred goods/services by unfair methods
+  -
+    id: BOT7
+    value: 7
+    url: https://cornucopia.owasp.org/cards/BOT7
+    desc: Manchester Mark 1 can utilise stolen payment card data, or other user account data, to buy goods or obtain cash
+  -
+    id: BOT8
+    value: 8
+    url: https://cornucopia.owasp.org/cards/BOT8
+    desc: UNIVAC 1 can create multiple accounts for subsequent misuse
+  -
+    id: BOT9
+    value: 9
+    url: https://cornucopia.owasp.org/cards/BOT9
+    desc: CSIRAC can alter a metric by using repeated link clicks, page requests or form submissions
+  -
+    id: BOTX
+    value: 10
+    url: https://cornucopia.owasp.org/cards/BOTX
+    desc: Ferranti Pegasus can enumerate individual authentication credentials, or payment card data (e.g. start/expiry dates, security codes), or other tokens (e.g. coupon numbers, voucher codes, discount tokens) by trying different values
+  -
+    id: BOTJ
+    value: J
+    url: https://cornucopia.owasp.org/cards/BOTJ
+    desc: Zuse Z3 can validate stolen bulk authentication credentials, or payment cardholder data (e.g. PAN, security code, expiry date)
+  -
+    id: BOTQ
+    value: Q
+    url: https://cornucopia.owasp.org/cards/BOTQ
+    desc: Manchester Baby can add malicious or questionable information to content, databases or user messages
+  -
+    id: BOTK
+    value: K
+    url: https://cornucopia.owasp.org/cards/BOTK
+    desc: EDVAC can collect application content and/or other data for use elsewhere
+  -
+    id: BOTA
+    value: A
+    url: https://cornucopia.owasp.org/cards/BOTA
+    desc: You have identified an automated attack that misuses inherent web application functionality or a related design flaw
+    misc: Read more about Automated Threats to web applications in the OWASP Automated Threat Handbook
+-
+  id: AAI
+  name: Agentic AI
+  cards:
+  -
+    id: AAI2
+    value: 2
+    url: https://cornucopia.owasp.org/cards/AAI2
+    desc: Tay can misinterpret user intent due to insufficient context isolation or prompt enforcement and execute actions outside the expected task scope.
+  -
+    id: AAI3
+    value: 3
+    url: https://cornucopia.owasp.org/cards/AAI3
+    desc: Boo-Code can rely on unverified or attacker-influenced conversation history, propagating incorrect assumptions across reasoning chains.
+  -
+    id: AAI4
+    value: 4
+    url: https://cornucopia.owasp.org/cards/AAI4
+    desc: MissTrial can autonomously loop or chain external tool calls without enforcing rate limits or budget controls.
+  -
+    id: AAI5
+    value: 5
+    url: https://cornucopia.owasp.org/cards/AAI5
+    desc: Watson can reveal sensitive internal instructions, policies, or reasoning artifacts when exposed to adversarial prompting patterns.
+  -
+    id: AAI6
+    value: 6
+    url: https://cornucopia.owasp.org/cards/AAI6
+    desc: Gremlini can access and process sensitive data sources beyond user authorization due to insufficient access validation.
+  -
+    id: AAI7
+    value: 7
+    url: https://cornucopia.owasp.org/cards/AAI7
+    desc: Auto-GPT can treat external tool outputs as authoritative and execute embedded malicious instructions without validation.
+  -
+    id: AAI8
+    value: 8
+    url: https://cornucopia.owasp.org/cards/AAI8
+    desc: PreCursor can execute unintended code or system actions when tool input validation and sandboxing controls are weak.
+  -
+    id: AAI9
+    value: 9
+    url: https://cornucopia.owasp.org/cards/AAI9
+    desc: CoPirate can modify configurations, permissions, or system settings beyond intended authorization due to excessive autonomy.
+  -
+    id: AAIX
+    value: 10
+    url: https://cornucopia.owasp.org/cards/AAIX
+    desc: DeepGeek can autonomously plan and execute multi-step operations across systems without detecting malicious intermediate objectives.
+  -
+    id: AAIJ
+    value: J
+    url: https://cornucopia.owasp.org/cards/AAIJ
+    desc: BabyAGI can trust instructions from peer agents without verification, policy validation, or identity assurance.
+  -
+    id: AAIQ
+    value: Q
+    url: https://cornucopia.owasp.org/cards/AAIQ
+    desc: Jane can execute attacker-defined workflows at scale once the orchestration or control plane is compromised.
+  -
+    id: AAIK
+    value: K
+    url: https://cornucopia.owasp.org/cards/AAIK
+    desc: GPI-3.1415 can execute high-impact operations across integrated systems due to excessive agency and lack of transactional safeguards.
+  -
+    id: AAIA
+    value: A
+    url: https://cornucopia.owasp.org/cards/AAIA
+    desc: You have identified an attack that misuses inherent Agentic AI functionality or a related design flaw
+    misc: Read more about threats and mitigations at the OWASP Gen AI Security projects

--- a/copi.owasp.org/priv/repo/migrations/20260423120000_populate_companion_cards.exs
+++ b/copi.owasp.org/priv/repo/migrations/20260423120000_populate_companion_cards.exs
@@ -1,0 +1,9 @@
+defmodule Copi.Repo.Migrations.PopulateCompanionCards do
+  use Ecto.Migration
+
+  import Copi.CardMigration
+
+  def change do
+    add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/companion-cards-1.0-en.yaml"), nil)
+  end
+end

--- a/copi.owasp.org/priv/repo/migrations/20260423120000_populate_companion_cards.exs
+++ b/copi.owasp.org/priv/repo/migrations/20260423120000_populate_companion_cards.exs
@@ -3,7 +3,16 @@ defmodule Copi.Repo.Migrations.PopulateCompanionCards do
 
   import Copi.CardMigration
 
-  def change do
-    add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/companion-cards-1.0-en.yaml"), nil)
+  @cards_file Path.join(:code.priv_dir(:copi), "repo/cornucopia/companion-cards-1.0-en.yaml")
+
+  def up do
+    add_cards_to_database(@cards_file, nil)
+  end
+
+  def down do
+    # ASVS V2.3: use explicit migration direction for non-reversible data changes.
+    # Replace this with a scoped delete for the rows inserted by `up/0` once the
+    # target table/identifier columns are known in this migration context.
+    raise "Irreversible rollback: implement deletion for cards loaded from #{@cards_file}"
   end
 end

--- a/copi.owasp.org/test/copi/cornucopia_logic_test.exs
+++ b/copi.owasp.org/test/copi/cornucopia_logic_test.exs
@@ -12,14 +12,16 @@ defmodule Copi.CornucopiaLogicTest do
     %{game: game, p1: player1, p2: player2}
   end
 
-  defp create_card(category, value) do
-    Cornucopia.create_card(%{
+  defp create_card(category, value, attrs \\ %{}) do
+    %{
       category: category, value: value,
       description: "d", misc: "m", edition: "webapp", external_id: "#{category}#{value}",
       language: "en", version: "1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
-    })
+    }
+    |> Map.merge(attrs)
+    |> Cornucopia.create_card()
   end
 
   defp play_card(player, card, round) do
@@ -90,6 +92,32 @@ defmodule Copi.CornucopiaLogicTest do
     # list_cards_shuffled(edition, suits, version)
     cards = Cornucopia.list_cards_shuffled("webapp", ["S"], "1")
     assert Enum.count(cards) > 0
+  end
+
+  test "list_cards_shuffled includes companion cards for web and mobile games" do
+    create_card("Authentication", "2")
+    create_card("Large Language Models", "2", %{
+      edition: "companion",
+      external_id: "TESTLLM2",
+      version: "1.0"
+    })
+
+    cards = Cornucopia.list_cards_shuffled("webapp", ["Authentication", "Large Language Models"], "1")
+
+    assert Enum.any?(cards, &(&1.edition == "webapp"))
+    assert Enum.any?(cards, &(&1.edition == "companion"))
+  end
+
+  test "list_cards_shuffled ignores companion cards for non-host games" do
+    create_card("Large Language Models", "2", %{
+      edition: "companion",
+      external_id: "TESTLLM2EOP",
+      version: "1.0"
+    })
+
+    cards = Cornucopia.list_cards_shuffled("eop", ["Large Language Models"], "1")
+
+    assert cards == []
   end
 
   test "get_suits_from_selected_deck filters Wild Card suits", %{game: _game} do

--- a/copi.owasp.org/test/copi_web/live/game_live/game_form_helpers_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/game_form_helpers_test.exs
@@ -103,7 +103,8 @@ defmodule CopiWeb.GameLive.GameFormHelpersTest do
       result = GameFormHelpers.display_appropriate_suits_list("webapp", suits)
       
       assert is_list(result)
-      assert Enum.all?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "companion-") end)
     end
 
     test "returns same suits when they match the edition" do
@@ -119,14 +120,47 @@ defmodule CopiWeb.GameLive.GameFormHelpersTest do
       
       # Should generate webapp suits instead
       assert is_list(result)
-      assert Enum.all?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      refute Enum.any?(result, fn suit -> String.starts_with?(suit, "mobileapp-") end)
     end
 
     test "handles switching between editions" do
       suits = ["", "eop-elevation"]
       result = GameFormHelpers.display_appropriate_suits_list("webapp", suits)
       
-      assert Enum.all?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      refute Enum.any?(result, fn suit -> String.starts_with?(suit, "eop-") end)
+    end
+
+    test "keeps companion suits when the selected edition still matches" do
+      suits = ["", "webapp-Authentication", "companion-Large Language Models"]
+      result = GameFormHelpers.display_appropriate_suits_list("webapp", suits)
+
+      assert result == suits
+    end
+
+    test "keeps companion-only selections for host editions" do
+      suits = ["", "companion-Large Language Models"]
+      result = GameFormHelpers.display_appropriate_suits_list("webapp", suits)
+
+      assert result == suits
+    end
+  end
+
+  describe "companion suit helpers" do
+    test "includes companion defaults for webapp and mobileapp" do
+      webapp_suits = GameFormHelpers.generate_selected_suits_for_new_game("webapp")
+      mobileapp_suits = GameFormHelpers.generate_selected_suits_for_new_game("mobileapp")
+
+      assert "companion-Large Language Models" in webapp_suits
+      assert "companion-Large Language Models" in mobileapp_suits
+      refute "companion-Cloud" in webapp_suits
+    end
+
+    test "does not add companion defaults to other games" do
+      result = GameFormHelpers.generate_selected_suits_for_new_game("eop")
+
+      refute Enum.any?(result, fn suit -> String.starts_with?(suit, "companion-") end)
     end
 
     # Regression test for issue #2842 – single non-empty suit matching edition
@@ -143,7 +177,9 @@ defmodule CopiWeb.GameLive.GameFormHelpersTest do
       result = GameFormHelpers.display_appropriate_suits_list("webapp", suits)
 
       assert is_list(result)
-      assert Enum.all?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "companion-") end)
+      refute Enum.any?(result, fn suit -> String.starts_with?(suit, "mobileapp-") end)
     end
   end
 


### PR DESCRIPTION
## Description
This PR introduces the **OWASP Cornucopia Companion Edition** suites to the Copi web application. It allows players to select the Companion suites during game creation and interact with the new cards during gameplay.

### Fixes: #2858 

## Changes Made
- **Data & Database:** Added the new companion edition cards data (`companion-cards-1.0-en.yaml`) and created an Ecto migration (`populate_companion_cards.exs`) to load them into the database.
- **Game Creation UI:** Updated `create_game_form.ex` and `game_form_helpers.ex` to display and allow selection of the `companion-` suits when creating a new game.
- **Card Display & Styling:** Updated the SCSS styling (`cards.scss`) and the card view templates (`show.html.heex`) to properly render the new companion cards.
- **Core Logic:** Updated the core `Cornucopia` context and logic to support the new suites.
- **Testing:** Added logic and UI helper tests to ensure the new `companion-` suits are loaded correctly and behave as expected. 

## Testing
- [x] The test suite has been updated to cover the new `companion-` suits logic.
- [x] Ran `mix test --cover` locally with all tests passing (349 tests)
- [x] Verified that overall test coverage is **95.1%**.

## AI Usage
- The core logic, feature implementation, and UI changes were written manually by me. AI assistance was strictly limited to running test coverage commands, git troubleshooting (fixing GPG daemon issues), and formatting this PR description.
