### PR TITLE
Add DBD card deck support

### DIFF
--- a/copi.owasp.org/priv/repo/cornucopia/dbd-cards-1.0-en.yaml
+++ b/copi.owasp.org/priv/repo/cornucopia/dbd-cards-1.0-en.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  edition: "dbd"
+  component: "cards"
+  language: "EN"
+  version: "1.0"
+
+suits:
+  -
+    id: "DB"
+    name: "Data Breach Defense"
+    cards:
+      -
+        id: "DB2"
+        value: "2"
+        desc: "Sensitive data may be exposed due to improper handling or insecure storage."
+
+      -
+        id: "DB3"
+        value: "3"
+        desc: "Weak authentication mechanisms may allow attackers to compromise accounts."
+
+      -
+        id: "DBA"
+        value: "A"
+        desc: "You've identified a new DBD-related threat."
+        misc: "Read more about this topic ..."

--- a/copi.owasp.org/priv/repo/migrations/20260424130000_populate_dbd_cards.exs
+++ b/copi.owasp.org/priv/repo/migrations/20260424130000_populate_dbd_cards.exs
@@ -1,0 +1,15 @@
+defmodule Copi.Repo.Migrations.PopulateDbdCards do
+  use Ecto.Migration
+
+  import Copi.CardMigration
+
+  def change do
+    add_cards_to_database(
+      Path.join(
+        :code.priv_dir(:copi),
+        "/repo/cornucopia/dbd-cards-1.0-en.yaml"
+      ),
+      nil
+    )
+  end
+end


### PR DESCRIPTION

### Description
Adds support for the DBD card deck in copi.owasp.org.
## Changes
- Added dbd-cards-1.0-en.yaml
- Added PopulateDbdCards migration using existing CardMigration helper


### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
