### PR TITLE
Add companion edition mapping API endpoint (closes #2929)

### DIFF
--- a/cornucopia.owasp.org/script/headers-stage.js
+++ b/cornucopia.owasp.org/script/headers-stage.js
@@ -67,6 +67,11 @@ function main() {
   Access-Control-Allow-Origin: *
   ! Content-Type
   Content-Type: application/json
+/api/mapping/companion/1.0
+  ! Access-Control-Allow-Origin
+  Access-Control-Allow-Origin: *
+  ! Content-Type
+  Content-Type: application/json
 /api/cre/mobileapp/en
   ! Access-Control-Allow-Origin
   Access-Control-Allow-Origin: *
@@ -124,3 +129,4 @@ function main() {
 }
 
 main();
+

--- a/cornucopia.owasp.org/script/headers.js
+++ b/cornucopia.owasp.org/script/headers.js
@@ -128,6 +128,11 @@ function main() {
   Access-Control-Allow-Origin: *
   ! Content-Type
   Content-Type: application/json
+/api/mapping/companion/1.0
+  ! Access-Control-Allow-Origin
+  Access-Control-Allow-Origin: *
+  ! Content-Type
+  Content-Type: application/json
 `;
 
   const headersFile = path.join(buildDir, '_headers');
@@ -135,3 +140,4 @@ function main() {
 }
 
 main();
+

--- a/cornucopia.owasp.org/static/api/openapi.yaml
+++ b/cornucopia.owasp.org/static/api/openapi.yaml
@@ -287,6 +287,48 @@ paths:
                           capec: [ 54, 113, 116, 143, 144, 149, 150, 155, 169, 215, 224, 497, 541, 546 ]
                           capec_map: {}
 
+  /mapping/companion/{version}:
+    get:
+      summary: Get Companion Edition mapping by version
+      description: |
+        Get the OWASP Cornucopia Companion Edition mapping data
+        by version.
+      parameters:
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: ["1.0"]
+      responses:
+        '200':
+          description: Companion mapping data
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                example:
+                  summary: Example Companion mapping response
+                  value:
+                    meta:
+                      edition: companion
+                      component: mappings
+                      language: ALL
+                      version: "1.0"
+                    cards:
+                      LLM2:
+                        id: "LLM2"
+                        value: "2"
+                        url: "https://cornucopia.owasp.org/cards/LLM2"
+                        stride: [ D ]
+                        stride_print: [ "Denial of Service" ]
+                        cia: [ A ]
+                        cia_print: [ "Availability" ]
+                        owasp_llm_top10: [ LLM10:2025 ]
+                        owasp_llm_top10_print: [ "LLM10:2025: Unbounded Consumption" ]
+                        cwe: [ CWE-400, CWE-770 ]
+
   /mapping/mobileapp/{version}:
     get:
       summary: Get Mobile App mapping by version

--- a/cornucopia.owasp.org/svelte.config.js
+++ b/cornucopia.owasp.org/svelte.config.js
@@ -348,6 +348,7 @@ export default {
 				'/api/mapping/webapp/2.2',
 				'/api/mapping/webapp/3.0',
 				'/api/mapping/mobileapp/1.1',
+                                '/api/mapping/companion/1.0',
 				'/edition/mobileapp/PC2/1.1/en',
 				'/edition/mobileapp/PC2/1.1/uk',
                 '/edition/mobileapp/PC2/1.1/hi',


### PR DESCRIPTION
### Description
The companion edition mapping data was accessible internally but not exposed via the public API. This PR wires up the missing configuration to make `/api/mapping/companion/1.0` available as a public endpoint.

Changes made:
- `svelte.config.js` I added prerender entry for `/api/mapping/companion/1.0`
- `headers.js` and `headers-stage.js` then added CORS headers for the new endpoint
- `openapi.yaml`  added `/mapping/companion/{version}` endpoint documentation

No new route file was needed as the existing dynamic `[edition]/[version]` route and `MappingService` already handle the companion edition.

fixed issue: #2929
## Screenshot
before it was missing companion endpoint
<img width="959" height="469" alt="image" src="https://github.com/user-attachments/assets/9e6c0d0d-3967-430a-aab4-84786bbcc1e0" />
after
<img width="1600" height="820" alt="image" src="https://github.com/user-attachments/assets/189fe63b-c1c8-4fcb-836d-3d3482a8f004" />


### AI Tool Disclosure
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude`
    - LLMs and versions: `Claude Sonnet 4.6`
    - Prompts: `Asked Claude to help verify my changes and approach were correct`
### Affirmation
- [x] My code follows the CONTRIBUTING.md guidelines