### PR TITLE
fix: align copy URL button to left of input field on game show page

### DIFF
--- a/copi.owasp.org/lib/copi_web/components/core_components/buttons.ex
+++ b/copi.owasp.org/lib/copi_web/components/core_components/buttons.ex
@@ -58,16 +58,16 @@ defmodule CopiWeb.CoreComponents.Buttons do
 
   def copy_url_button(assigns) do
     ~H"""
-    <div id="copy-url-container" phx-hook="CopyUrl" class="flex flex-col w-full">
+    <div id="copy-url-container" phx-hook="CopyUrl" class="flex flex-row items-center w-full">
       <button
         id="copy-url-btn"
-        class="mt-2 rounded-md px-4 py-4 text-sm font-semibold shadow-sm transition-colors bg-gray-100 text-gray-800 hover:bg-gray-300 active:bg-gray-100 active:opacity-50"
+        class="rounded-md px-4 py-4 text-sm font-semibold shadow-sm transition-colors bg-gray-100 text-gray-800 hover:bg-gray-300 active:bg-gray-100 active:opacity-50"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3.535 3.535a4 4 0 01-5.656-5.656l1.414-1.414M10.172 13.828a4 4 0 010-5.656l3.535-3.535a4 4 0 015.656 5.656l-1.414 1.414" />
         </svg>
       </button>
-      <input id="copied-url" class="mt-2 w-full rounded-md px-3 py-3 text-sm font-semibold shadow-sm text-gray-500 break-all" value={@uri} />
+      <input id="copied-url" class="w-full rounded-md px-3 py-3 text-sm font-semibold shadow-sm text-gray-500 break-all" value={@uri} />
       <span id="url-copied" class="hidden">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
@@ -77,3 +77,6 @@ defmodule CopiWeb.CoreComponents.Buttons do
     """
   end
 end
+
+
+


### PR DESCRIPTION
### Description

The copy URL button on the game show page was rendered as a full-width bar above the input field due to `flex-col` layout. This fix changes the container to `flex-row items-center` so the button appears as a compact rectangular button to the left of the URL input field, as intended.
Fixes #2936
### Changes
- Changed `flex-col` to `flex-row items-center` on the copy URL container div
- Removed `mt-2` top margin from the button and input (no longer needed in row layout)
### Screenshots
before:-
<img width="955" height="476" alt="image" src="https://github.com/user-attachments/assets/a1afd678-a59d-41fc-b055-67b265189610" />
after:-
<img width="1600" height="799" alt="image" src="https://github.com/user-attachments/assets/28ab3d00-b9d2-4a58-ab40-e6a316dd0b08" />


### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
