### PR TITLE
Upgraded from Website App v2.2 to v3.0

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -113,8 +113,7 @@
               pipenv run python scripts/convert.py -l all -lt guide -t bridge_qr -v 3.0 -e webapp --pdf
               pipenv run python scripts/convert.py -l en -lt guide -t bridge -v 3.0 -e webapp --pdf
               pipenv run python scripts/convert.py -l en -lt guide -t bridge_qr -v 3.0 -e webapp --pdf
-              pipenv run python scripts/convert.py -l en -lt cards -t tarot -v 1.0 -e companion
-              pipenv run python scripts/convert.py -l en -lt leaflet -t tarot -v 1.0 -e companion
+              pipenv run python scripts/convert.py -l all -lt all -t all -v 1.0 -e companion
 
               #
               # Debug: List generated files to verify PDF and ODT files exist
@@ -249,8 +248,6 @@
                 resources/case/*\3.0_case_*.pdf
                 resources/case/*\1.1_case_*.pdf
                 resources/case/*\1.0_case_*.pdf
-                source/*1\.1-*.yaml
-                source/*3\.0-*.yaml
                 output/owasp_cornucopia_companion_1.0_en.zip
       sbom:
         needs: [hardening, pre-release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,36 +84,42 @@
               cp -rf ./resources/templates/Links/cornucopia_companion output/cornucopia_companion/Links/
               cp -rf ./resources/templates/Fonts/NotoSans/* output/cornucopia_companion/Fonts/
               #
-              pipenv run python scripts/convert.py -l all -lt all -t all -v 2.2 -e webapp
+              pipenv run python scripts/convert.py -l all -lt all -t all -v 3.0 -e webapp
               pipenv run python scripts/convert.py -l all -lt all -t all -v 1.1 -e mobileapp
+              pipenv run python scripts/convert.py -l all -lt all -t all -v 1.0 -e companion
+
               #
               cp output/owasp_cornucopia_mobileapp_1.1_cards_bridge_en.idml output/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_en.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_en.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_en.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_en.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_en.idml output/cornucopia_mobileapp/
               cp output/owasp_cornucopia_mobileapp_1.1_cards_bridge_ru.idml output/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_ru.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_ru.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_ru.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_ru.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_ru.idml output/cornucopia_mobileapp/
               cp output/owasp_cornucopia_mobileapp_1.1_cards_bridge_uk.idml output/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_uk.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_uk.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_uk.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_uk.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_uk.idml output/cornucopia_mobileapp/
               cp output/owasp_cornucopia_mobileapp_1.1_cards_bridge_hi.idml output/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_hi.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_hi.idml output/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_hi.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_hi.idml output/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_hi.idml output/cornucopia_mobileapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_en.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_en.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_en.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_en.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_en.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_en.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_es.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_es.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_es.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_es.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_es.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_es.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_fr.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_fr.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_fr.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_fr.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_fr.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_fr.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_it.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_it.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_it.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_it.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_it.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_it.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_nl.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_nl.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_nl.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_nl.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_nl.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_nl.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_no_nb.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_no_nb.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_no_nb.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_no_nb.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_no_nb.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_no_nb.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_pt_br.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_pt_br.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_pt_br.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_pt_br.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_pt_br.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_pt_br.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_pt_pt.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_pt_pt.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_pt_pt.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_pt_pt.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_pt_pt.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_pt_pt.idml output/cornucopia_webapp/
-              cp output/owasp_cornucopia_webapp_2.2_cards_bridge_ru.idml output/owasp_cornucopia_webapp_2.2_cards_bridge_qr_ru.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_ru.idml output/owasp_cornucopia_webapp_2.2_cards_tarot_qr_ru.idml output/owasp_cornucopia_webapp_2.2_leaflet_bridge_ru.idml output/owasp_cornucopia_webapp_2.2_leaflet_tarot_ru.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_en.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_en.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_en.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_en.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_hi.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_hi.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_hi.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_hi.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_uk.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_uk.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_uk.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_uk.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_es.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_es.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_es.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_es.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_fr.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_fr.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_fr.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_fr.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_nl.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_nl.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_nl.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_nl.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_no_nb.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_no_nb.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_no_nb.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_no_nb.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_pt_br.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_pt_br.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_pt_br.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_pt_br.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_pt_pt.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_pt_pt.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_pt_pt.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_pt_pt.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_ru.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_ru.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_ru.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_ru.idml output/cornucopia_webapp/
+              cp output/owasp_cornucopia_webapp_3.0_cards_bridge_qr_it.idml output/owasp_cornucopia_webapp_3.0_cards_tarot_qr_it.idml output/owasp_cornucopia_webapp_3.0_leaflet_bridge_it.idml output/owasp_cornucopia_webapp_3.0_leaflet_tarot_it.idml output/cornucopia_webapp/
               cp output/owasp_cornucopia_companion_1.0_cards_tarot_en.idml output/owasp_cornucopia_companion_1.0_leaflet_tarot_en.idml output/cornucopia_companion/
               zip -r output/owasp_cornucopia_mobileapp_1.1_en.zip output/cornucopia_mobileapp/Links/* output/cornucopia_mobileapp/Fonts/* output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_en.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_en.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_en.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_en.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_en.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_en.idml ./resources/templates/owasp_cornucopia_mobileapp_scoresheet.pdf
               zip -r output/owasp_cornucopia_mobileapp_1.1_uk.zip output/cornucopia_mobileapp/Links/* output/cornucopia_mobileapp/Fonts/* output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_uk.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_uk.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_uk.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_uk.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_uk.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_uk.idml ./resources/templates/owasp_cornucopia_mobileapp_scoresheet.pdf
               zip -r output/owasp_cornucopia_mobileapp_1.1_ru.zip output/cornucopia_mobileapp/Links/* output/cornucopia_mobileapp/Fonts/* output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_ru.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_ru.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_ru.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_ru.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_ru.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_ru.idml ./resources/templates/owasp_cornucopia_mobileapp_scoresheet.pdf
               zip -r output/owasp_cornucopia_mobileapp_1.1_hi.zip output/cornucopia_mobileapp/Links/* output/cornucopia_mobileapp/Fonts/* output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_hi.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_bridge_qr_hi.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_hi.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_cards_tarot_qr_hi.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_bridge_hi.idml output/cornucopia_mobileapp/owasp_cornucopia_mobileapp_1.1_leaflet_tarot_hi.idml ./resources/templates/owasp_cornucopia_mobileapp_scoresheet.pdf              
-              zip -r output/owasp_cornucopia_webapp_2.2_en.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_en.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_es.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_es.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_fr.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_fr.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_it.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_it.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_nl.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_nl.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_no_nb.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_no_nb.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_pt_br.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_pt_br.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_pt_pt.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_pt_pt.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
-              zip -r output/owasp_cornucopia_webapp_2.2_ru.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_bridge_qr_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_cards_tarot_qr_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_bridge_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_2.2_leaflet_tarot_ru.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_en.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_en.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_hi.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_hi.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_hi.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_hi.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_hi.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_uk.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_uk.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_uk.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_uk.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_uk.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_es.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_es.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_es.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_fr.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_fr.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_fr.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_nl.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_nl.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_nl.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_no_nb.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_no_nb.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_no_nb.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_pt_br.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_pt_br.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_pt_br.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_pt_pt.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_pt_pt.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_pt_pt.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_ru.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_ru.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_ru.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
+              zip -r output/owasp_cornucopia_webapp_3.0_it.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_it.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_it.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
               zip -r output/owasp_cornucopia_companion_1.0_en.zip output/cornucopia_companion/Links/* output/cornucopia_companion/Fonts/* output/cornucopia_companion/owasp_cornucopia_companion_1.0_cards_tarot_en.idml output/cornucopia_companion/owasp_cornucopia_companion_1.0_leaflet_tarot_en.idml
           - name: Create release
             uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
@@ -132,28 +138,62 @@
                 output/owasp_cornucopia_mobileapp_1.1_hi.zip
                 output/owasp_cornucopia_mobileapp_1.1_ru.zip
                 output/owasp_cornucopia_mobileapp_1.1_uk.zip
-                output/owasp_cornucopia_webapp_2.2_en.zip
-                output/owasp_cornucopia_webapp_2.2_es.zip
-                output/owasp_cornucopia_webapp_2.2_fr.zip
-                output/owasp_cornucopia_webapp_2.2_it.zip
-                output/owasp_cornucopia_webapp_2.2_nl.zip
-                output/owasp_cornucopia_webapp_2.2_no_nb.zip
-                output/owasp_cornucopia_webapp_2.2_pt_br.zip
-                output/owasp_cornucopia_webapp_2.2_pt_pt.zip
-                output/owasp_cornucopia_webapp_2.2_ru.zip
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_en.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_es.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_fr.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_it.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_nl.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_no_nb.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_pt_br.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_pt_pt.odt
-                output/owasp_cornucopia_webapp_2.2_guide_bridge_ru.odt
-                resources/case/*\2.2_case_*
-                resources/case/*\1.1_case_*
-                source/*1\.1-*.yaml
-                source/*2\.2-*.yaml
+                output/owasp_cornucopia_webapp_3.0_en.zip
+                output/owasp_cornucopia_webapp_3.0_es.zip
+                output/owasp_cornucopia_webapp_3.0_fr.zip
+                output/owasp_cornucopia_webapp_3.0_it.zip
+                output/owasp_cornucopia_webapp_3.0_nl.zip
+                output/owasp_cornucopia_webapp_3.0_no_nb.zip
+                output/owasp_cornucopia_webapp_3.0_pt_br.zip
+                output/owasp_cornucopia_webapp_3.0_pt_pt.zip
+                output/owasp_cornucopia_webapp_3.0_ru.zip
+                output/owasp_cornucopia_webapp_3.0_hi.zip
+                output/owasp_cornucopia_webapp_3.0_uk.zip
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_en.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_es.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_fr.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_it.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_nl.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_no_nb.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_pt_br.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_pt_pt.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_ru.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_hi.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_uk.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_en.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_es.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_fr.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_it.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_nl.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_no_nb.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_pt_br.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_pt_pt.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_ru.odt
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_en.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_es.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_fr.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_it.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_nl.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_no_nb.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_pt_br.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_pt_pt.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_ru.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_hi.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_uk.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_en.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_es.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_fr.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_it.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_nl.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_no_nb.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_pt_br.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_pt_pt.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_ru.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_hi.pdf
+                output/owasp_cornucopia_webapp_3.0_guide_bridge_qr_uk.pdf
+                resources/case/*\3.0_case_*.pdf
+                resources/case/*\1.1_case_*.pdf
+                resources/case/*\1.0_case_*.pdf
       sbom:
         needs: [hardening, tagged-release]
         name: SBOM

--- a/copi.owasp.org/assets/package-lock.json
+++ b/copi.owasp.org/assets/package-lock.json
@@ -15,28 +15,33 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1",
-      "dependencies": {
-        "@babel/cli": "7.28.3",
-        "@babel/core": "7.28.5",
-        "@babel/preset-env": "7.28.5",
-        "@eslint/js": "^9.28.0",
+      "version": "1.8.7",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/cli": "7.28.6",
+        "@babel/core": "7.29.0",
+        "@babel/preset-env": "7.29.3",
+        "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.0.0",
         "documentation": "^14.0.3",
-        "eslint": "9.39.1",
-        "eslint-plugin-jest": "29.2.1",
+        "eslint": "10.2.1",
+        "eslint-plugin-jest": "29.15.2",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
-        "jsdom": "^27.0.0",
+        "jsdom": "^29.0.1",
         "mock-socket": "^9.3.1"
       }
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "4.3.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1",
+      "version": "1.1.30",
+      "license": "MIT",
       "dependencies": {
+        "morphdom": "2.7.8"
+      },
+      "devDependencies": {
         "@babel/cli": "7.27.2",
         "@babel/core": "7.27.4",
         "@babel/preset-env": "7.27.2",
@@ -54,7 +59,6 @@
         "jest-environment-jsdom": "^30.0.0",
         "jest-monocart-coverage": "^1.1.1",
         "monocart-reporter": "^2.9.21",
-        "morphdom": "2.7.8",
         "phoenix": "1.7.21",
         "prettier": "3.5.3",
         "ts-jest": "^29.4.0",
@@ -1678,17 +1682,17 @@
     "phoenix": {
       "version": "file:../deps/phoenix",
       "requires": {
-        "@babel/cli": "7.28.3",
-        "@babel/core": "7.28.5",
-        "@babel/preset-env": "7.28.5",
-        "@eslint/js": "^9.28.0",
+        "@babel/cli": "7.28.6",
+        "@babel/core": "7.29.0",
+        "@babel/preset-env": "7.29.3",
+        "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.0.0",
         "documentation": "^14.0.3",
-        "eslint": "9.39.1",
-        "eslint-plugin-jest": "29.2.1",
+        "eslint": "10.2.1",
+        "eslint-plugin-jest": "29.15.2",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
-        "jsdom": "^27.0.0",
+        "jsdom": "^29.0.1",
         "mock-socket": "^9.3.1"
       }
     },

--- a/copi.owasp.org/lib/copi/migrations/card_migration.ex
+++ b/copi.owasp.org/lib/copi/migrations/card_migration.ex
@@ -77,14 +77,14 @@ defmodule Copi.CardMigration do
                     safecode: set_mappings_for_card(card["safecode"])
                 )
                 "webapp" -> Ecto.Changeset.change(this_card,
-                    owasp_scp: set_mappings_for_card(card["owasp_scp"]),
-                    owasp_devguide: set_mappings_for_card(devguide),
-                    owasp_asvs: set_mappings_for_card(card["owasp_asvs"]),
+                    owasp_scp: [],
+                    owasp_devguide: [],
+                    owasp_asvs: [],
                     owasp_masvs: [],
                     owasp_mastg: [],
-                    owasp_appsensor: set_mappings_for_card(card["owasp_appsensor"]),
-                    capec: set_mappings_for_card(card["capec"]),
-                    safecode: set_mappings_for_card(card["safecode"])
+                    owasp_appsensor: [],
+                    capec: [],
+                    safecode: []
                 )
                 "masvs" -> Ecto.Changeset.change(this_card,
                     owasp_scp: [],

--- a/copi.owasp.org/lib/copi_web/controllers/card_html/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/card_html/show.html.heex
@@ -16,50 +16,7 @@
         <p class="misc"><%= @card.misc %></p>
 
         <% else %>
-
-        <dl class="mappings">
-          <dt>OWASP DevGuide</dt>
-          <dd>
-            <%= if @card.owasp_devguide != nil and Enum.count(@card.owasp_devguide) > 0 do %>
-              <%= Enum.join @card.owasp_devguide, ", " %>
-            <% else %>
-              &ndash;
-            <% end %>
-          </dd>
-          <dt>OWASP ASVS</dt>
-          <dd>
-            <%= if @card.owasp_asvs != nil and Enum.count(@card.owasp_asvs) > 0 do %>
-              <%= Enum.join @card.owasp_asvs, ", " %>
-            <% else %>
-              &ndash;
-            <% end %>
-          </dd>
-          <dt>OWASP AppSensor</dt>
-          <dd>
-            <%= if @card.owasp_appsensor != nil and Enum.count(@card.owasp_appsensor) > 0 do %>
-              <%= Enum.join @card.owasp_appsensor, ", " %>
-            <% else %>
-              &ndash;
-            <% end %>
-          </dd>
-          <dt>CAPEC</dt>
-          <dd>
-            <%= if @card.capec != nil and Enum.count(@card.capec) > 0 do %>
-              <%= Enum.join @card.capec, ", " %>
-            <% else %>
-              &ndash;
-            <% end %>
-          </dd>
-          <dt>SAFECODE</dt>
-          <dd>
-            <%= if @card.safecode != nil and Enum.count(@card.safecode) > 0 do %>
-              <%= Enum.join @card.safecode, ", " %>
-            <% else %>
-              &ndash;
-            <% end %>
-          </dd>
-        </dl>
-
+          &nbsp;
         <% end %>
       </div>
     </div>

--- a/copi.owasp.org/lib/copi_web/live/game_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/show.ex
@@ -118,7 +118,7 @@ defmodule CopiWeb.GameLive.Show do
 
   def latest_version(edition) do
     case edition do
-      "webapp" -> "2.2"
+      "webapp" -> "3.0"
       "ecommerce" -> "1.22"
       "mobileapp" -> "1.1"
       "mlsec" -> "1.0"

--- a/copi.owasp.org/priv/repo/cornucopia/webapp-cards-3.0-en.yaml
+++ b/copi.owasp.org/priv/repo/cornucopia/webapp-cards-3.0-en.yaml
@@ -1,0 +1,1374 @@
+---
+meta:
+  edition: "webapp"
+  component: "cards"
+  language: "en"
+  version: "3.0"
+suits:
+-
+  id: "VE"
+  name: "DATA VALIDATION & ENCODING"
+  cards:
+  -
+    id: "VE2"
+    value: "2"
+    url: "https://cornucopia.owasp.org/cards/VE2"
+    desc: "Brian can gather information about the underlying configurations, schemas, logic, code, software, services and infrastructure due to the content of error messages, or poor configuration, or the presence of default installation files or old, test, backup or copies of resources, or exposure of source code"
+  -
+    id: "VE3"
+    value: "3"
+    url: "https://cornucopia.owasp.org/cards/VE3"
+    desc: "Robert can input malicious data because the allowed protocol format is not being checked, or duplicates are accepted, or the structure is not being verified, or the individual data elements are not being sanitized, or preferably validated for format, type, range, size, length and a whitelist of allowed characters or formats"
+  -
+    id: "VE4"
+    value: "4"
+    url: "https://cornucopia.owasp.org/cards/VE4"
+    desc: "Dave can input malicious field names or data because it is not being checked within the context of the current user and process"
+  -
+    id: "VE5"
+    value: "5"
+    url: "https://cornucopia.owasp.org/cards/VE5"
+    desc: "Jee can bypass the centralized encoding routines since they are not being used everywhere, or the wrong encodings are being used"
+  -
+    id: "VE6"
+    value: "6"
+    url: "https://cornucopia.owasp.org/cards/VE6"
+    desc: "Jason can bypass the centralized validation routines since they are not being used on all inputs"
+  -
+    id: "VE7"
+    value: "7"
+    url: "https://cornucopia.owasp.org/cards/VE7"
+    desc: "Jan can craft special payloads to foil input validation because the character set is not specified/enforced, or the data is encoded multiple times, or the data is not fully converted into the same format the application uses (e.g. canonicalization) before being validated, or variables are not strongly typed"
+  -
+    id: "VE8"
+    value: "8"
+    url: "https://cornucopia.owasp.org/cards/VE8"
+    desc: "Oana can bypass the centralized sanitization routines since they are not being used comprehensively"
+  -
+    id: "VE9"
+    value: "9"
+    url: "https://cornucopia.owasp.org/cards/VE9"
+    desc: "Shamun can bypass input validation or output validation checks because validation failures are not rejected and/or sanitized"
+  -
+    id: "VEX"
+    value: "10"
+    url: "https://cornucopia.owasp.org/cards/VEX"
+    desc: "Darío can exploit the trust the application places in a source of data (e.g. user-definable data, manipulation of locally stored data, alteration to state data on a client device, lacking and/or improper enforcement of client-side controls, lack of verification of identity during data validation such as Darío can pretend to be Colin)"
+  -
+    id: "VEJ"
+    value: "J"
+    url: "https://cornucopia.owasp.org/cards/VEJ"
+    desc: "Toby has control over input validation, output validation, sanitization or output encoding code or routines so they can be bypassed"
+  -
+    id: "VEQ"
+    value: "Q"
+    url: "https://cornucopia.owasp.org/cards/VEQ"
+    desc: "Xavier can inject data into a client or device side interpreter because a parameterised interface is not being used, or has not been implemented correctly, or the data has not been encoded, sanitized or escaped correctly for the context, or there is no restrictive policy on code or data includes"
+  -
+    id: "VEK"
+    value: "K"
+    url: "https://cornucopia.owasp.org/cards/VEK"
+    desc: "Gabe can inject data into a server-side interpreter (e.g. SQL, OS commands, Xpath, Server JavaScript, SMTP) because a strongly typed parameterised interface is not being used, not implemented correctly, or properly configured"
+  -
+    id: "VEA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/VEA"
+    desc: "You have invented a new attack against Data Validation and Encoding"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Input Validation, XSS Prevention, DOM-based XSS Prevention, SQL Injection Prevention, and Query Parameterization"
+-
+  id: "AT"
+  name: "AUTHENTICATION"
+  cards:
+  -
+    id: "AT2"
+    value: "2"
+    url: "https://cornucopia.owasp.org/cards/AT2"
+    desc: "James can undertake authentication functions without the real user ever being aware this has occurred (e.g. attempt to log in, log in with stolen credentials, reset the password) "
+  -
+    id: "AT3"
+    value: "3"
+    url: "https://cornucopia.owasp.org/cards/AT3"
+    desc: "Muhammad can obtain a user's password or other secrets such as MFA codes or biometrics, by observation during entry, or from a local cache, or from memory, or in transit, or by reading it from some unprotected location, or because it is widely known or leaked"
+  -
+    id: "AT4"
+    value: "4"
+    url: "https://cornucopia.owasp.org/cards/AT4"
+    desc: "Sebastien can easily identify user names or can enumerate them"
+  -
+    id: "AT5"
+    value: "5"
+    url: "https://cornucopia.owasp.org/cards/AT5"
+    desc: "Javier can use default, test or easily guessable credentials to authenticate, or can use an old account, or an account not necessary for the application"
+  -
+    id: "AT6"
+    value: "6"
+    url: "https://cornucopia.owasp.org/cards/AT6"
+    desc: "Sven can reuse a temporary password, a recovery-, activation-, auth-, or MFA code because it's not changed after use, or it can not be reset by the user or admin, or it has an insufficiently implemented, too long or no expiry, or is still valid after being used, reset or revoked, or it does not use a secure out-of-band delivery method (e.g. post, mobile app, SMS)"
+  -
+    id: "AT7"
+    value: "7"
+    url: "https://cornucopia.owasp.org/cards/AT7"
+    desc: "Cecilia can use brute force and dictionary attacks against one or many accounts without limit, or these attacks are simplified due to insufficient complexity, length, expiration and requirements for the use of passwords, recovery-, activation-, or MFA codes"
+  -
+    id: "AT8"
+    value: "8"
+    url: "https://cornucopia.owasp.org/cards/AT8"
+    desc: "Kate can bypass authentication because it does not fail secure (i.e. it defaults to allowing unauthenticated access)"
+  -
+    id: "AT9"
+    value: "9"
+    url: "https://cornucopia.owasp.org/cards/AT9"
+    desc: "Claudia can undertake more critical functions because authentication requirements are inconsistent, too weak (e.g. do not use passkeys or other strong authentication such as a recommended MFA method), or there is no requirement to re-authenticate for these"
+  -
+    id: "ATX"
+    value: "10"
+    url: "https://cornucopia.owasp.org/cards/ATX"
+    desc: "Pravin can bypass authentication controls because a centralized standard, tested, proven, recommended and approved authentication module/framework/service, separate to the resource being requested, is not being used, has been misconfigured, or has been improperly implemented"
+  -
+    id: "ATJ"
+    value: "J"
+    url: "https://cornucopia.owasp.org/cards/ATJ"
+    desc: "Mark can access resources or services because there is no authentication requirement, or because authentication is missing due to misconfiguration, improper design or implementation, or it was mistakenly assumed authentication would be undertaken by some other system or performed in some previous action"
+  -
+    id: "ATQ"
+    value: "Q"
+    url: "https://cornucopia.owasp.org/cards/ATQ"
+    desc: "Johan can bypass authentication because it is not enforced with equal rigor for all types of authentication functionality (e.g. register, password change, password recovery, log out, administration) or across all versions/channels (e.g. mobile website, mobile app, full website, API, call centre)"
+  -
+    id: "ATK"
+    value: "K"
+    url: "https://cornucopia.owasp.org/cards/ATK"
+    desc: "Olga can influence or alter authentication code/routines so they can be bypassed"
+  -
+    id: "ATA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/ATA"
+    desc: "You have invented a new attack against Authentication"
+    misc: "Read more about this topic in OWASP's free Authentication Cheat Sheet"
+-
+  id: "SM"
+  name: "SESSION MANAGEMENT"
+  cards:
+  -
+    id: "SM2"
+    value: "2"
+    url: "https://cornucopia.owasp.org/cards/SM2"
+    desc: "William has control over the generation of session identifiers or authorization tokens"
+  -
+    id: "SM3"
+    value: "3"
+    url: "https://cornucopia.owasp.org/cards/SM3"
+    desc: "Ryan can continue to use a stolen session for its maximum duration because the user can not check whether the session might be stolen, or terminate the session or ask the administrator to do so, or because the application does not mitigate against authorization code interception"
+  -
+    id: "SM4"
+    value: "4"
+    url: "https://cornucopia.owasp.org/cards/SM4"
+    desc: "Alison can set session identification cookies or use tokens for another web application because the domain, path, (or in the case of tokens) audience are not restricted sufficiently"
+  -
+    id: "SM5"
+    value: "5"
+    url: "https://cornucopia.owasp.org/cards/SM5"
+    desc: "John can predict or guess session identifiers because they are not changed when the user's role alters (e.g. pre and post authentication), or are not verified using a trusted backend service, or are not sufficiently long and random, or are not changed periodically"
+  -
+    id: "SM6"
+    value: "6"
+    url: "https://cornucopia.owasp.org/cards/SM6"
+    desc: "Gary can take over a user's session because there is a long or no inactivity timeout, or a long or no overall session time limit, or the same session can be used from more than one device/location"
+  -
+    id: "SM7"
+    value: "7"
+    url: "https://cornucopia.owasp.org/cards/SM7"
+    desc: "Graham can utilize Adam's session after he has finished, because there is no log out function, or he cannot easily log out, or because the log out and other mechanisms for changing authentication settings do not permit the user to terminate the session or sessions"
+  -
+    id: "SM8"
+    value: "8"
+    url: "https://cornucopia.owasp.org/cards/SM8"
+    desc: "Matt can abuse sessions because the application does not require re-authentication after a session time limit has been reached, account terminated, or when privileges have changed, or after any abrupt and risky change to the user's authentication settings or environmental and contextual attributes (e.g. IP address, device, location, time of day, browser, etc.)"
+  -
+    id: "SM9"
+    value: "9"
+    url: "https://cornucopia.owasp.org/cards/SM9"
+    desc: "Ivan can steal session identifiers or authorization tokens because they are sent over insecure channels, or are logged, or are revealed in error messages, or are included in URLs, or are accessible un-necessarily by code, cache or load balancers which the attacker can influence or alter"
+  -
+    id: "SMX"
+    value: "10"
+    url: "https://cornucopia.owasp.org/cards/SMX"
+    desc: "Marce can forge requests because per-session, or per-request for more critical actions, strong random tokens (i.e. anti-CSRF tokens) or similar are not being used for actions that change state"
+  -
+    id: "SMJ"
+    value: "J"
+    url: "https://cornucopia.owasp.org/cards/SMJ"
+    desc: "Jeff can reuse stolen session identifiers and/or tokens because they are not handled confidentially or because there is no strong proof of possession (e.g. binding to certificate, device, IP address, user-agent, etc.)"
+  -
+    id: "SMQ"
+    value: "Q"
+    url: "https://cornucopia.owasp.org/cards/SMQ"
+    desc: "Salim can bypass session management because it is not applied comprehensively and consistently across the application"
+  -
+    id: "SMK"
+    value: "K"
+    url: "https://cornucopia.owasp.org/cards/SMK"
+    desc: "Peter can bypass the session management controls because they have been self-built and/or are weak, instead of using a standard framework or approved tested module"
+  -
+    id: "SMA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/SMA"
+    desc: "You have invented a new attack against Session Management"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Session Management, and Cross Site Request Forgery (CSRF) Prevention"
+-
+  id: "AZ"
+  name: "AUTHORIZATION"
+  cards:
+  -
+    id: "AZ2"
+    value: "2"
+    url: "https://cornucopia.owasp.org/cards/AZ2"
+    desc: "Tim can influence where data is sent or forwarded to"
+  -
+    id: "AZ3"
+    value: "3"
+    url: "https://cornucopia.owasp.org/cards/AZ3"
+    desc: "Christian can access information, which he should not have permission to, through another mechanism that does have permission (e.g. search indexer, logger, reporting), or because it is cached, or kept for longer than necessary, or through other information leakage"
+  -
+    id: "AZ4"
+    value: "4"
+    url: "https://cornucopia.owasp.org/cards/AZ4"
+    desc: "Kelly can bypass authorization controls because they do not fail securely (i.e. they default to allowing access)"
+  -
+    id: "AZ5"
+    value: "5"
+    url: "https://cornucopia.owasp.org/cards/AZ5"
+    desc: "Chad can access resources (including services, processes, AJAX, video, images, documents, temporary files, session data, system properties, configuration data, registry settings, logs) he should not be able to due to missing authorization, or due to excessive privileges (e.g. not using the principle of least privilege)"
+  -
+    id: "AZ6"
+    value: "6"
+    url: "https://cornucopia.owasp.org/cards/AZ6"
+    desc: "Eduardo can access data he does not have permission to, even though he has permission to the form/page/URL/entry point"
+  -
+    id: "AZ7"
+    value: "7"
+    url: "https://cornucopia.owasp.org/cards/AZ7"
+    desc: "Yuanjing can access application functions, objects, or properties he is not authorized to access"
+  -
+    id: "AZ8"
+    value: "8"
+    url: "https://cornucopia.owasp.org/cards/AZ8"
+    desc: "Tom can bypass business rules by altering the usual process sequence or flow, or by undertaking the process in the incorrect order, or by manipulating date and time values used by the application, or by using valid features for unintended purposes, or by otherwise manipulating control data"
+  -
+    id: "AZ9"
+    value: "9"
+    url: "https://cornucopia.owasp.org/cards/AZ9"
+    desc: "Michael can bypass the application to gain access to data because administrative tools or administrative interfaces are not secured adequately"
+  -
+    id: "AZX"
+    value: "10"
+    url: "https://cornucopia.owasp.org/cards/AZX"
+    desc: "Richard can bypass the centralized authorization controls since they are not being used comprehensively on all interactions, or because they have been misconfigured, or because the application does not use a centralized standard, tested, proven, recommended and approved authorization module/framework/service"
+  -
+    id: "AZJ"
+    value: "J"
+    url: "https://cornucopia.owasp.org/cards/AZJ"
+    desc: "Dinis can access security configuration information, or access control lists"
+  -
+    id: "AZQ"
+    value: "Q"
+    url: "https://cornucopia.owasp.org/cards/AZQ"
+    desc: "Christopher can inject a command that the application will run at a higher privilege level"
+  -
+    id: "AZK"
+    value: "K"
+    url: "https://cornucopia.owasp.org/cards/AZK"
+    desc: "Adrian can influence or alter authorization controls and permissions, and can therefore bypass them"
+  -
+    id: "AZA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/AZA"
+    desc: "You have invented a new attack against Authorization"
+    misc: "Read more about this topic in OWASP's Development and Testing Guides"
+-
+  id: "CR"
+  name: "CRYPTOGRAPHY"
+  cards:
+  -
+    id: "CR2"
+    value: "2"
+    url: "https://cornucopia.owasp.org/cards/CR2"
+    desc: "Kyun can access data because it has been obfuscated rather than using an approved cryptographic function"
+  -
+    id: "CR3"
+    value: "3"
+    url: "https://cornucopia.owasp.org/cards/CR3"
+    desc: "Axel can modify transient or permanent data (stored or in transit), or source code, or updates/patches, or configuration data, because it is not subject to integrity checking"
+  -
+    id: "CR4"
+    value: "4"
+    url: "https://cornucopia.owasp.org/cards/CR4"
+    desc: "Paulo can access data in transit that is not encrypted, even though the channel is encrypted"
+  -
+    id: "CR5"
+    value: "5"
+    url: "https://cornucopia.owasp.org/cards/CR5"
+    desc: "Kyle can bypass cryptographic controls because they do not fail securely (i.e. they default to unprotected)"
+  -
+    id: "CR6"
+    value: "6"
+    url: "https://cornucopia.owasp.org/cards/CR6"
+    desc: "Romain can read and modify unencrypted data in memory or in transit (e.g. cryptographic secrets, credentials, session identifiers, personal and commercially-sensitive data), in use or in communications within the application, or between the application and users, or between the application and external systems"
+  -
+    id: "CR7"
+    value: "7"
+    url: "https://cornucopia.owasp.org/cards/CR7"
+    desc: "Gunter can intercept or modify encrypted and/or hashed data in transit because the protocol is poorly deployed, or weakly configured, or certificates are invalid, or certificates are not trusted, or the connection can be degraded to a weaker or un-encrypted communication"
+  -
+    id: "CR8"
+    value: "8"
+    url: "https://cornucopia.owasp.org/cards/CR8"
+    desc: "Eoin can access stored business data (e.g. passwords, session identifiers, PII, cardholder data) because it is not securely encrypted or securely hashed"
+  -
+    id: "CR9"
+    value: "9"
+    url: "https://cornucopia.owasp.org/cards/CR9"
+    desc: "Andy can bypass cryptographic controls because random-number, GUID, or hashing functions are self-built, risky or weak"
+  -
+    id: "CRX"
+    value: "10"
+    url: "https://cornucopia.owasp.org/cards/CRX"
+    desc: "Susanna can break the cryptography in use because it is not strong enough for the degree of protection required, or it is not strong enough for the amount of effort the attacker is willing to make"
+  -
+    id: "CRJ"
+    value: "J"
+    url: "https://cornucopia.owasp.org/cards/CRJ"
+    desc: "Justin can read credentials for accessing internal or external resources, services and others systems because they are stored in an unencrypted format, or saved in the source code"
+  -
+    id: "CRQ"
+    value: "Q"
+    url: "https://cornucopia.owasp.org/cards/CRQ"
+    desc: "Artim can access or predict the master cryptographic secrets"
+  -
+    id: "CRK"
+    value: "K"
+    url: "https://cornucopia.owasp.org/cards/CRK"
+    desc: "Dan can influence or alter cryptography code/routines (encryption, hashing, digital signatures, random number and GUID generation) and can therefore bypass them"
+  -
+    id: "CRA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/CRA"
+    desc: "You have invented a new attack against Cryptography"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Cryptographic Storage, and Transport Layer Protection"
+-
+  id: "C"
+  name: "CORNUCOPIA"
+  cards:
+  -
+    id: "C2"
+    value: "2"
+    url: "https://cornucopia.owasp.org/cards/C2"
+    desc: "Lee can bypass application controls because dangerous/risky programming language functions have been used instead of safer alternatives, or there are type conversion errors, or because the application is unreliable when an external resource is unavailable, or there are race conditions, or there are resource initialization, leak or allocation issues, or overflows can occur"
+  -
+    id: "C3"
+    value: "3"
+    url: "https://cornucopia.owasp.org/cards/C3"
+    desc: "Andrew can access source code, or decompile, or debug, or otherwise access business logic to understand how the application works and any secrets contained"
+  -
+    id: "C4"
+    value: "4"
+    url: "https://cornucopia.owasp.org/cards/C4"
+    desc: "Keith can perform an action and it is not possible to attribute it to him"
+  -
+    id: "C5"
+    value: "5"
+    url: "https://cornucopia.owasp.org/cards/C5"
+    desc: "Larry can influence the trust other parties including users have in the application, or abuse that trust elsewhere (e.g. in another application)"
+  -
+    id: "C6"
+    value: "6"
+    url: "https://cornucopia.owasp.org/cards/C6"
+    desc: "Aaron can bypass controls because error/exception handling is missing, or is implemented inconsistently or partially, or does not deny access by default (i.e. errors should terminate access/execution), or relies on handling by some other service or system"
+  -
+    id: "C7"
+    value: "7"
+    url: "https://cornucopia.owasp.org/cards/C7"
+    desc: "Mwengu's actions cannot be investigated because there is not an adequate accurately time-stamped record of security events, or there is not a full audit trail, or these can be altered or deleted by Mwengu, or there is no centralized logging service"
+  -
+    id: "C8"
+    value: "8"
+    url: "https://cornucopia.owasp.org/cards/C8"
+    desc: "David can bypass the application to gain access to data because the network and host infrastructure, and supporting services/applications, have not been securely configured, the configuration rechecked periodically and security patches applied, or the data is stored locally, or the data is not physically protected"
+  -
+    id: "C9"
+    value: "9"
+    url: "https://cornucopia.owasp.org/cards/C9"
+    desc: "Mike can misuse an application by using a valid feature too fast, or too frequently, or other way that is not intended, or consumes the application's resources, or causes race conditions, or over-utilizes a feature"
+  -
+    id: "CX"
+    value: "10"
+    url: "https://cornucopia.owasp.org/cards/CX"
+    desc: "Spyros can circumvent the application's controls because code frameworks, libraries and components contain malicious code or vulnerabilities (e.g. in-house, commercial off the shelf, outsourced, open source, externally-located)"
+  -
+    id: "CJ"
+    value: "J"
+    url: "https://cornucopia.owasp.org/cards/CJ"
+    desc: "Roman can exploit the application because it was insecurely compiled or deployed, or its configuration is not secure by default, or because security information was not documented, or passed on to operational teams, or the user is not warned and access blocked when the expected security features are unsupported or disabled"
+  -
+    id: "CQ"
+    value: "Q"
+    url: "https://cornucopia.owasp.org/cards/CQ"
+    desc: "Jim can undertake malicious, non-normal, actions without real-time detection and response by the application"
+  -
+    id: "CK"
+    value: "K"
+    url: "https://cornucopia.owasp.org/cards/CK"
+    desc: "Grant can utilize the application to deny service to some or all of its users"
+  -
+    id: "CA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/CA"
+    desc: "You have invented a new attack of any type"
+    misc: "Read more about application security in OWASP's free Guides on Requirements, Development, Code Review and Testing, the Cheat Sheet series, and the Open Software Assurance Maturity Model"
+-
+  id: "WC"
+  name: "WILD CARD"
+  cards:
+  -
+    id: "JOA"
+    value: "A"
+    url: "https://cornucopia.owasp.org/cards/JOA"
+    card: "Joker"
+    desc: "Alice can utilize the application to attack users' systems and data"
+    misc: "Have you thought about becoming an individual OWASP member? All tools, guidance and local meetings are free for everyone, but individual membership helps support OWASP's work"
+  -
+    id: "JOB"
+    value: "B"
+    url: "https://cornucopia.owasp.org/cards/JOB"
+    card: "Joker"
+    desc: "Bob can influence, alter or affect the application so that it no longer complies with legal, regulatory, contractual or other organizational mandates"
+    misc: "Examine vulnerabilities and discover how they can be fixed using the free OWASP® Juice Shop, Security Shepherd, or using the online challenges in the free OWASP® Hacking-lab"
+paragraphs:
+-
+  id: "Common"
+  name: "Common"
+  sentences:
+  -
+    id: "NoCard"
+    text: "No Card"
+  -
+    id: "Title"
+    text: "Website App Edition v3.0-EN"
+  -
+    id: "Title_full"
+    text: "OWASP® Cornucopia Website App Edition v3.0-EN"
+  -
+    id: "T00005"
+    text: "Index"
+  -
+    id: "T00005"
+    text: "Index"
+  -
+    id: "T00010"
+    text: "OWASP® Cornucopia is a mechanism to assist software development teams identify security requirements in Agile, conventional and formal development processes."
+  -
+    id: "T00020"
+    text: "Author"
+  -
+    id: "T00030"
+    text: "Project Leaders"
+  -
+    id: "T00090"
+    text: "© 2012-2026 OWASP Foundation"
+  -
+    id: "T00100"
+    text: "Acknowledgements"
+  -
+    id: "T00110"
+    text: "Adam Shostack and the Microsoft SDL Team for the “Elevation of Privilege Threat Modelling Game”, published under a Creative Commons Attribution license, as the inspiration for Cornucopia and from which many ideas, especially the game theory, were copied."
+  -
+    id: "T00120"
+    text: "Keith Turpin and contributors to the OWASP® “Secure Coding Practices - Quick Reference Guide”, originally donated to OWASP by Boeing, which is used as the primary source of security requirements information to formulate the content of the cards."
+  -
+    id: "T00130"
+    text: "Contributors, supporters, sponsors and volunteers to the OWASP® ASVS, AppSensor, Developer Guide and Web Framework Security Matrix projects, Mitre's Common Attack Pattern Enumeration and Classification (CAPEC™), and SAFECode's “Practical Security Stories and Security Tasks for Agile Development Environments” which are all used in the cross-references provided."
+  -
+    id: "T00140"
+    text: "Playgen for providing an illuminating afternoon seminar on task gamification, and tartanmaker.com for the online tool to help create the card back pattern."
+  -
+    id: "T00145"
+    text: "Current and past OWASP® Cornucopia project contributors and leaders, especially those involved most recently updating the cross-references, creating online versions, and writing scripts to dynamically generate Cornucopia's output files."
+  -
+    id: "T00150"
+    text: "Blackfoot (UK) Limited for creating and donating print-ready design files, Tom Brennan and the OWASP® Foundation for instigating the creation of an OWASP-branded box and leaflet, and Secure Delivery Ltd for developing and donating Copi, the platform to play Cornucopia and EoP online."
+  -
+    id: "T00161"
+    text: "(continued on page 20)"
+  -
+    id: "T00162"
+    text: "(continued from page 10)"
+  -
+    id: "T00170"
+    text: "Colin Watson as author and co-project leader with Grant Ongers along with other OWASP volunteers who have helped in many ways."
+  -
+    id: "T00180"
+    text: "OWASP® does not endorse or recommend commercial products or services © 2012-2025 OWASP® Foundation This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 license"
+  -
+    id: "T00200"
+    text: "Introduction"
+  -
+    id: "T00210"
+    text: "The idea behind Cornucopia is to help development teams, especially those using Agile methodologies, to identify application security requirements and develop security-based user stories."
+  -
+    id: "T00220"
+    text: "Although the idea had been waiting for enough time to progress it, the final motivation came when SAFECode published its Practical Security Stories and Security Tasks for Agile Development Environments in July 2012."
+  -
+    id: "T00230"
+    text: "The Microsoft SDL team had already published its super Elevation of Privilege: The Threat Modeling Game (EoP) but that did not seem to address the most appropriate kind of issues that web application development teams mostly have to address."
+  -
+    id: "T00240"
+    text: "EoP is a great concept and game strategy, and was published under a Creative Commons Attribution License."
+  -
+    id: "T00250"
+    text: "Cornucopia Website App Edition is based on the concepts and game ideas in EoP, but those have been modified to be more relevant to the types of issues webapp website developers encounter."
+  -
+    id: "T00260"
+    text: "It attempts to introduce threat-modelling ideas into development teams that use Agile methodologies, or are more focused on web application weaknesses than other types of software vulnerabilities, or are not familiar with STRIDE and DREAD."
+  -
+    id: "T00270"
+    text: "Cornucopia Website App Edition is referenced as an information resource in the PCI Security Standard Council's Information Supplement PCI DSS E-commerce Guidelines, v2, January 2013."
+  -
+    id: "T00300"
+    text: "The card deck (pack)"
+  -
+    id: "T00310"
+    text: "Instead of EoP's STRIDE suits (sets of cards with matching designs), Cornucopia suits are based on the structure of the OWASP® Secure Coding Practices - Quick Reference Guide (SCP), but with additional consideration of sections from the OWASP® Application Security Verification Standard, the Web Security Testing Guide (WSTG) and David Rook's Principles of Secure Development. "
+  -
+    id: "T00320"
+    text: "These provided five suits, and a sixth called “Cornucopia” was created for everything else: "
+  -
+    id: "T00330"
+    text: "Data Validation and Encoding (VE)"
+  -
+    id: "T00340"
+    text: "Authentication (AT)"
+  -
+    id: "T00350"
+    text: "Session Management (SM)"
+  -
+    id: "T00360"
+    text: "Authorization (AZ)"
+  -
+    id: "T00370"
+    text: "Cryptography (CR)"
+  -
+    id: "T00380"
+    text: "Cornucopia (C)"
+  -
+    id: "T00390"
+    text: "Similar to poker-playing cards, each suit contains 13 cards (Ace, 2-10, Jack, Queen and King) but, unlike EoP, there are also two Joker cards."
+  -
+    id: "T00400"
+    text: "The content was mainly drawn from the SCP."
+  -
+    id: "T00500"
+    text: "Mappings"
+  -
+    id: "T00510"
+    text: "The other driver for Cornucopia is to link the attacks with requirements and verification techniques."
+  -
+    id: "T00520"
+    text: "An initial aim had been to reference CWE™ weakness IDs, but these proved too numerous, and instead it was decided to map each card to CAPEC™ software attack pattern IDs which themselves are mapped to CWEs, so the desired result is achieved."
+  -
+    id: "T00530"
+    text: "Each card is also mapped to the 36 primary security stories in the SAFECode document, as well as to the OWASP® Developer Guide Web Application Checklist v4.1.9, ASVS v5.0 and AppSensor (application attack detection and response) to help teams create their own security-related stories for use in Agile processes."
+  -
+    id: "T00600"
+    text: "Game strategy"
+  -
+    id: "T00610"
+    text: "Apart from the content differences, the game rules are virtually identical to those for EoP."
+  -
+    id: "T00700"
+    text: "Printing the cards"
+  -
+    id: "T00710"
+    text: "Check the Cornucopia project page for how to obtain pre-printed decks on glossy card."
+  -
+    id: "T00720"
+    text: "The cards can be printed from this document in black & white but are more effective in color."
+  -
+    id: "T00730"
+    text: "The cards in the later pages of this document have been laid out to fit on one type of pre-scored business A4 card sheets. "
+  -
+    id: "T00740"
+    text: "This appeared to be the quickest way to initially provide to create playing cards quickly. "
+  -
+    id: "T00750"
+    text: "Avery product codes C32015 and C32030 have been tested successfully, but any 10 up 85mm x 54 mm cards on A4 paper should work with a little adjustment."
+  -
+    id: "T00760"
+    text: "Other stationery suppliers like Ryman and Sigel produce similar sheets"
+  -
+    id: "T00770"
+    text: "These card sheets are not inexpensive, so care should be taken in deciding what to print and using what media and printer type."
+  -
+    id: "T00780"
+    text: "The cards can of course just be printed on any size of paper or card and then cut-up manually, or a commercial printer would be able to print larger volumes and cut the cards to size. "
+  -
+    id: "T00790"
+    text: "The cut lines are shown on the penultimate page of this document, but Avery also produce a landscape A4 template (A-0017-01_L.doc) that can be used as a guide."
+  -
+    id: "T00800"
+    text: "Printing and cutting up can take an hour or so, and using a faster printer helps."
+  -
+    id: "T00810"
+    text: "Try to print at a higher quality to increase legibility."
+  -
+    id: "T00820"
+    text: "An optional card back design (in OWASP® tartan) has been provided as the last page of this document."
+  -
+    id: "T00830"
+    text: "There is no special alignment needed. "
+  -
+    id: "T00840"
+    text: "Dual-sided printing needs special care taken. "
+  -
+    id: "T00850"
+    text: "You could customize the card faces or the backs for your own organization's preferences."
+  -
+    id: "T00900"
+    text: "Customization"
+  -
+    id: "T00910"
+    text: "After you have used Cornucopia a few times, you may feel that some cards are less relevant to your applications, or the threats are different for your organization."
+  -
+    id: "T00920"
+    text: "Edit this document yourself to make the cards more suitable for your teams, or create new decks completely."
+  -
+    id: "T01000"
+    text: "Provide feedback"
+  -
+    id: "T01010"
+    text: "If you have ideas or feedback on the use of OWASP® Cornucopia, please share them."
+  -
+    id: "T01020"
+    text: "Even better if you create alternative versions of the cards, or produce professional print-ready versions, please share that with the volunteers who created this edition and with the wider application development and application security community."
+  -
+    id: "T01030"
+    text: "The best place to use to discuss or contribute is the list/group for the OWASP project:"
+  -
+    id: "T01040"
+    text: "List/Group"
+  -
+    id: "T01050"
+    text: "Project home page"
+  -
+    id: "T01060"
+    text: "All OWASP documents and tools are free to download and use."
+  -
+    id: "T01070"
+    text: "OWASP® Cornucopia is licensed under the Creative Commons Attribution-ShareAlike 3.0 license."
+  -
+    id: "T01100"
+    text: "Instructions"
+  -
+    id: "T01110"
+    text: "The text on each card describes an attack, but the attacker is given a name, which are unique across all the cards."
+  -
+    id: "T01120"
+    text: "The name can represent a computer system (e.g. the database, the file system, another application, a related service, a botnet), an individual person (e.g. a citizen, a customer, a client, an employee, a criminal, a spy), or even a group of people (e.g. a competitive organization, activists with a common cause)."
+  -
+    id: "T01130"
+    text: "The attacker might be remote in some other device/location, or local/internal with access to the same device, host or network as the application is running on."
+  -
+    id: "T01140"
+    text: "The attacker is always named at the start of each description"
+  -
+    id: "T01150"
+    text: "An example is:"
+  -
+    id: "T01160"
+    text: "William has control over the generation of session identifiers."
+  -
+    id: "T01170"
+    text: "This means the attacker (William) can create new session identifiers that the application accepts."
+  -
+    id: "T01180"
+    text: "The attacks were primarily drawn from the security requirements listed in the SCP, v2 but then supplemented with verification objectives from the OWASP® “Application Security Verification Standard”, the security focused stories in SAFECode's “Practical Security Stories and Security Tasks for Agile Development Environments”, and finally a review of the cards in EOP. in OWASP Cornucopia Website Edition v3.0 the SCP mapping was replaced by the OWASP Developer Guide Web Application Checklist"
+  -
+    id: "T01190"
+    text: "Further guidance about each card is available on the OWASP Website at "
+  -
+    id: "T01200"
+    text: "Lookups between the attacks and five resources are provided on most cards:"
+  -
+    id: "T01210"
+    text: "Requirements in “OWASP DevGuide - Web Checklist”, v4.1.9, OWASP®, July 2025 "
+  -
+    id: "T01220"
+    text: "Verification IDs in OWASP® “Application Security Verification Standard”"
+  -
+    id: "T01230"
+    text: "Attack detection points IDs in “AppSensor”, OWASP®, August 2010-2015"
+  -
+    id: "T01240"
+    text: "IDs in “Common Attack Pattern Enumeration and Classification (CAPEC™)”, v3.9, Mitre Corporation, November 2015"
+  -
+    id: "T01250"
+    text: "Security-focused stories in 'Practical Security Stories and Security Tasks for Agile Development Environments', SAFECode, July 2012"
+  -
+    id: "T01260"
+    text: "A look-up means the attack is included within the referenced item, but does not necessarily encompass the whole of its intent. "
+  -
+    id: "T01270"
+    text: "For structured data like CAPEC, the most specific reference is provided but sometimes a cross-reference is provided that also has more specific (child) examples."
+  -
+    id: "T01280"
+    text: "There are no lookups on the six Aces and two Jokers. "
+  -
+    id: "T01290"
+    text: "Instead these cards have some general tips in italicized text."
+  -
+    id: "T01300"
+    text: "It is possible to play Cornucopia in many different ways. "
+  -
+    id: "T01301"
+    text: "For how to play, read pages: 11-19."
+  -
+    id: "T01310"
+    text: "Here is one way, demonstrated online in a video at "
+  -
+    id: "T01311"
+    text: " which uses the new (May 2015) score/record sheet at "
+  -
+    id: "T01400"
+    text: "Preparations"
+  -
+    id: "T01410"
+    text: "Obtain a deck, or print your own deck of Cornucopia cards (see page 2 of this document) and separate/cut out the cards"
+  -
+    id: "T01411"
+    text: "Use the cards in this pack"
+  -
+    id: "T01420"
+    text: "Identify an application or application process to review; this might be a concept, design or an actual implementation"
+  -
+    id: "T01430"
+    text: "Create a data flow diagram, user stories, or other artefacts to help the review"
+  -
+    id: "T01431"
+    text: "This will help answer the question: “What are we working on?”"
+  -
+    id: "T01440"
+    text: "Identify and invite a group of 3-6 architects, developers, testers and other business stakeholders together and sit around a table (try to include someone fairly familiar with application security)"
+  -
+    id: "T01450"
+    text: "Have some prizes to hand (gold stars, chocolate, pizza, beer or flowers depending upon your office culture)"
+  -
+    id: "T01500"
+    text: "Play"
+  -
+    id: "T01510"
+    text: "One suit - Cornucopia - acts as trumps."
+  -
+    id: "T01520"
+    text: "Aces are high (i.e. they beat Kings)."
+  -
+    id: "T01530"
+    text: "It helps if there is a non-player to document the issues and scores."
+  -
+    id: "T01540"
+    text: "Remove the Jokers and a few low-score (2, 3, 4) cards from Cornucopia suit to ensure each player will have the same number of cards"
+  -
+    id: "T01550"
+    text: "Shuffle the deck and deal all the cards"
+  -
+    id: "T01560"
+    text: "To begin, choose a player randomly who will play the first card - they can play any card from their hand except from the trump suit - Cornucopia"
+  -
+    id: "T01570"
+    text: "To play a card, each player must read it out aloud, and explain (see the online Wiki Deck for tips) how the threat could apply (the player gets a point for attacks that might work which the group thinks is an actionable bug) - do not try to think of mitigations at this stage, and do not exclude a threat just because of a belief that it is already mitigated - someone note the card and record the issues raised"
+  -
+    id: "T01571"
+    text: "If a player gets stuck, ask them to scan the QR code on the card to access the online card page and read the section called: “What can go wrong?”"
+  -
+    id: "T01580"
+    text: "Play clockwise, each person must play a card in the same way; if you have any card of the matching lead suit you must play one of those, otherwise they can play a card from any other suit. "
+  -
+    id: "T01590"
+    text: "Only a higher card of the same suit, or the highest card in the trump suit Cornucopia, wins the hand."
+  -
+    id: "T01600"
+    text: "The person who wins the round, leads the next round (i.e. they play first), and thus defines the next lead suit"
+  -
+    id: "T01610"
+    text: "Repeat until all the cards are played"
+  -
+    id: "T01700"
+    text: "Scoring"
+  -
+    id: "T01710"
+    text: "The objective is to identify applicable threats, and win hands (rounds):"
+  -
+    id: "T01720"
+    text: "Score +1 for each card you can identify as a valid threat to the application under consideration"
+  -
+    id: "T01730"
+    text: "Score +1 if you win a round"
+  -
+    id: "T01740"
+    text: "Once all cards have been played, whoever has the most points wins"
+  -
+    id: "T01800"
+    text: "Closure"
+  -
+    id: "T01810"
+    text: "Review all the applicable threats and the matching security requirements"
+  -
+    id: "T01811"
+    text: "Use the QR codes on the cards to access the online card page and read the section called: “What are we going to do about it?”"
+  -
+    id: "T01820"
+    text: "Create user stories, specifications and test cases as required for your development methodology."
+  -
+    id: "T01900"
+    text: "Alternative game rules"
+  -
+    id: "T01910"
+    text: "If you are new to the game, remove the Aces and two Joker cards to begin with."
+  -
+    id: "T01920"
+    text: "Add the Joker cards back in once people become more familiar with the process."
+  -
+    id: "T01930"
+    text: "Apart from the “trumps card game” rules described above which are very similar to the EoP, the deck can also be played as the “twenty-one card game” (also known as “pontoon” or “blackjack”) which normally reduces the number of cards played in each round."
+  -
+    id: "T01940"
+    text: "Practice on an imaginary application, or even a future planned application, rather than trying to find fault with existing applications until the participants are happy with the usefulness of the game."
+  -
+    id: "T01950"
+    text: "Consider just playing with one suit to make a shorter session - but try to cover all the suits for every project. "
+  -
+    id: "T01960"
+    text: "Or even better just play one hand with some pre-selected cards, and score only on the ability to identify security requirements. "
+  -
+    id: "T01970"
+    text: "Perhaps have one game of each suit each day for a week or so, if the participants cannot spare long enough for a full deck."
+  -
+    id: "T01980"
+    text: "Some teams have preferred to play a full hand of cards, and then discuss what is on the cards after each round (instead of after each person plays a card)."
+  -
+    id: "T01990"
+    text: "Another suggestion is that if a player fails to identify the card as relevant, allow other players to suggest ideas, and potentially let them gain the point for the card. "
+  -
+    id: "T02000"
+    text: "Consider allowing extra points for especially good contributions."
+  -
+    id: "T02010"
+    text: "You can even play by yourself. "
+  -
+    id: "T02020"
+    text: "Just use the cards to act as thought-provokers. "
+  -
+    id: "T02030"
+    text: "Involving more people will be beneficial though."
+  -
+    id: "T02040"
+    text: "In Microsoft's EoP guidance, they recommend cheating as a good game strategy."
+  -
+    id: "T02100"
+    text: "Development framework-specific modified card decks"
+  -
+    id: "T02110"
+    text: "There can be built in security controls in some commonly used languages and frameworks for web and mobile application development."
+  -
+    id: "T02120"
+    text: "With certain provisos it is useful to consider how using these controls can simplify the identification of additional requirements – provided of course the controls are included, enabled and configured correctly."
+  -
+    id: "T02130"
+    text: "Consider removing cards from the decks if you are confident they are addressed by the way you are using the language/framework."
+  -
+    id: "T02140"
+    text: "Items in parentheses are “maybes”."
+  -
+    id: "T02200"
+    text: "Internal coding standards and libraries"
+  -
+    id: "T02210"
+    text: "Add your own list of excluded cards based on your organisation's coding standards (provided they are confirmed by appropriate verification steps in the development lifecycle)."
+  -
+    id: "T02220"
+    text: "Your coding standards and libraries"
+  -
+    id: "T02230"
+    text: "Data Validation and Encoding"
+  -
+    id: "T02240"
+    text: "[your list]"
+  -
+    id: "T02250"
+    text: "Authentication"
+  -
+    id: "T02260"
+    text: "[your list]"
+  -
+    id: "T02270"
+    text: "Session Management"
+  -
+    id: "T02280"
+    text: "[your list]"
+  -
+    id: "T02290"
+    text: "Authorization"
+  -
+    id: "T02300"
+    text: "[your list]"
+  -
+    id: "T02310"
+    text: "Cryptography"
+  -
+    id: "T02320"
+    text: "[your list]"
+  -
+    id: "T02330"
+    text: "Cornucopia"
+  -
+    id: "T02340"
+    text: "[your list]"
+  -
+    id: "T02400"
+    text: "Compliance requirement decks"
+  -
+    id: "T02410"
+    text: "Create a smaller deck by only including cards for a particular compliance requirement."
+  -
+    id: "T02420"
+    text: "Compliance requirement"
+  -
+    id: "T02430"
+    text: "Data validation and Encoding"
+  -
+    id: "T02440"
+    text: "[compliance list]"
+  -
+    id: "T02450"
+    text: "Authentication"
+  -
+    id: "T02460"
+    text: "[compliance list]"
+  -
+    id: "T02470"
+    text: "Session Management"
+  -
+    id: "T02480"
+    text: "[compliance list]"
+  -
+    id: "T02490"
+    text: "Authorization"
+  -
+    id: "T02500"
+    text: "[compliance list]"
+  -
+    id: "T02510"
+    text: "Cryptography"
+  -
+    id: "T02520"
+    text: "[compliance list]"
+  -
+    id: "T02530"
+    text: "Cornucopia"
+  -
+    id: "T02540"
+    text: "[compliance list]"
+  -
+    id: "T02600"
+    text: "Frequently asked questions"
+  -
+    id: "T02610"
+    text: "1. Can I copy or edit the game?"
+  -
+    id: "T02620"
+    text: "Yes of course."
+  -
+    id: "T02630"
+    text: "All OWASP materials are free to do with as you like provided you comply with the Creative Commons Attribution-ShareAlike 3.0 license. "
+  -
+    id: "T02640"
+    text: "Perhaps if you create a new version, you might donate it to the OWASP® Cornucopia Project?"
+  -
+    id: "T02650"
+    text: "2. How can I get involved?"
+  -
+    id: "T02660"
+    text: "Please send ideas or offers of help to the project's mailing list."
+  -
+    id: "T02670"
+    text: "3. How were the attackers' names chosen?"
+  -
+    id: "T02680"
+    text: "EoP begins every description with words like 'An attacker can...'. "
+  -
+    id: "T02690"
+    text: "These have to be phrased as an attack but I was not keen on the anonymous terminology, wanting something more engaging, and therefore used personal names. "
+  -
+    id: "T02700"
+    text: "These can be thought of as external or internal people or aliases for computer systems. But instead of just random names, I thought how they might reflect the OWASP community aspect. "
+  -
+    id: "T02710"
+    text: "Therefore, apart from 'Alice and Bob' I use the given (first) names of current and recent OWASP employees and Board members (assigned in no order), and then randomly selected the remaining 50 or so names from the current list of paying individual OWASP members. "
+  -
+    id: "T02720"
+    text: "No name was used more than once, and where people had provided two personal names, I dropped one part to try to ensure no-one can be easily identified. "
+  -
+    id: "T02730"
+    text: "Names were not deliberately allocated to any particular attack, defence or requirement. The cultural and gender mix simply reflects these sources of names, and is not meant to be world-representative."
+  -
+    id: "T02740"
+    text: "In v1.20, the name on VE-10 changed to reflect the project's new co-leader - this card is also the only one with two names in the attack."
+  -
+    id: "T02750"
+    text: "4. Why aren't there any images on the card faces?"
+  -
+    id: "T02760"
+    text: "There is quite a lot of text on the cards, and the cross-referencing takes up space too."
+  -
+    id: "T02770"
+    text: "But it would be great to have additional design elements included."
+  -
+    id: "T02790"
+    text: "5. Are the attacks ranked by the number on the card?"
+  -
+    id: "T02800"
+    text: "Only approximately."
+  -
+    id: "T02810"
+    text: "The risk will be application and organisation dependent, due to varying security and compliance requirements, so your own severity rating may place the cards in some other order than the numbers on the cards."
+  -
+    id: "T02820"
+    text: "6. How long does it take to play a round of cards using the full deck?"
+  -
+    id: "T02830"
+    text: "This depends upon the scope of the application, amount of discussion and how familiar the players are with application security concepts."
+  -
+    id: "T02840"
+    text: "But perhaps allow 1.5 to 2.0 hours for 4-6 people."
+  -
+    id: "T02850"
+    text: "7. What sort of people should play the game?"
+  -
+    id: "T02860"
+    text: "Always try to have a mix of roles who can contribute alternative perspectives."
+  -
+    id: "T02870"
+    text: "But include someone who has a reasonable knowledge of application vulnerability terminology. "
+  -
+    id: "T02880"
+    text: "Otherwise try to include a mix of architects, developers, testers and a relevant project manager or business owner."
+  -
+    id: "T02890"
+    text: "8. Who should take notes and record scores?"
+  -
+    id: "T02900"
+    text: "It is better if that someone else, not playing the game, takes notes about the requirements identified and issues discussed."
+  -
+    id: "T02910"
+    text: "This could be used as training for a more junior developer, or performed by the project manager."
+  -
+    id: "T02920"
+    text: "Some organisations have made a recording to review afterwards when the requirements are written up more formally."
+  -
+    id: "T02930"
+    text: "9. Should we always use the full deck of cards?"
+  -
+    id: "T02940"
+    text: "No. "
+  -
+    id: "T02950"
+    text: "A smaller deck is quicker to play. "
+  -
+    id: "T02960"
+    text: "Start your first game with only enough cards for two or three rounds. "
+  -
+    id: "T02970"
+    text: "Always consider removing cards that are not appropriate at all of the target application or function being reviewed. "
+  -
+    id: "T02980"
+    text: "For the first few times people play the game it is also usually better to remove the Aces and the two Jokers."
+  -
+    id: "T02990"
+    text: "It is also usual to play the game without any trumps suit until people are more familiar with the idea."
+  -
+    id: "T03000"
+    text: "10. What should players do when they have an Ace card that says “invented a new X attack”?"
+  -
+    id: "T03010"
+    text: "The player can make up any attack they think is valid, but must match the suit of the card (e.g. Data Validation and Encoding)."
+  -
+    id: "T03020"
+    text: "With players new to the game, it can be better to remove these to begin with (see also FAQ 9)."
+  -
+    id: "T03060"
+    text: "11. My company wants to print its own version of OWASP® Cornucopia - what license do we need to refer to?"
+  -
+    id: "T03070"
+    text: "Please refer to the full answer to this question on the project's web pages at"
+  -
+    id: "T03100"
+    text: "Change Log"
+  -
+    id: "T03110"
+    text: "Version / Date"
+  -
+    id: "T03120"
+    text: "Comments"
+  -
+    id: "T03130"
+    text: "0.1"
+  -
+    id: "T03140"
+    text: "Original Draft"
+  -
+    id: "T03150"
+    text: "0.2"
+  -
+    id: "T03160"
+    text: "Draft reviewed and updated"
+  -
+    id: "T03170"
+    text: "0.3"
+  -
+    id: "T03180"
+    text: "Draft announced OWASP® SCP mailing list for comment."
+  -
+    id: "T03190"
+    text: "0.4"
+  -
+    id: "T03200"
+    text: "Play rules updated based on feedback during workshops. "
+  -
+    id: "T03210"
+    text: "Added reference to PCI SSC Information Supplement: PCI DSS E-commerce Guidelines. "
+  -
+    id: "T03220"
+    text: "Descriptive text extended and updated."
+  -
+    id: "T03230"
+    text: "Added contributors section, page numbering, FAQs and change log."
+  -
+    id: "T03240"
+    text: "1"
+  -
+    id: "T03250"
+    text: "Release."
+  -
+    id: "T03260"
+    text: "1.01"
+  -
+    id: "T03270"
+    text: "Framework-specific card deck discussion added"
+  -
+    id: "T03280"
+    text: "Additional FAQs created. "
+  -
+    id: "T03290"
+    text: "Descriptive text updated. "
+  -
+    id: "T03300"
+    text: "New cover image, and previous cover image moved to back. "
+  -
+    id: "T03310"
+    text: "Cut lines added."
+  -
+    id: "T03320"
+    text: "FAQs 5 and 6 added."
+  -
+    id: "T03330"
+    text: "Attack descriptions on cards with tinted backgrounds changed to black (from dark grey). "
+  -
+    id: "T03340"
+    text: "Project contributors added."
+  -
+    id: "T03350"
+    text: "1.02"
+  -
+    id: "T03360"
+    text: "Warning about time to print added. "
+  -
+    id: "T03370"
+    text: "Additional alternative game rules added (twenty-one, play a deck over a week, play full hand and then discuss). "
+  -
+    id: "T03380"
+    text: "Compliance deck concept added. "
+  -
+    id: "T03390"
+    text: "FAQs 5 and 6 added."
+  -
+    id: "T03400"
+    text: "Attack descriptions on cards with tinted backgrounds changed to black (from dark grey). "
+  -
+    id: "T03410"
+    text: "Project contributors added."
+  -
+    id: "T03420"
+    text: "1.03"
+  -
+    id: "T03430"
+    text: "Minor attack wording changes on two cards. "
+  -
+    id: "T03440"
+    text: "OWASP® SCP and ASVS cross-references checked and updated. "
+  -
+    id: "T03450"
+    text: "Code letters added for suits. "
+  -
+    id: "T03460"
+    text: "All remaining attack descriptions on cards changed to black (from dark grey) and background colours amended to provide more contrast and increase readability."
+  -
+    id: "T03470"
+    text: "1.04"
+  -
+    id: "T03480"
+    text: "Text “password change, password change,” corrected to “password change, password recovery,” on Queen of Authentication card. "
+  -
+    id: "T03490"
+    text: "1.05"
+  -
+    id: "T03500"
+    text: "Updates to alternative game rules. "
+  -
+    id: "T03510"
+    text: "Additional FAQs created. "
+  -
+    id: "T03520"
+    text: "Contributors updated. "
+  -
+    id: "T03530"
+    text: "Podcast and video links added."
+  -
+    id: "T03540"
+    text: "1.1"
+  -
+    id: "T03550"
+    text: "Change log date corrected for v1.05. Cross-references updated for 2014 version of ASVS. "
+  -
+    id: "T03560"
+    text: "Contributors updated."
+  -
+    id: "T03570"
+    text: "Minor text changes to cards to improve readability."
+  -
+    id: "T03580"
+    text: "1.2"
+  -
+    id: "T03590"
+    text: "Video mentioned/linked"
+  -
+    id: "T03600"
+    text: "Separate score sheet mentioned/linked. "
+  -
+    id: "T03610"
+    text: "Previous embedded score sheet pages deleted"
+  -
+    id: "T03620"
+    text: "Correction (identified by Tom Brennan) and addition to "
+  -
+    id: "T03630"
+    text: "text on card 8 Authentication. "
+  -
+    id: "T03640"
+    text: "Oana Cornea and other participants at the AppSec EU 2015 project summit added to list of contributors. "
+  -
+    id: "T03650"
+    text: "Darío De Filippis added as project co-leader. "
+  -
+    id: "T03660"
+    text: "Wiki Deck link added"
+  -
+    id: "T03670"
+    text: "Cross-references updated for ASVS v3.0.1 and CAPEC™ v3.9. Minor text changes to a small number of cards. "
+  -
+    id: "T03680"
+    text: "Added “-EN” to version number in preparation for “-ES” version."
+  -
+    id: "T03690"
+    text: "Susana Romaniz added as a contributor to the Spanish translation."
+  -
+    id: "T03700"
+    text: "Minor text changes to instructions and FAQs."
+  -
+    id: "T03710"
+    text: "2.0"
+  -
+    id: "T03720"
+    text: "Cross-references updated from ASVS v3.0.1 to ASVS v4.0 by Johan Sydseter. "
+  -
+    id: "T03730"
+    text: "2.1"
+  -
+    id: "T03740"
+    text: "Adding italian translation done by Ruggero DallAglio"
+  -
+    id: "T03750"
+    text: "2.1"
+  -
+    id: "T03760"
+    text: "Adding portugeese translation done by André Ferreira"
+  -
+    id: "T03770"
+    text: "2.2"
+  -
+    id: "T03771"
+    text: "Migrated the cross-references from SCP to the DevGuide Web Checklist v4.1.9."
+  -
+    id: "T03772"
+    text: "3.0"
+  -
+    id: "T03773"
+    text: "ASVS has been migrated from v4.0.3 to v5.0. The text on the cards has been updated to include MFA and passkeys as an option for authentication. Cards within the session management suit have been updated to align with modern session management practices."
+  -
+    id: "T03774"
+    text: "3.0"
+  -
+    id: "T03775"
+    text: "STRIDE categories have been added to each card"
+  -
+    id: "T03800"
+    text: "Project contributors"
+  -
+    id: "T03810"
+    text: "All OWASP projects rely on the voluntary efforts of people in the software development and information security sectors. "
+  -
+    id: "T03820"
+    text: "They have contributed their time and energy to make suggestions, provide feedback, write, review and edit documentation, give encouragement, trial the game, and promote the concept. "
+  -
+    id: "T03830"
+    text: "Without all their efforts, the project would not have progressed to this point. "
+  -
+    id: "T03840"
+    text: "Please contact the mailing list or project leaders directly, if anyone is missing from the below lists."
+  -
+    id: "T03850"
+    text: "OWASP's hard-working employees."
+  -
+    id: "T03860"
+    text: "Attendees at OWASP® London, OWASP® Manchester, OWASP® Netherlands and OWASP® Scotland chapter meetings, and the London Gamification meetup, who made helpful suggestions and asked challenging questions"
+  -
+    id: "T03870"
+    text: "Blackfoot UK Limited for gifting print-ready design files and hundreds of professionally printed card decks for distribution by post and at OWASP chapter meetings"
+  -
+    id: "T03880"
+    text: 'OWASP® NYC for creating an OWASP box design and distributing packs at AppSec USA 2014.'
+  -
+    id: "T03900"
+    text: "Podcasts and videos"
+  -
+    id: "T03910"
+    text: 'The following supporting OWASP® Cornucopia resources are available online:'
+  -
+    id: "T03920"
+    text: "Video - Using the cards, created during AppSec EU 2015 project summit, 20th May 2015"
+  -
+    id: "T03930"
+    text: "Podcast interview, OWASP® 24/7 Podcast channel, 21st March 2014"
+  -
+    id: "T03940"
+    text: "	Video of presentation, OWASP® EU Tour 2013 London, 3rd June 2013"
+  -
+    id: "T03950"
+    text: "See the project website for further information and presentation materials."

--- a/copi.owasp.org/priv/repo/migrations/20260706100557_populate_cards_for_webapp3.exs
+++ b/copi.owasp.org/priv/repo/migrations/20260706100557_populate_cards_for_webapp3.exs
@@ -1,0 +1,10 @@
+defmodule Copi.Repo.Migrations.PopulateNewCardsForWebApp3 do
+  use Ecto.Migration
+  alias Copi.Repo
+  alias Copi.Cornucopia
+  import Copi.CardMigration
+
+  def change do
+    add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/webapp-cards-3.0-en.yaml"), nil)
+  end
+end

--- a/copi.owasp.org/test/copi_web/live/game_live/show_pure_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_pure_test.exs
@@ -11,7 +11,7 @@ defmodule CopiWeb.GameLive.ShowPureTest do
   end
 
   test "latest_version returns expected versions" do
-    assert Show.latest_version("webapp") == "2.2"
+    assert Show.latest_version("webapp") == "3.0"
     assert Show.latest_version("ecommerce") == "1.22"
     assert Show.latest_version("eop") == "5.1"
     assert Show.latest_version("other") == "1.0"

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -114,7 +114,7 @@ defmodule CopiWeb.GameLive.ShowTest do
 
     test "latest_version/1 returns correct version string for each edition", %{conn: _conn, game: _game} do
       alias CopiWeb.GameLive.Show
-      assert Show.latest_version("webapp")    == "2.2"
+      assert Show.latest_version("webapp")    == "3.0"
       assert Show.latest_version("ecommerce") == "1.22"
       assert Show.latest_version("mobileapp") == "1.1"
       assert Show.latest_version("mlsec")     == "1.0"

--- a/copi.owasp.org/test/copi_web/live/game_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live_test.exs
@@ -157,7 +157,7 @@ defmodule CopiWeb.GameLiveTest do
        {:ok, p1} = Cornucopia.create_player(%{name: "P1", game_id: game.id})
        {:ok, card} = Cornucopia.create_card(%{
         category: "C", value: "V", description: "D", edition: "webapp",
-        version: "2.2", external_id: "EXT", language: "en",
+        version: "3.0", external_id: "EXT", language: "en",
         misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [],
         owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
       })
@@ -231,7 +231,7 @@ defmodule CopiWeb.GameLiveTest do
     end
 
     test "latest_version returns correct version for each edition" do
-      assert Show.latest_version("webapp") == "2.2"
+      assert Show.latest_version("webapp") == "3.0"
       assert Show.latest_version("ecommerce") == "1.22"
       assert Show.latest_version("mobileapp") == "1.1"
       assert Show.latest_version("mlsec") == "1.0"

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -21,7 +21,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
 
     {:ok, card} = Cornucopia.create_card(%{
       category: "C", value: card_ext_id, description: "D", edition: "webapp",
-      version: "2.2", external_id: card_ext_id, language: "en", misc: "m",
+      version: "3.0", external_id: card_ext_id, language: "en", misc: "m",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
     })
@@ -70,7 +70,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, card} =
         Cornucopia.create_card(%{
           category: "C", value: "V", description: "D", edition: "webapp",
-          version: "2.2", external_id: "ST1", language: "en", misc: "misc",
+          version: "3.0", external_id: "ST1", language: "en", misc: "misc",
           owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
           capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
         })
@@ -180,7 +180,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, card1} =
         Cornucopia.create_card(%{
           category: "C", value: "V3", description: "D", edition: "webapp",
-          version: "2.2", external_id: "NR_CLOSED1", language: "en", misc: "m",
+          version: "3.0", external_id: "NR_CLOSED1", language: "en", misc: "m",
           owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
           capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
         })
@@ -188,7 +188,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, card2} =
         Cornucopia.create_card(%{
           category: "C", value: "V4", description: "D", edition: "webapp",
-          version: "2.2", external_id: "NR_CLOSED2", language: "en", misc: "m",
+          version: "3.0", external_id: "NR_CLOSED2", language: "en", misc: "m",
           owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
           capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
         })
@@ -222,7 +222,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, card} =
         Cornucopia.create_card(%{
           category: "C", value: "V5", description: "D", edition: "webapp",
-          version: "2.2", external_id: "NR_LAST1", language: "en", misc: "m",
+          version: "3.0", external_id: "NR_LAST1", language: "en", misc: "m",
           owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
           capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
         })
@@ -273,7 +273,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, card} =
         Cornucopia.create_card(%{
           category: "C", value: "TV1", description: "D", edition: "webapp",
-          version: "2.2", external_id: "TV_CARD1", language: "en", misc: "m",
+          version: "3.0", external_id: "TV_CARD1", language: "en", misc: "m",
           owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
           capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
         })

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -145,7 +145,7 @@ defmodule CopiWeb.PlayerLiveTest do
       # Deal/play card for Other
       {:ok, card} = Cornucopia.create_card(%{
         category: "C", value: "V", description: "D", edition: "webapp", 
-        version: "2.2", external_id: "EXT", language: "en",
+        version: "3.0", external_id: "EXT", language: "en",
         misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [], 
         owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
       })
@@ -266,7 +266,7 @@ defmodule CopiWeb.PlayerLiveTest do
       # With no nil-round cards, last_round? = true → finished_at gets set.
       {:ok, card} = Cornucopia.create_card(%{
         category: "C", value: "V9", description: "D", edition: "webapp",
-        version: "2.2", external_id: "CLOSEDRND9", language: "en",
+        version: "3.0", external_id: "CLOSEDRND9", language: "en",
         misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [],
         owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
       })
@@ -290,7 +290,7 @@ defmodule CopiWeb.PlayerLiveTest do
 
       {:ok, card} = Cornucopia.create_card(%{
         category: "C", value: "V2", description: "D", edition: "webapp",
-        version: "2.2", external_id: "EXT2", language: "en",
+        version: "3.0", external_id: "EXT2", language: "en",
         misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [],
         owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
       })

--- a/cornucopia.owasp.org/src/domain/suit/suitController.ts
+++ b/cornucopia.owasp.org/src/domain/suit/suitController.ts
@@ -5,7 +5,7 @@ import { cardOrder } from "$domain/card/order";
 
 export class SuitController {
 
-    private static decks = [{edition: 'mobileapp', version: '1.1'}, {edition: 'webapp', version: '3.0'}, {edition: 'companion', version: '1.0'}];
+    private static readonly decks = [{edition: 'mobileapp', version: '1.1'}, {edition: 'webapp', version: '3.0'}, {edition: 'companion', version: '1.0'}];
     private static languages : Map<string, { lang: string[] }> = new Map<string, { lang: string[] }>([
         ['mobileapp', {lang: ['en']}], 
         ['webapp', {lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it']}],

--- a/cornucopia.owasp.org/src/domain/suit/suitController.ts
+++ b/cornucopia.owasp.org/src/domain/suit/suitController.ts
@@ -5,7 +5,7 @@ import { cardOrder } from "$domain/card/order";
 
 export class SuitController {
 
-    private static decks = [{edition: 'mobileapp', version: '1.1'}, {edition: 'webapp', version: '2.2'}, {edition: 'companion', version: '1.0'}];
+    private static decks = [{edition: 'mobileapp', version: '1.1'}, {edition: 'webapp', version: '3.0'}, {edition: 'companion', version: '1.0'}];
     private static languages : Map<string, { lang: string[] }> = new Map<string, { lang: string[] }>([
         ['mobileapp', {lang: ['en']}], 
         ['webapp', {lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it']}],

--- a/cornucopia.owasp.org/src/lib/components/cardPreview.svelte
+++ b/cornucopia.owasp.org/src/lib/components/cardPreview.svelte
@@ -2,7 +2,6 @@
     import type { Card } from "../../domain/card/card";
     import { cardColor } from "../../domain/card/cardColor";
     import MobileAppCardMapping from "./mobileAppCardMapping.svelte";
-    import WebAppCardMapping from "./webAppCardMapping.svelte";
     import CompanionCardMapping from "./companionCardMapping.svelte";
     
     interface Props {
@@ -58,9 +57,6 @@
         {#if mapping}
         <span class="property-card-number{previewStyle} {getTextColor(card?.suit, card?.suitId)}-text {getRoyalTextColor(card?.suit, card?.suitId, card?.value)}">{card?.card ?? card?.value}</span>
         <p class="property-card-description{previewStyle}">{card?.desc}</p>
-            {#if card?.edition == 'webapp'}
-                <WebAppCardMapping {mapping} {style}></WebAppCardMapping>
-            {/if}
             {#if card?.edition == 'mobileapp'}
                 <MobileAppCardMapping {mapping}  {style}></MobileAppCardMapping>
             {/if}

--- a/cornucopia.owasp.org/src/lib/services/deckService.test.ts
+++ b/cornucopia.owasp.org/src/lib/services/deckService.test.ts
@@ -143,8 +143,8 @@ describe('DeckService tests', () => {
     }, 10000);
 
     describe('getLatestVersion', () => {
-        it('should return 2.2 for webapp', () => {
-            expect(DeckService.getLatestVersion('webapp')).toBe('2.2');
+        it('should return 3.0 for webapp', () => {
+            expect(DeckService.getLatestVersion('webapp')).toBe('3.0');
         });
 
         it('should return 1.1 for mobileapp', () => {
@@ -155,8 +155,8 @@ describe('DeckService tests', () => {
             expect(DeckService.getLatestVersion('companion')).toBe('1.0');
         });
 
-        it('should return 2.2 as default for unknown edition', () => {
-            expect(DeckService.getLatestVersion('unknown')).toBe('2.2');
+        it('should return 3.0 as default for unknown edition', () => {
+            expect(DeckService.getLatestVersion('unknown')).toBe('3.0');
         });
     }, 10000);
 

--- a/cornucopia.owasp.org/src/lib/services/deckService.ts
+++ b/cornucopia.owasp.org/src/lib/services/deckService.ts
@@ -15,13 +15,13 @@ export class DeckService {
     private static cache: object[] = [];
     private static readonly latests: Deck[] = [
         { lang: ['en', 'hi', 'uk'], edition: 'mobileapp', version: '1.1' },
-        { lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it'], edition: 'webapp', version: '2.2' },
+        { lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it', 'hi', 'uk'], edition: 'webapp', version: '3.0' },
         { lang: ['en'], edition: 'companion', version: '1.0' }
     ];
     private static readonly decks: Deck[] = [
         { edition: 'mobileapp', version: '1.1', lang: ['en', 'hi', 'uk'] },
-        { edition: 'webapp', version: '2.2', lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it'] },
         { edition: 'webapp', version: '3.0', lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it', 'hi', 'uk'] },
+        { edition: 'webapp', version: '2.2', lang: ['en', 'es', 'fr', 'nl', 'no_nb', 'pt_br', 'pt_pt', 'ru', 'it'] },
         { edition: 'companion', version: '1.0', lang: ['en'] },
         { edition: 'dbd', version: '1.0', lang: ['en'] }
     ];
@@ -43,7 +43,7 @@ export class DeckService {
     }
 
     public static getLatestVersion(edition: string): string {
-        return DeckService.latests.find((deck) => deck.edition == edition)?.version || '2.2';
+        return DeckService.latests.find((deck) => deck.edition == edition)?.version || '3.0';
     }
 
     public static getLatestEditions(): string[] {

--- a/cornucopia.owasp.org/src/routes/api/cre/[edition]/[lang]/server.test.ts
+++ b/cornucopia.owasp.org/src/routes/api/cre/[edition]/[lang]/server.test.ts
@@ -121,7 +121,7 @@ describe('GET /api/cre/[edition]/[lang]', () => {
 
     it('falls back to webapp and en defaults when url has no path segments', () => {
         vi.spyOn(DeckService, 'getLanguages').mockReturnValue(['en']);
-        vi.spyOn(DeckService, 'getLatestVersion').mockReturnValue('2.2');
+        vi.spyOn(DeckService, 'getLatestVersion').mockReturnValue('3.0');
         vi.spyOn(DeckService.prototype, 'getCardDataForEditionVersionLang')
             .mockReturnValue(new Map([['VE2', { id: 'VE2' }]]) as any);
         vi.spyOn(MappingService.prototype, 'getCardMappingForLatestEdtions')

--- a/cornucopia.owasp.org/src/routes/cards/[card]/+page.server.ts
+++ b/cornucopia.owasp.org/src/routes/cards/[card]/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from "./$types";
 import type { Route } from "../../../domain/routes/route";
 import type { Card } from "$domain/card/card";
 import { MappingService } from "$lib/services/mappingService";
+import { CapecService } from "$lib/services/capecService";
 
 export const load = (async ({ params }) => {
 
@@ -40,18 +41,24 @@ export const load = (async ({ params }) => {
   }
 
   const edition = card.edition;
+  const latestVersion = DeckService.getLatestVersion(edition);
+  const asvsVersion = latestVersion === '3.0' ? '5.0' : '4.0.3';
 
   const versions = DeckService.getVersions(edition);
-
+  let capecData = undefined;
+  if (edition === 'webapp' && parseFloat(latestVersion) >= 3.0) {
+        capecData = CapecService.getCapecData(edition, latestVersion);
+      }
   return {
     card: fixedCode,
     decks: decks,
     versions: versions,
     routes: new Map<string, Route[]>([
-      ["ASVSRoutes", FileSystemHelper.ASVSRouteMap()],
+      ["ASVSRoutes", FileSystemHelper.ASVSRouteMap(asvsVersion)],
     ]),
     mappingData: new MappingService().getCardMappingForLatestEdtions(),
-    languages: DeckService.getLanguages(card.edition),
+    languages: DeckService.getLanguagesForEditionVersion(edition, latestVersion),
+    capecData: capecData
   };
 
 }) satisfies PageServerLoad;

--- a/cornucopia.owasp.org/src/routes/cards/[card]/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/cards/[card]/+page.svelte
@@ -73,7 +73,9 @@
   mappingData={data.mappingData.get(card.edition)}
   {languages}
   {language}
+  capecData={data.capecData}
 />
+
 {:else}
   <CardNotFound card={data.card} />
 {/if}

--- a/cornucopia.owasp.org/src/routes/edition/[edition]/[card]/+page.server.ts
+++ b/cornucopia.owasp.org/src/routes/edition/[edition]/[card]/+page.server.ts
@@ -8,8 +8,7 @@ import { CapecService } from "$lib/services/capecService";
 export const load = (({ params }) => {
     const edition =  params?.edition;
     const version = DeckService.getLatestVersion(edition);
-    let asvsVersion: string = "4.0.3";
-    if (params.version === '3.0') asvsVersion = '5.0';
+    const asvsVersion = version === '3.0' ? '5.0' : '4.0.3';
     if (!DeckService.hasEdition(edition)) error(
       404, 'Edition not found. Only: ' + DeckService.getLatestEditions().join(', ') + ' are supported.');
     


### PR DESCRIPTION

### Description

In this pull-request:

- Upgrade webapp to version 3.0 for copi.owasp.org and cornucopia.owasp.org
- Removed the mapping table on the card
- Fixes a couple of bugs related to the language picker and the ASVS index and CAPEC map.
- Changing the release pipeline from releasing v2.2 to be releasing v3.0

<!-- ✍️-->
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

Resolved or fixed issue: <!-- ✍️ Add GitHub issue number in format `#0000` or `none` -->

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
