### PR TITLE
Fixed raw malicious content stored in db

### DIFF
--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -32,7 +32,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-    |> validate_format(:name, ~r/^[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\uFDF2\uFDF3\uFDF4\uFDFD\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uFF66-\uFF9Fー々〆〤\u3400-\u4DBF\uF900-\uFAFF\u0900-\u097F\u0621-\u064A\u0660-\u0669\u0E00-\u0E7F«»฿ฯ๏๚๛\u0400-\u04FF\u0500-\u052F\u2DE0-\u2DFF\uA640-\uA69FЮ́ю́Я́я́\u0370-\u03FF\u1F00-\u1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ \s]+$/,
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲ🷴🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/,
       message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -32,8 +32,8 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲ🷴🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/,
-      message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\-'"ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ﷲﷴ🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/ux,
+      message: "contains invalid characters. Only letters, numbers, spaces, and ._-'\" are allowed.")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -32,7 +32,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\-'"ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ﷲﷴ🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/ux,
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\-'"ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ﷲ🷴🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/ux,
       message: "contains invalid characters. Only letters, numbers, spaces, and ._-'\" are allowed.")
   end
 

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -1,4 +1,4 @@
-defmodule Copi.Cornucopia.Game do
++copi.owasp.org\lib\copi\cornucopia\game.exdefmodule Copi.Cornucopia.Game do
   use Ecto.Schema
   import Ecto.Changeset
 
@@ -32,6 +32,8 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
+    |> validate_format(:name, ~r/^[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\uFDF2\uFDF3\uFDF4\uFDFD\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uFF66-\uFF9Fー々〆〤\u3400-\u4DBF\uF900-\uFAFF\u0900-\u097F\u0621-\u064A\u0660-\u0669\u0E00-\u0E7F«»฿ฯ๏๚๛\u0400-\u04FF\u0500-\u052F\u2DE0-\u2DFF\uA640-\uA69FЮ́ю́Я́я́\u0370-\u03FF\u1F00-\u1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ \s]+$/,
+      message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -1,4 +1,4 @@
-+copi.owasp.org\lib\copi\cornucopia\game.exdefmodule Copi.Cornucopia.Game do
++defmodule Copi.Cornucopia.Game do
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -1,4 +1,4 @@
-+defmodule Copi.Cornucopia.Game do
+defmodule Copi.Cornucopia.Game do
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -27,7 +27,7 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\-'"ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ﷲﷴ🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/ux,
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\-'"ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ﷲ🷴🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/ux,
       message: "contains invalid characters. Only letters, numbers, spaces, and ._-'\" are allowed.")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -27,7 +27,7 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-    |> validate_format(:name, ~r/^[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\uFDF2\uFDF3\uFDF4\uFDFD\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uFF66-\uFF9Fー々〆〤\u3400-\u4DBF\uF900-\uFAFF\u0900-\u097F\u0621-\u064A\u0660-\u0669\u0E00-\u0E7F«»฿ฯ๏๚๛\u0400-\u04FF\u0500-\u052F\u2DE0-\u2DFF\uA640-\uA69FЮ́ю́Я́я́\u0370-\u03FF\u1F00-\u1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ \s]+$/,
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ \s]+$/,
       message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -27,7 +27,7 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ \s]+$/,
-      message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}ー々〆〤\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}«»฿ฯ๏๚๛\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}Ю́ю́Я́я́\x{0370}-\x{03FF}\x{1F00}-\x{1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\-'"ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ﷲﷴ🷺🷻 ٠١٢٣٤٥٦٧٨٩ \s]+$/ux,
+      message: "contains invalid characters. Only letters, numbers, spaces, and ._-'\" are allowed.")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -27,5 +27,7 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
+    |> validate_format(:name, ~r/^[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\uFDF2\uFDF3\uFDF4\uFDFD\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uFF66-\uFF9Fー々〆〤\u3400-\u4DBF\uF900-\uFAFF\u0900-\u097F\u0621-\u064A\u0660-\u0669\u0E00-\u0E7F«»฿ฯ๏๚๛\u0400-\u04FF\u0500-\u052F\u2DE0-\u2DFF\uA640-\uA69FЮ́ю́Я́я́\u0370-\u03FF\u1F00-\u1FFFA-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9._\--ءآأؤإئابةتثجحخدذرزسشصضطظعغفقكلمنهوي ًٌٍَُِّْٰﷲﷴﷺﷻ ٠١٢٣٤٥٦٧٨٩ \s]+$/,
+      message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 end

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -553,7 +553,7 @@ def parse_arguments(input_args: List[str]) -> argparse.Namespace:
         type=is_valid_string_argument,
         default="en",
         help=(
-            f"Output language to produce (e.g: all, en, es, fr, nl, no_nb, pt_br, pt_pt, it, ru, uk, hi) "
+            "Output language to produce (e.g: all, en, es, fr, nl, no_nb, pt_br, pt_pt, it, ru, uk, hi) "
             "you can also specify your own language file. If so, there needs to be a yaml "
             "file in the source folder where the name ends with the language code. Eg. edition-template-ver-lang.yaml "
             "You also need to have the code defined as part of the meta info in the yaml meta -> language -> en "


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Games, playing cards, and requirement mapping related to these playing cards generated by LLM.
It takes a lot of time to make sure AI-generated games actually work. It's not only generating the content, 
you also need to make sure others want to play the game. We also have to check that the content is appropriate
and makes sense. Therefore, it's not really a help to us that you have AI-generated games. 
If we wanted AI-generated games, we would create them ourselves.

🚫 Spam PRs (accidental or intentional) - these will result in a 30-day or even
∞ ban from interacting with the project depending on recurrence and severity.
You can find more information [here](https://pwning.owasp-juice.shop/companion-guide/latest/part3/contribution.html#_handling_of_spam_prs). 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
I've implemented input validation for player and game names to prevent storing malicious HTML/JS payloads. The validation uses the provided regex pattern to allow only safe characters.

__Changes made:__

1. __`copi.owasp.org/lib/copi/cornucopia/player.ex`__ (line 30-31):

   - Added `validate_format/3` to the changeset that validates the `:name` field against the provided regex pattern
   - Rejects names containing HTML tags, JavaScript, or other unsafe characters

2. __`copi.owasp.org/lib/copi/cornucopia/game.ex`__ (line 35-36):

   - Added the same `validate_format/3` validation to the game changeset for the `:name` field

Resolved or fixed issue: #2555 

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
