### PR TITLE
fix: prevent game share URL from overflowing on mobile screens

### DIFF
--- a/copi.owasp.org/lib/copi_web/components/core_components/buttons.ex
+++ b/copi.owasp.org/lib/copi_web/components/core_components/buttons.ex
@@ -67,7 +67,7 @@ defmodule CopiWeb.CoreComponents.Buttons do
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3.535 3.535a4 4 0 01-5.656-5.656l1.414-1.414M10.172 13.828a4 4 0 010-5.656l3.535-3.535a4 4 0 015.656 5.656l-1.414 1.414" />
         </svg>
       </button>
-      <input id="copied-url" class="w-full rounded-md px-3 py-3 text-sm font-semibold shadow-sm text-gray-500 break-all" value={@uri} />
+      <input id="copied-url" class="min-w-0 mt-2 w-full rounded-md px-3 py-3 text-sm font-semibold shadow-sm text-gray-500 break-all" value={@uri} />
       <span id="url-copied" class="hidden">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />


### PR DESCRIPTION
### Description 

fixed issue: #2979 

When creating a game and viewing the session page on a mobile device, the share URL input box overflows outside its container causing the layout to break on small screens.

The input element sits inside a flex row container but was missing min-w-0. Without this, flex children cannot shrink below their content size, so long URLs overflow the screen width on mobile.

Added min-w-0 to the input in the copy_url_button component in lib/copi_web/components/core_components/buttons.ex

Tested on iPhone SE viewport (375px) in Chrome DevTools.
Before:-
<img width="1600" height="790" alt="image" src="https://github.com/user-attachments/assets/d612c4fc-a68f-4abc-9352-a3484f6fae08" />

After:-
<img width="1600" height="794" alt="image" src="https://github.com/user-attachments/assets/f34e13a1-1fa2-4835-913d-3d50908dfd39" />

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
