### PR TITLE
Add copy link button to card browser (closes #2937)

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/cardFound.svelte
+++ b/cornucopia.owasp.org/src/lib/components/cardFound.svelte
@@ -53,6 +53,24 @@
 <div>
   <h1 title="OWASP Cornucopia card {Text.convertToTitleCase(card.suitName)} ({card.id})" class="title">{Text.convertToTitleCase(card.suitName)} ({card.id})</h1>
   <CardBrowser {card} {cards} mappingData={mappings}></CardBrowser>
+  <button
+    class="copy-link-btn"
+    onclick={() => {
+      const url = window.location.origin + '/cards/' + card.id;
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(url);
+      } else {
+        const el = document.createElement('textarea');
+        el.value = url;
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand('copy');
+        document.body.removeChild(el);
+      }
+    }}
+  >
+    🔗 {$t('cards.cardFound.copyLink') ?? 'Copy card link'}
+  </button>
   <a title="How to play OWASP Cornucopia" class="link" href="/how-to-play">{$t('cards.cardFound.a')}</a>
   <Concept card={card}></Concept>
   <Explanation card={card}></Explanation>
@@ -98,6 +116,23 @@
     text-transform: uppercase;
   }
 
+  .copy-link-btn {
+    display: block;
+    margin: 0.5rem auto;
+    padding: 0.5rem 1.5rem;
+    background: none;
+    border: 2px solid var(--background);
+    color: var(--background);
+    font-family: var(--font-title);
+    font-size: 1rem;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: var(--transition);
+  }
+  .copy-link-btn:hover {
+    background: var(--background);
+    color: white;
+  }
   .clicable {
     cursor: pointer;
   }


### PR DESCRIPTION
### Description
The card browser on cornucopia.owasp.org was missing a copy link button. I added a small rectangular copy button that sits right under the card, above the "How to play?" link. Clicking it copies the card URL (/cards/{card_id}) to the clipboard. It also has a fallback for older browsers that don't support the Clipboard API.

fixed issue: #2937

### Screenshots
before:-
<img width="853" height="479" alt="image" src="https://github.com/user-attachments/assets/3561f291-faca-4e33-a664-c14b6d514afa" />

After:-
<img width="1600" height="831" alt="image" src="https://github.com/user-attachments/assets/e1e1b567-e72c-4e7b-a1b0-cf87572bb170" />
copy card link is working perfectly also i verified that locally as well

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
