### PR TITLE
Making copi.owasp.org more stable by adding retry logic when there are glitches.

### DIFF
--- a/copi.owasp.org/config/config.exs
+++ b/copi.owasp.org/config/config.exs
@@ -11,6 +11,11 @@ config :copi,
   ecto_repos: [Copi.Repo],
   generators: [timestamp_type: :utc_datetime]
 
+config :copi, :resilience,
+  retry_delay_ms: 750,
+  max_game_load_retries: 3,
+  max_player_load_retries: 3
+
 # Configures the endpoint
 config :copi, CopiWeb.Endpoint,
   debug_errors: false,

--- a/copi.owasp.org/config/dev.exs
+++ b/copi.owasp.org/config/dev.exs
@@ -80,3 +80,9 @@ config :phoenix_live_view,
 # Disable colocated JS symlink warning on Windows
 config :phoenix_live_view, :colocated_js,
   disable_symlink_warning: true
+
+# Retry settings for transient LiveView load failures.
+config :copi, :resilience,
+  retry_delay_ms: 750,
+  max_game_load_retries: 3,
+  max_player_load_retries: 3

--- a/copi.owasp.org/config/prod.exs
+++ b/copi.owasp.org/config/prod.exs
@@ -16,5 +16,10 @@ config :swoosh, local: false
 # Do not print debug messages in production
 config :logger, level: :info
 
+config :copi, :resilience,
+	retry_delay_ms: 750,
+	max_game_load_retries: 3,
+	max_player_load_retries: 3
+
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/copi.owasp.org/config/prod.exs
+++ b/copi.owasp.org/config/prod.exs
@@ -17,9 +17,9 @@ config :swoosh, local: false
 config :logger, level: :info
 
 config :copi, :resilience,
-	retry_delay_ms: 750,
-	max_game_load_retries: 3,
-	max_player_load_retries: 3
+  retry_delay_ms: 750,
+  max_game_load_retries: 3,
+  max_player_load_retries: 3
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/copi.owasp.org/config/test.exs
+++ b/copi.owasp.org/config/test.exs
@@ -15,3 +15,8 @@ config :logger, level: :warning
 
 # Fixed test key - never use in production
 config :copi, :encryption_key, "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
+
+config :copi, :resilience,
+  retry_delay_ms: 100,
+  max_game_load_retries: 1,
+  max_player_load_retries: 1

--- a/copi.owasp.org/lib/copi/cornucopia/dealt_card.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/dealt_card.ex
@@ -17,7 +17,7 @@ defmodule Copi.Cornucopia.DealtCard do
   def find(id) do
     case Copi.Repo.get(Copi.Cornucopia.DealtCard, id) do
       nil ->
-        Logger.warning("Dealt card not found: #{id}")
+        Logger.debug("Dealt card not found: #{inspect(id)}")
         {:error, :not_found}
       dealt_card -> {:ok, dealt_card  |> Copi.Repo.preload([:card, :votes])}
     end

--- a/copi.owasp.org/lib/copi/cornucopia/dealt_card.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/dealt_card.ex
@@ -1,6 +1,7 @@
 defmodule Copi.Cornucopia.DealtCard do
   use Ecto.Schema
   import Ecto.Changeset
+  require Logger
 
   schema "dealt_cards" do
     field :played_in_round, :integer
@@ -15,7 +16,9 @@ defmodule Copi.Cornucopia.DealtCard do
 
   def find(id) do
     case Copi.Repo.get(Copi.Cornucopia.DealtCard, id) do
-      nil -> {:error, :not_found}
+      nil ->
+        Logger.warning("Dealt card not found: #{id}")
+        {:error, :not_found}
       dealt_card -> {:ok, dealt_card  |> Copi.Repo.preload([:card, :votes])}
     end
   end

--- a/copi.owasp.org/lib/copi/cornucopia/dealt_card.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/dealt_card.ex
@@ -15,11 +15,18 @@ defmodule Copi.Cornucopia.DealtCard do
   end
 
   def find(id) do
-    case Copi.Repo.get(Copi.Cornucopia.DealtCard, id) do
-      nil ->
-        Logger.debug("Dealt card not found: #{inspect(id)}")
+    case Ecto.Type.cast(:integer, id) do
+      {:ok, cast_id} ->
+        case Copi.Repo.get(Copi.Cornucopia.DealtCard, cast_id) do
+          nil ->
+            Logger.debug("Dealt card not found: #{inspect(id)}")
+            {:error, :not_found}
+          dealt_card -> {:ok, dealt_card  |> Copi.Repo.preload([:card, :votes])}
+        end
+
+      :error ->
+        Logger.debug("DealtCard find called with invalid id format: #{inspect(id)}")
         {:error, :not_found}
-      dealt_card -> {:ok, dealt_card  |> Copi.Repo.preload([:card, :votes])}
     end
   end
   @doc false

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -1,6 +1,7 @@
 defmodule Copi.Cornucopia.Game do
   use Ecto.Schema
   import Ecto.Changeset
+  require Logger
 
   @primary_key {:id, Ecto.ULID, autogenerate: true}
 
@@ -22,7 +23,9 @@ defmodule Copi.Cornucopia.Game do
 
   def find(id) do
     case Copi.Repo.get(Copi.Cornucopia.Game, id) do
-      nil -> {:error, :not_found}
+      nil -> 
+        Logger.warning("Game not found: #{id}")
+        {:error, :not_found}
       game -> {:ok, game |> Copi.Repo.preload([players: [dealt_cards: [:card, :votes]], continue_votes: [:player]])}
     end
   end

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -22,11 +22,18 @@ defmodule Copi.Cornucopia.Game do
   end
 
   def find(id) do
-    case Copi.Repo.get(Copi.Cornucopia.Game, id) do
-      nil -> 
-        Logger.warning("Game not found: #{id}")
+    case Ecto.ULID.cast(id) do
+      {:ok, cast_id} ->
+        case Copi.Repo.get(Copi.Cornucopia.Game, cast_id) do
+          nil ->
+            Logger.debug("Game not found: #{inspect(id)}")
+            {:error, :not_found}
+          game -> {:ok, game |> Copi.Repo.preload([players: [dealt_cards: [:card, :votes]], continue_votes: [:player]])}
+        end
+
+      :error ->
+        Logger.debug("Game find called with invalid id format: #{inspect(id)}")
         {:error, :not_found}
-      game -> {:ok, game |> Copi.Repo.preload([players: [dealt_cards: [:card, :votes]], continue_votes: [:player]])}
     end
   end
 

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -37,6 +37,22 @@ defmodule Copi.Cornucopia.Game do
     end
   end
 
+  def find_basic(id) do
+    case Ecto.ULID.cast(id) do
+      {:ok, cast_id} ->
+        case Copi.Repo.get(Copi.Cornucopia.Game, cast_id) do
+          nil ->
+            Logger.debug("Game not found: #{inspect(id)}")
+            {:error, :not_found}
+          game -> {:ok, game}
+        end
+
+      :error ->
+        Logger.debug("Game find called with invalid id format: #{inspect(id)}")
+        {:error, :not_found}
+    end
+  end
+
   @doc false
   def changeset(game, attrs) do
     game

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -16,11 +16,18 @@ defmodule Copi.Cornucopia.Player do
   end
 
   def find(id) do
-    case Copi.Repo.get(Copi.Cornucopia.Player, id) do
-      nil ->
-        Logger.warning("Player not found: #{id}")
+    case Ecto.ULID.cast(id) do
+      {:ok, cast_id} ->
+        case Copi.Repo.get(Copi.Cornucopia.Player, cast_id) do
+          nil ->
+            Logger.debug("Player not found: #{inspect(id)}")
+            {:error, :not_found}
+          player -> {:ok, player |> Copi.Repo.preload([:game, dealt_cards: [:card, :votes]])}
+        end
+
+      :error ->
+        Logger.debug("Player find called with invalid id format: #{inspect(id)}")
         {:error, :not_found}
-      player -> {:ok, player |> Copi.Repo.preload([:game, dealt_cards: [:card, :votes]])}
     end
   end
 

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -1,6 +1,7 @@
 defmodule Copi.Cornucopia.Player do
   use Ecto.Schema
   import Ecto.Changeset
+  require Logger
 
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
@@ -16,7 +17,9 @@ defmodule Copi.Cornucopia.Player do
 
   def find(id) do
     case Copi.Repo.get(Copi.Cornucopia.Player, id) do
-      nil -> {:error, :not_found}
+      nil ->
+        Logger.warning("Player not found: #{id}")
+        {:error, :not_found}
       player -> {:ok, player |> Copi.Repo.preload([:game, dealt_cards: [:card, :votes]])}
     end
   end

--- a/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
@@ -1,37 +1,70 @@
 defmodule CopiWeb.ApiController do
   use CopiWeb, :controller
   alias Copi.Cornucopia.Game
+
+  require Logger
+
   def play_card(conn, %{"game_id" => game_id, "player_id" => player_id, "dealt_card_id" => dealt_card_id}) do
-    with {:ok, game} <- Game.find(game_id) do
-      player = Enum.find(game.players, fn player -> player.id == player_id end)
-      if player do
-        dealt_card = Enum.find(player.dealt_cards, fn dealt_card -> Integer.to_string(dealt_card.id) == dealt_card_id end)
-        if dealt_card do
-          current_round = game.rounds_played + 1
-          cond do
-            dealt_card.played_in_round ->
-              conn |> put_status(:not_acceptable) |> json(%{"error" => "Card already played"})
-            Enum.find(player.dealt_cards, fn dealt_card -> dealt_card.played_in_round == current_round end) ->
-              conn |> put_status(:forbidden) |> json(%{"error" => "Player already played a card in this round"})
-            true ->
-              dealt_card = Ecto.Changeset.change(dealt_card, played_in_round: current_round)
-              dealt_card = Copi.Repo.update!(dealt_card)
-              
-              {:ok, updated_game} = Game.find(game.id)
-              CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
-              
-              conn |> json(%{"id" => dealt_card.id})
+    case Game.find(game_id) do
+      {:ok, game} ->
+        player = Enum.find(game.players, fn player -> player.id == player_id end)
+
+        if player do
+          dealt_card = Enum.find(player.dealt_cards, fn dealt_card -> Integer.to_string(dealt_card.id) == dealt_card_id end)
+
+          if dealt_card do
+            current_round = game.rounds_played + 1
+
+            cond do
+              dealt_card.played_in_round ->
+                conn |> put_status(:not_acceptable) |> json(%{"error" => "Card already played"})
+
+              Enum.find(player.dealt_cards, fn dealt_card -> dealt_card.played_in_round == current_round end) ->
+                conn |> put_status(:forbidden) |> json(%{"error" => "Player already played a card in this round"})
+
+              true ->
+                dealt_card_changeset = Ecto.Changeset.change(dealt_card, played_in_round: current_round)
+
+                case Copi.Repo.update(dealt_card_changeset) do
+                  {:ok, updated_dealt_card} ->
+                    case Game.find(game.id) do
+                      {:ok, updated_game} ->
+                        CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
+                        conn |> json(%{"id" => updated_dealt_card.id})
+
+                      {:error, :not_found} ->
+                        Logger.warning("Game disappeared after card update: #{game.id}")
+                        conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
+
+                      {:error, reason} ->
+                        Logger.warning("Transient game reload failure after card update for game_id=#{game.id}, reason=#{inspect(reason)}")
+                        conn |> put_status(:service_unavailable) |> json(%{"error" => "Temporary service issue. Please retry."})
+                    end
+
+                  {:error, changeset} ->
+                    Logger.warning("Card update failed for dealt_card_id=#{dealt_card.id}, player_id=#{player_id}, game_id=#{game_id}, errors=#{inspect(changeset.errors)}")
+                    conn |> put_status(:unprocessable_entity) |> json(%{"error" => "Could not play card"})
+                end
+            end
+          else
+            Logger.warning("Dealt card #{dealt_card_id} not found for player: #{player_id}")
+            conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
           end
         else
-          conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
+          Logger.warning("Player #{player_id} not found in game: #{game_id}")
+          conn |> put_status(:not_found) |> json(%{"error" => "Player not found in this game"})
         end
-      else
-        conn |> put_status(:not_found) |> json(%{"error" => "Player not found in this game"})
-      end
-    else
-      {:error, _reason} -> conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
+
+      {:error, :not_found} ->
+        Logger.warning("Game not found: #{game_id}")
+        conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
+
+      {:error, reason} ->
+        Logger.warning("Transient game lookup failure for game_id=#{game_id}, reason=#{inspect(reason)}")
+        conn |> put_status(:service_unavailable) |> json(%{"error" => "Temporary service issue. Please retry."})
     end
   end
+
   def topic(game_id) do
     "game:#{game_id}"
   end

--- a/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
@@ -36,34 +36,34 @@ defmodule CopiWeb.ApiController do
                         conn |> json(%{"id" => updated_dealt_card.id})
 
                       {:error, :not_found} ->
-                        Logger.warning("Game disappeared after card update: #{game.id}")
+                        Logger.warning("Game disappeared after card update: #{inspect(game.id)}")
                         conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
 
                       {:error, reason} ->
-                        Logger.warning("Transient game reload failure after card update for game_id=#{game.id}, reason=#{inspect(reason)}")
+                        Logger.warning("Transient game reload failure after card update for game_id=#{inspect(game.id)}, reason=#{inspect(reason)}")
                         conn |> put_status(:service_unavailable) |> json(%{"error" => "Temporary service issue. Please retry."})
                     end
 
                   {:error, changeset} ->
-                    Logger.warning("Card update failed for dealt_card_id=#{dealt_card.id}, player_id=#{player_id}, game_id=#{game_id}, errors=#{inspect(changeset.errors)}")
+                    Logger.warning("Card update failed for dealt_card_id=#{inspect(dealt_card.id)}, player_id=#{inspect(player_id)}, game_id=#{inspect(game_id)}, errors=#{inspect(changeset.errors)}")
                     conn |> put_status(:unprocessable_entity) |> json(%{"error" => "Could not play card"})
                 end
             end
           else
-            Logger.warning("Dealt card #{dealt_card_id} not found for player: #{player_id}")
+            Logger.debug("Dealt card #{inspect(dealt_card_id)} not found for player: #{inspect(player_id)}")
             conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
           end
         else
-          Logger.warning("Player #{player_id} not found in game: #{game_id}")
+          Logger.debug("Player #{inspect(player_id)} not found in game: #{inspect(game_id)}")
           conn |> put_status(:not_found) |> json(%{"error" => "Player not found in this game"})
         end
 
       {:error, :not_found} ->
-        Logger.warning("Game not found: #{game_id}")
+        Logger.debug("Game not found: #{inspect(game_id)}")
         conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
 
       {:error, reason} ->
-        Logger.warning("Transient game lookup failure for game_id=#{game_id}, reason=#{inspect(reason)}")
+        Logger.debug("Transient game lookup failure for game_id=#{inspect(game_id)}, reason=#{inspect(reason)}")
         conn |> put_status(:service_unavailable) |> json(%{"error" => "Temporary service issue. Please retry."})
     end
   end

--- a/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
@@ -5,7 +5,10 @@ defmodule CopiWeb.ApiController do
   require Logger
 
   def play_card(conn, %{"game_id" => game_id, "player_id" => player_id, "dealt_card_id" => dealt_card_id}) do
-    case Game.find(game_id) do
+    game_mod = Application.get_env(:copi, :api_game_module, Game) || Game
+    repo_mod = Application.get_env(:copi, :api_repo_module, Copi.Repo) || Copi.Repo
+
+    case game_mod.find(game_id) do
       {:ok, game} ->
         player = Enum.find(game.players, fn player -> player.id == player_id end)
 
@@ -25,9 +28,9 @@ defmodule CopiWeb.ApiController do
               true ->
                 dealt_card_changeset = Ecto.Changeset.change(dealt_card, played_in_round: current_round)
 
-                case Copi.Repo.update(dealt_card_changeset) do
+                case repo_mod.update(dealt_card_changeset) do
                   {:ok, updated_dealt_card} ->
-                    case Game.find(game.id) do
+                    case game_mod.find(game.id) do
                       {:ok, updated_game} ->
                         CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
                         conn |> json(%{"id" => updated_dealt_card.id})

--- a/copi.owasp.org/lib/copi_web/controllers/error_html.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/error_html.ex
@@ -13,10 +13,16 @@ defmodule CopiWeb.ErrorHTML do
   # The default is to render a plain text page based on
   # the template name. For example, "404.html" becomes
   # "Not Found".
-  def render(_template, assigns) do
+  def render(template, assigns) do
+    status = assigns[:status] || 500
+    status_template = if function_exported?(__MODULE__, String.to_atom(to_string(status)), 1) do
+      String.to_atom(to_string(status))
+    else
+      :"500"
+    end
 
     #Phoenix.Controller.status_message_from_template(template)
-    apply(__MODULE__, :"500", [assigns])
+    apply(__MODULE__, status_template, [assigns])
   end
 
 end

--- a/copi.owasp.org/lib/copi_web/controllers/error_html.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/error_html.ex
@@ -14,14 +14,16 @@ defmodule CopiWeb.ErrorHTML do
   # the template name. For example, "404.html" becomes
   # "Not Found".
   def render(template, assigns) do
-    status = assigns[:status] || 500
-    status_template = if function_exported?(__MODULE__, String.to_atom(to_string(status)), 1) do
-      String.to_atom(to_string(status))
-    else
-      :"500"
-    end
+    # Derive the status code from the template name (e.g. "400.html" -> :"400")
+    status_template =
+      case String.split(template, ".") do
+        [status | _] ->
+          atom = String.to_atom(status)
+          if function_exported?(__MODULE__, atom, 1), do: atom, else: :"500"
+        _ ->
+          :"500"
+      end
 
-    #Phoenix.Controller.status_message_from_template(template)
     apply(__MODULE__, status_template, [assigns])
   end
 

--- a/copi.owasp.org/lib/copi_web/controllers/error_html/400.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/error_html/400.html.heex
@@ -1,0 +1,81 @@
+<div class="bg-gray-900">
+  <main>
+    <!-- Hero section -->
+    <div class="relative isolate overflow-hidden">
+      <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+        <defs>
+          <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
+            <path d="M.5 200V.5H200" fill="none" />
+          </pattern>
+        </defs>
+        <svg x="50%" y="-1" class="overflow-visible fill-gray-800/20">
+          <path d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z" stroke-width="0" />
+        </svg>
+        <rect width="100%" height="100%" stroke-width="0" fill="url(#983e3e4c-de6d-4c3f-8d64-b9761d1534cc)" />
+      </svg>
+      <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
+        <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20 bg-clip-path-polygon"></div>
+      </div>
+      <div class="mx-auto max-w-7xl px-6 pb-24 pt-10 sm:pb-40 lg:flex lg:px-8 lg:pt-40">
+        <div class="mx-auto max-w-2xl flex-shrink-0 lg:mx-0 lg:max-w-xl lg:pt-8">
+          <a href="https://cornucopia.owasp.org" target="_blank" title="The OWASP Cornucopia home page" rel="external"><img class="h-40" src="/images/cornucopia_logo_white.svg" alt="OWASP Logo"></a>
+          <div class="mt-24 sm:mt-32 lg:mt-16">
+            <a href="#" class="inline-flex space-x-6">
+              <span class="rounded-full bg-indigo-500/10 px-3 py-1 text-sm font-semibold leading-6 text-indigo-400 ring-1 ring-inset ring-indigo-500/20">Latest updates</span>
+              <span class="inline-flex items-center space-x-2 text-sm font-medium leading-6 text-gray-300">
+                <span>Cornucopia Mobile deck now available</span>
+                <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+                </svg>
+              </span>
+            </a>
+          </div>
+          <h1 class="mt-10 text-4xl font-bold tracking-tight text-white sm:text-6xl">HTTP 400</h1>
+          <p class="mt-6 text-lg leading-8 text-gray-300">
+            Bad request. The provided input is invalid.
+          </p>
+          <div class="mt-10 flex items-center gap-x-6">
+            <a href="/games/new" class="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">Start a game</a>
+            <a href="/games/new#howtoplay" class="text-sm font-semibold leading-6 text-white">How do we play? <span aria-hidden="true">→</span></a>
+          </div>
+        </div>
+        <div class="mx-auto mt-16 flex max-w-2xl sm:mt-24 lg:ml-10 lg:mr-0 lg:mt-0 lg:max-w-none lg:flex-none xl:ml-32">
+          <div class="max-w-3xl flex-none sm:max-w-5xl lg:max-w-none">
+            <img src="/images/copi-screenie.png" alt="App screenshot" width="2596" height="1602" class="w-[76rem] rounded-md bg-white/5 shadow-2xl ring-1 ring-white/10">
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- Footer -->
+  <footer aria-labelledby="footer-heading" class="relative">
+    <h2 id="footer-heading" class="sr-only">Footer</h2>
+    <div class="mx-auto max-w-7xl px-6 pb-8 pt-4 lg:px-8">
+      <div class="border-t border-white/10 pt-8 md:flex md:items-center md:justify-between">
+        <div class="flex space-x-6 md:order-2">
+
+          <a href="https://github.com/OWASP/cornucopia/tree/master/copi.owasp.org" class="text-gray-500 hover:text-gray-400">
+            <span class="sr-only">GitHub</span>
+            <svg class="h-8 w-8" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          <a href="https://cornucopia.owasp.org" class="opacity-70 hover:opacity-100" target="_blank" title="The OWASP Cornucopia home page" rel="external">
+            <span class="sr-only">OWASP Cornucopia</span>
+            <img src="/images/cornucopia_logo_white.svg" class="h-10"  aria-hidden="true" />
+          </a>
+        </div>
+        <div>
+          <p class="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0">OWASP Cornucopia, Website App Edition is licensed under the <a href="https://github.com/OWASP/cornucopia/blob/master/LICENSE-CC-BY-SA-3.0.md" class="underline">CC-BY-SA-3.0</a>, created by Colin Watson</p>
+          <p class="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0">OWASP Cornucopia, Mobile App Edition is licensed under the <a href="https://github.com/OWASP/cornucopia/blob/master/LICENSE-CC-BY-SA-3.0.md" class="underline">CC-BY-SA-3.0</a>, created by Johan Sydseter & Xavier Godard</p>
+          <p class="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0">Copi is licensed under the <a href="https://www.gnu.org/licenses/" class="underline">GNU Affero General Public License</a>, created by Toby Irvine</p>
+          <p class="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0">Elevation of Privilege are licensed under <a href="https://creativecommons.org/licenses/by-sa/3.0/" class="underline">CC BY 3.0</a>, created by Adam Shostack when working at Microsoft Corporation (see: [adamshostack/eop](https://github.com/adamshostack/eop))</p>
+          <p class="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0"><a href="https://github.com/kantega/elevation-of-mlsec" class="underline">Elevation of MLSec</a> is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="underline">CC BY 4.0</a>, created by Elias Brattli Sørensen (design: Jorun Kristin Bremseth) when working at Kantega AS</p>
+          <p class="mt-8 text-xs leading-5 text-gray-400 md:order-1 md:mt-0"><a href="https://github.com/OWASP/cumulus" class="underline">OWASP Cumulus</a> is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="underline">CC BY 4.0</a>, created by Christoph Niehoff when working at TNG Technology Consulting</p>
+        </div>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/copi.owasp.org/lib/copi_web/controllers/health_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/health_controller.ex
@@ -3,9 +3,11 @@ defmodule CopiWeb.HealthController do
   require Logger
 
   def index(conn, _params) do
+    repo_mod = Application.get_env(:copi, :health_repo_module, Copi.Repo) || Copi.Repo
+
     # Check database connection with timeouts and exception handling
     try do
-      {:ok, _} = Copi.Repo.query("SELECT 1", [], timeout: 1_000, pool_timeout: 1_000)
+      {:ok, _} = repo_mod.query("SELECT 1", [], timeout: 1_000, pool_timeout: 1_000)
       send_resp(conn, :ok, "healthy\n")
     rescue
       _ -> send_resp(conn, :service_unavailable, "not ready\n")

--- a/copi.owasp.org/lib/copi_web/live/game_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/show.ex
@@ -36,8 +36,8 @@ defmodule CopiWeb.GameLive.Show do
       {:error, reason} ->
         retry_count = socket.assigns[:game_load_retry_count] || 0
 
-        Logger.warning(
-          "Transient game load failure for game_id=#{params["game_id"]}, retry=#{retry_count}, reason=#{inspect(reason)}"
+        Logger.debug(
+          "Transient game load failure for game_id=#{inspect(params["game_id"])}, retry=#{retry_count}, reason=#{inspect(reason)}"
         )
 
         cond do

--- a/copi.owasp.org/lib/copi_web/live/game_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/show.ex
@@ -3,6 +3,9 @@ defmodule CopiWeb.GameLive.Show do
 
   alias Copi.Cornucopia.Game
   alias Copi.Cornucopia.DealtCard
+  alias CopiWeb.Resilience
+
+  require Logger
 
   @impl true
   def mount(_params, session, socket) do
@@ -19,31 +22,51 @@ defmodule CopiWeb.GameLive.Show do
 
   @impl true
   def handle_params(params, _, socket) do
-    with {:ok, game} <- Game.find(params["game_id"]) do
-      CopiWeb.Endpoint.subscribe(topic(params["game_id"]))
+    case Game.find(params["game_id"]) do
+      {:ok, game} ->
+        CopiWeb.Endpoint.subscribe(topic(params["game_id"]))
+        assign_game_and_round(socket, params, game)
 
-      current_round = if game.finished_at do
-        game.rounds_played
-      else
-        game.rounds_played + 1
-      end
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Game not found.")
+         |> redirect(to: "/games")}
 
-      round_result = if params["round"] do
-        Want.integer(params["round"], min: 1, max: current_round)
-      else
-        {:ok, current_round}
-      end
+      {:error, reason} ->
+        retry_count = socket.assigns[:game_load_retry_count] || 0
 
-      case round_result do
-        {:ok, requested_round} ->
-          {:noreply, socket |> assign(:game, game) |> assign(:requested_round, requested_round)}
-        {:error, _reason} ->
-          {:noreply, redirect(socket, to: "/error")}
-      end
-    else
-      {:error, _reason} ->
-        {:noreply, redirect(socket, to: "/error")}
+        Logger.warning(
+          "Transient game load failure for game_id=#{params["game_id"]}, retry=#{retry_count}, reason=#{inspect(reason)}"
+        )
+
+        cond do
+          socket.assigns[:game] && retry_count < Resilience.max_game_load_retries() ->
+            Process.send_after(self(), {:retry_game_load, params}, Resilience.retry_delay_ms())
+
+            {:noreply,
+             socket
+             |> assign(:game_load_retry_count, retry_count + 1)
+             |> put_flash(:error, "Temporary issue loading game. Retrying...")}
+
+          socket.assigns[:game] ->
+            {:noreply,
+             socket
+             |> assign(:game_load_retry_count, 0)
+             |> put_flash(:error, "Temporary issue loading game. Please try again.")}
+
+          true ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Temporary issue loading game. Please try again.")
+             |> redirect(to: "/games")}
+        end
     end
+  end
+
+  @impl true
+  def handle_info({:retry_game_load, params}, socket) do
+    handle_params(params, nil, socket)
   end
 
   @impl true
@@ -53,6 +76,37 @@ defmodule CopiWeb.GameLive.Show do
         {:noreply, assign(socket, :game, updated_game) |> assign(:requested_round, updated_game.rounds_played + 1)}
       true ->
         {:noreply, socket}
+    end
+  end
+
+  defp assign_game_and_round(socket, params, game) do
+    current_round = if game.finished_at do
+      game.rounds_played
+    else
+      game.rounds_played + 1
+    end
+
+    round_result = if params["round"] do
+      Want.integer(params["round"], min: 1, max: current_round)
+    else
+      {:ok, current_round}
+    end
+
+    case round_result do
+      {:ok, requested_round} ->
+        {:noreply,
+         socket
+         |> assign(:game, game)
+         |> assign(:requested_round, requested_round)
+         |> assign(:game_load_retry_count, 0)}
+
+      {:error, _reason} ->
+        {:noreply,
+         socket
+         |> assign(:game, game)
+         |> assign(:requested_round, current_round)
+         |> assign(:game_load_retry_count, 0)
+         |> put_flash(:error, "Invalid round value. Showing current round instead.")}
     end
   end
 

--- a/copi.owasp.org/lib/copi_web/live/game_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/show.ex
@@ -22,7 +22,7 @@ defmodule CopiWeb.GameLive.Show do
 
   @impl true
   def handle_params(params, _, socket) do
-    case Game.find(params["game_id"]) do
+    case game_module().find(params["game_id"]) do
       {:ok, game} ->
         CopiWeb.Endpoint.subscribe(topic(params["game_id"]))
         assign_game_and_round(socket, params, game)
@@ -181,5 +181,9 @@ defmodule CopiWeb.GameLive.Show do
       "eop" -> "5.1"
       _ -> "1.0"
     end
+  end
+
+  defp game_module do
+    Application.get_env(:copi, :game_live_show_game_module, Game) || Game
   end
 end

--- a/copi.owasp.org/lib/copi_web/live/player_live/index.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/index.ex
@@ -2,46 +2,110 @@ defmodule CopiWeb.PlayerLive.Index do
   use CopiWeb, :live_view
 
   alias Copi.Cornucopia
+  alias Copi.Cornucopia.Game
   alias Copi.Cornucopia.Player
+  alias CopiWeb.Resilience
+
+  require Logger
 
   @impl true
   def mount(%{"game_id" => game_id}, session, socket) do
     ip = socket.assigns[:client_ip] || Map.get(session, "client_ip") || Copi.IPHelper.get_ip_from_socket(socket)
-    game = Cornucopia.get_game!(game_id)
+    socket = assign(socket, :client_ip, ip)
 
-    # V2.2: Block at mount — returning redirect from mount sends a true HTTP 302
-    # during the dead (static) render, before any HTML or WebSocket reaches the client.
-    if game.started_at do
-      {:ok,
-       socket
-       |> put_flash(:error, "This game has already started. New players cannot join a game in progress.")
-       |> redirect(to: ~p"/games")}
-    else
-      {:ok, assign(assign(socket, :client_ip, ip), players: list_players(game_id), game: game)}
+    case Game.find(game_id) do
+      {:ok, game} ->
+        if game.started_at do
+          {:ok,
+           socket
+           |> put_flash(:error, "This game has already started. New players cannot join a game in progress.")
+           |> redirect(to: ~p"/games")}
+        else
+          {:ok,
+           socket
+           |> assign(:game, game)
+           |> assign(:players, list_players(game_id))
+           |> assign(:game_load_retry_count, 0)}
+        end
+
+      {:error, :not_found} ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Game not found.")
+         |> redirect(to: ~p"/games")}
+
+      {:error, reason} ->
+        Logger.warning("Transient game load failure in PlayerLive.Index mount for game_id=#{game_id}, reason=#{inspect(reason)}")
+
+        {:ok,
+         socket
+         |> put_flash(:error, "Temporary issue loading game. Please try again.")
+         |> redirect(to: ~p"/games")}
     end
   end
 
   @impl true
   def handle_params(%{"game_id" => game_id} = params, _url, socket) do
-    # Re-fetch game state for LiveView client-side navigations (when mount isn't called)
-    game = Cornucopia.get_game!(game_id)
+    case Game.find(game_id) do
+      {:ok, game} ->
+        # V2.2: Also check in handle_params for LiveView navigation scenarios
+        if game.started_at do
+          {:noreply,
+           socket
+           |> put_flash(:error, "This game has already started. New players cannot join a game in progress.")
+           |> redirect(to: ~p"/games")}
+        else
+          # Assign freshly loaded game and players for LiveView client-side navigations
+          players = list_players(game_id)
 
-    # V2.2: Also check in handle_params for LiveView navigation scenarios
-    if game.started_at do
-      {:noreply,
-       socket
-       |> put_flash(:error, "This game has already started. New players cannot join a game in progress.")
-       |> redirect(to: ~p"/games")}
-    else
-      # Assign freshly loaded game and players for LiveView client-side navigations
-      players = list_players(game_id)
+          {:noreply,
+           socket
+           |> assign(:game, game)
+           |> assign(:players, players)
+           |> assign(:game_load_retry_count, 0)
+           |> apply_action(socket.assigns.live_action, params)}
+        end
 
-      {:noreply,
-       socket
-       |> assign(:game, game)
-       |> assign(:players, players)
-       |> apply_action(socket.assigns.live_action, params)}
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Game not found.")
+         |> redirect(to: ~p"/games")}
+
+      {:error, reason} ->
+        retry_count = socket.assigns[:game_load_retry_count] || 0
+
+        Logger.warning(
+          "Transient game load failure in PlayerLive.Index handle_params for game_id=#{game_id}, retry=#{retry_count}, reason=#{inspect(reason)}"
+        )
+
+        cond do
+          socket.assigns[:game] && retry_count < Resilience.max_game_load_retries() ->
+            Process.send_after(self(), {:retry_player_index_load, params}, Resilience.retry_delay_ms())
+
+            {:noreply,
+             socket
+             |> assign(:game_load_retry_count, retry_count + 1)
+             |> put_flash(:error, "Temporary issue loading game. Retrying...")}
+
+          socket.assigns[:game] ->
+            {:noreply,
+             socket
+             |> assign(:game_load_retry_count, 0)
+             |> put_flash(:error, "Temporary issue loading game. Please try again.")}
+
+          true ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Temporary issue loading game. Please try again.")
+             |> redirect(to: ~p"/games")}
+        end
     end
+  end
+
+  @impl true
+  def handle_info({:retry_player_index_load, params}, socket) do
+    handle_params(params, nil, socket)
   end
 
   defp apply_action(socket, :edit, %{"id" => id}) do

--- a/copi.owasp.org/lib/copi_web/live/player_live/index.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/index.ex
@@ -13,7 +13,7 @@ defmodule CopiWeb.PlayerLive.Index do
     ip = socket.assigns[:client_ip] || Map.get(session, "client_ip") || Copi.IPHelper.get_ip_from_socket(socket)
     socket = assign(socket, :client_ip, ip)
 
-    case Game.find(game_id) do
+    case game_module().find(game_id) do
       {:ok, game} ->
         if game.started_at do
           {:ok,
@@ -46,7 +46,7 @@ defmodule CopiWeb.PlayerLive.Index do
 
   @impl true
   def handle_params(%{"game_id" => game_id} = params, _url, socket) do
-    case Game.find(game_id) do
+    case game_module().find(game_id) do
       {:ok, game} ->
         # V2.2: Also check in handle_params for LiveView navigation scenarios
         if game.started_at do
@@ -129,5 +129,9 @@ defmodule CopiWeb.PlayerLive.Index do
 
   defp list_players(game_id) do
     Cornucopia.list_players(game_id)
+  end
+
+  defp game_module do
+    Application.get_env(:copi, :player_live_index_game_module, Game) || Game
   end
 end

--- a/copi.owasp.org/lib/copi_web/live/player_live/index.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/index.ex
@@ -13,7 +13,7 @@ defmodule CopiWeb.PlayerLive.Index do
     ip = socket.assigns[:client_ip] || Map.get(session, "client_ip") || Copi.IPHelper.get_ip_from_socket(socket)
     socket = assign(socket, :client_ip, ip)
 
-    case game_module().find(game_id) do
+    case game_module().find_basic(game_id) do
       {:ok, game} ->
         if game.started_at do
           {:ok,
@@ -46,7 +46,7 @@ defmodule CopiWeb.PlayerLive.Index do
 
   @impl true
   def handle_params(%{"game_id" => game_id} = params, _url, socket) do
-    case game_module().find(game_id) do
+    case game_module().find_basic(game_id) do
       {:ok, game} ->
         # V2.2: Also check in handle_params for LiveView navigation scenarios
         if game.started_at do

--- a/copi.owasp.org/lib/copi_web/live/player_live/index.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/index.ex
@@ -35,7 +35,7 @@ defmodule CopiWeb.PlayerLive.Index do
          |> redirect(to: ~p"/games")}
 
       {:error, reason} ->
-        Logger.warning("Transient game load failure in PlayerLive.Index mount for game_id=#{game_id}, reason=#{inspect(reason)}")
+        Logger.debug("Transient game load failure in PlayerLive.Index mount for game_id=#{inspect(game_id)}, reason=#{inspect(reason)}")
 
         {:ok,
          socket
@@ -75,8 +75,8 @@ defmodule CopiWeb.PlayerLive.Index do
       {:error, reason} ->
         retry_count = socket.assigns[:game_load_retry_count] || 0
 
-        Logger.warning(
-          "Transient game load failure in PlayerLive.Index handle_params for game_id=#{game_id}, retry=#{retry_count}, reason=#{inspect(reason)}"
+        Logger.debug(
+          "Transient game load failure in PlayerLive.Index handle_params for game_id=#{inspect(game_id)}, retry=#{retry_count}, reason=#{inspect(reason)}"
         )
 
         cond do

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -154,10 +154,24 @@ defmodule CopiWeb.PlayerLive.Show do
 
   @impl true
   def handle_event("toggle_vote", %{"dealt_card_id" => dealt_card_id}, socket) do
+    # Parse dealt_card_id defensively - it comes from client params
+    case Integer.parse(dealt_card_id) do
+      {card_id, ""} ->
+        # Successfully parsed entire string as integer
+        handle_toggle_vote(card_id, socket)
+
+      _ ->
+        # Failed to parse as integer or had trailing characters
+        Logger.warning("Invalid dealt_card_id format received: #{inspect(dealt_card_id)}")
+        {:noreply, socket |> put_flash(:error, "Invalid card format. Please refresh and try again.")}
+    end
+  end
+
+  defp handle_toggle_vote(card_id, socket) do
     game = socket.assigns.game
     player = socket.assigns.player
 
-    case dealt_card_module().find(dealt_card_id) do
+    case dealt_card_module().find(card_id) do
       {:ok, dealt_card} ->
         game_card_ids = game.players
           |> Enum.flat_map(fn p -> p.dealt_cards end)
@@ -167,15 +181,15 @@ defmodule CopiWeb.PlayerLive.Show do
           vote = get_vote(dealt_card, player)
 
           if vote do
-            Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+            Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{card_id}, game_id: #{game.id}")
             Copi.Repo.delete!(vote)
           else
-            Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-            case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
+            Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{card_id}, game_id: #{game.id}")
+            case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: card_id, player_id: player.id}) do
               {:ok, _vote} ->
-                Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+                Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{card_id}, game_id: #{game.id}")
               {:error, changeset} ->
-                Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+                Logger.warning("Voting failed for player_id: #{inspect(player.id)}, dealt_card_id: #{inspect(card_id)}, game_id: #{inspect(game.id)}, errors: #{inspect(changeset.errors)}")
             end
           end
 
@@ -183,16 +197,16 @@ defmodule CopiWeb.PlayerLive.Show do
           CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
           {:noreply, assign(socket, :game, updated_game)}
         else
-          Logger.warning("Unauthorized vote attempt: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+          Logger.warning("Unauthorized vote attempt: player_id: #{inspect(player.id)}, dealt_card_id: #{inspect(card_id)}, game_id: #{inspect(game.id)}")
           {:noreply, socket |> put_flash(:error, "Invalid card selection")}
         end
 
       {:error, :not_found} ->
-        Logger.warning("Vote attempt with missing dealt_card_id=#{dealt_card_id} for player_id=#{player.id}, game_id=#{game.id}")
+        Logger.debug("Vote attempt with missing dealt_card_id=#{inspect(card_id)} for player_id=#{inspect(player.id)}, game_id=#{inspect(game.id)}")
         {:noreply, socket |> put_flash(:error, "Card not found. Please refresh and try again.")}
 
       {:error, reason} ->
-        Logger.warning("Transient dealt card lookup failure for dealt_card_id=#{dealt_card_id}, player_id=#{player.id}, game_id=#{game.id}, reason=#{inspect(reason)}")
+        Logger.debug("Transient dealt card lookup failure for dealt_card_id=#{inspect(card_id)}, player_id=#{inspect(player.id)}, game_id=#{inspect(game.id)}, reason=#{inspect(reason)}")
         {:noreply, socket |> put_flash(:error, "Temporary issue loading card. Please try again.")}
     end
   end
@@ -258,8 +272,8 @@ defmodule CopiWeb.PlayerLive.Show do
   defp handle_transient_player_load_failure(socket, player_id, reason) do
     retry_count = socket.assigns[:player_load_retry_count] || 0
 
-    Logger.warning(
-      "Transient player/game load failure in PlayerLive.Show for player_id=#{player_id}, retry=#{retry_count}, reason=#{inspect(reason)}"
+    Logger.debug(
+      "Transient player/game load failure in PlayerLive.Show for player_id=#{inspect(player_id)}, retry=#{retry_count}, reason=#{inspect(reason)}"
     )
 
     cond do

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -41,10 +41,7 @@ defmodule CopiWeb.PlayerLive.Show do
         end
 
       {:error, :not_found} ->
-        {:noreply,
-         socket
-         |> put_flash(:error, "Player not found.")
-         |> redirect(to: "/games")}
+        raise Ecto.NoResultsError, queryable: Player
 
       {:error, reason} ->
         handle_transient_player_load_failure(socket, player_id, reason)

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -8,6 +8,7 @@ defmodule CopiWeb.PlayerLive.Show do
   alias Copi.Cornucopia.Player
   alias Copi.Cornucopia.Game
   alias Copi.Cornucopia.DealtCard
+  alias CopiWeb.Resilience
 
   @impl true
   def mount(_params, session, socket) do
@@ -17,14 +18,42 @@ defmodule CopiWeb.PlayerLive.Show do
 
   @impl true
   def handle_params(%{"id" => player_id}, _, socket) do
-    with {:ok, player} <- Player.find(player_id),
-         {:ok, game} <- Game.find(player.game_id) do
-      CopiWeb.Endpoint.subscribe(topic(player.game_id))
-      {:noreply, socket |> assign(:game, game) |> assign(:player, player)}
-    else
-      {:error, _reason} ->
-        {:noreply, redirect(socket, to: "/error")}
+    case Player.find(player_id) do
+      {:ok, player} ->
+        case Game.find(player.game_id) do
+          {:ok, game} ->
+            CopiWeb.Endpoint.subscribe(topic(player.game_id))
+
+            {:noreply,
+             socket
+             |> assign(:game, game)
+             |> assign(:player, player)
+             |> assign(:player_load_retry_count, 0)}
+
+          {:error, :not_found} ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Game not found.")
+             |> redirect(to: "/games")}
+
+          {:error, reason} ->
+            handle_transient_player_load_failure(socket, player_id, reason)
+        end
+
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Player not found.")
+         |> redirect(to: "/games")}
+
+      {:error, reason} ->
+        handle_transient_player_load_failure(socket, player_id, reason)
     end
+  end
+
+  @impl true
+  def handle_info({:retry_player_show_load, player_id}, socket) do
+    handle_params(%{"id" => player_id}, nil, socket)
   end
 
   @impl true
@@ -121,34 +150,43 @@ defmodule CopiWeb.PlayerLive.Show do
     game = socket.assigns.game
     player = socket.assigns.player
 
-    {:ok, dealt_card} = DealtCard.find(dealt_card_id)
+    case DealtCard.find(dealt_card_id) do
+      {:ok, dealt_card} ->
+        game_card_ids = game.players
+          |> Enum.flat_map(fn p -> p.dealt_cards end)
+          |> Enum.map(fn dc -> dc.id end)
 
-    game_card_ids = game.players
-      |> Enum.flat_map(fn p -> p.dealt_cards end)
-      |> Enum.map(fn dc -> dc.id end)
+        if dealt_card.id in game_card_ids do
+          vote = get_vote(dealt_card, player)
 
-    if dealt_card.id in game_card_ids do
-      vote = get_vote(dealt_card, player)
+          if vote do
+            Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+            Copi.Repo.delete!(vote)
+          else
+            Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+            case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
+              {:ok, _vote} ->
+                Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+              {:error, changeset} ->
+                Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+            end
+          end
 
-      if vote do
-        Logger.debug("Player has voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-        Copi.Repo.delete!(vote)
-      else
-        Logger.debug("Player has not voted: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-        case Copi.Repo.insert(%Copi.Cornucopia.Vote{dealt_card_id: String.to_integer(dealt_card_id), player_id: player.id}) do
-          {:ok, _vote} ->
-            Logger.debug("Vote added successfully for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-          {:error, changeset} ->
-            Logger.warning("Voting failed for player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}, errors: #{inspect(changeset.errors)}")
+          {:ok, updated_game} = Game.find(game.id)
+          CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
+          {:noreply, assign(socket, :game, updated_game)}
+        else
+          Logger.warning("Unauthorized vote attempt: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
+          {:noreply, socket |> put_flash(:error, "Invalid card selection")}
         end
-      end
 
-      {:ok, updated_game} = Game.find(game.id)
-      CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
-      {:noreply, assign(socket, :game, updated_game)}
-    else
-      Logger.warning("Unauthorized vote attempt: player_id: #{player.id}, dealt_card_id: #{dealt_card_id}, game_id: #{game.id}")
-      {:noreply, socket |> put_flash(:error, "Invalid card selection")}
+      {:error, :not_found} ->
+        Logger.warning("Vote attempt with missing dealt_card_id=#{dealt_card_id} for player_id=#{player.id}, game_id=#{game.id}")
+        {:noreply, socket |> put_flash(:error, "Card not found. Please refresh and try again.")}
+
+      {:error, reason} ->
+        Logger.warning("Transient dealt card lookup failure for dealt_card_id=#{dealt_card_id}, player_id=#{player.id}, game_id=#{game.id}, reason=#{inspect(reason)}")
+        {:noreply, socket |> put_flash(:error, "Temporary issue loading card. Please try again.")}
     end
   end
 
@@ -207,6 +245,36 @@ defmodule CopiWeb.PlayerLive.Show do
       "cumulus" -> "OWASP Cumulus Session:"
       "mlsec" -> "Elevation of MLSec Session:"
       _ -> "EoP Session:"
+    end
+  end
+
+  defp handle_transient_player_load_failure(socket, player_id, reason) do
+    retry_count = socket.assigns[:player_load_retry_count] || 0
+
+    Logger.warning(
+      "Transient player/game load failure in PlayerLive.Show for player_id=#{player_id}, retry=#{retry_count}, reason=#{inspect(reason)}"
+    )
+
+    cond do
+      socket.assigns[:game] && socket.assigns[:player] && retry_count < Resilience.max_player_load_retries() ->
+        Process.send_after(self(), {:retry_player_show_load, player_id}, Resilience.retry_delay_ms())
+
+        {:noreply,
+         socket
+         |> assign(:player_load_retry_count, retry_count + 1)
+         |> put_flash(:error, "Temporary issue loading player/game. Retrying...")}
+
+      socket.assigns[:game] && socket.assigns[:player] ->
+        {:noreply,
+         socket
+         |> assign(:player_load_retry_count, 0)
+         |> put_flash(:error, "Temporary issue loading player/game. Please try again.")}
+
+      true ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Temporary issue loading player/game. Please try again.")
+         |> redirect(to: "/games")}
     end
   end
 

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -10,6 +10,10 @@ defmodule CopiWeb.PlayerLive.Show do
   alias Copi.Cornucopia.DealtCard
   alias CopiWeb.Resilience
 
+  defmodule BadPlayerID do
+    defexception message: "Invalid player ID format", plug_status: 400
+  end
+
   @impl true
   def mount(_params, session, socket) do
     ip = socket.assigns[:client_ip] || Map.get(session, "client_ip") || Copi.IPHelper.get_ip_from_socket(socket)
@@ -18,7 +22,9 @@ defmodule CopiWeb.PlayerLive.Show do
 
   @impl true
   def handle_params(%{"id" => player_id}, _, socket) do
-    case player_module().find(player_id) do
+    case validate_ulid_format(player_id) do
+      :ok ->
+        case player_module().find(player_id) do
       {:ok, player} ->
         case game_module().find(player.game_id) do
           {:ok, game} ->
@@ -45,6 +51,10 @@ defmodule CopiWeb.PlayerLive.Show do
 
       {:error, reason} ->
         handle_transient_player_load_failure(socket, player_id, reason)
+        end
+
+      :invalid_format ->
+        raise BadPlayerID
     end
   end
 
@@ -286,5 +296,20 @@ defmodule CopiWeb.PlayerLive.Show do
   defp dealt_card_module do
     Application.get_env(:copi, :player_live_show_dealt_card_module, DealtCard) || DealtCard
   end
+
+  defp validate_ulid_format(id) when is_binary(id) do
+    case String.length(id) do
+      26 ->
+        case Ecto.ULID.cast(id) do
+          {:ok, _} -> :ok
+          :error -> :invalid_format
+        end
+
+      _ ->
+        :invalid_format
+    end
+  end
+
+  defp validate_ulid_format(_), do: :invalid_format
 
 end

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -18,9 +18,9 @@ defmodule CopiWeb.PlayerLive.Show do
 
   @impl true
   def handle_params(%{"id" => player_id}, _, socket) do
-    case Player.find(player_id) do
+    case player_module().find(player_id) do
       {:ok, player} ->
-        case Game.find(player.game_id) do
+        case game_module().find(player.game_id) do
           {:ok, game} ->
             CopiWeb.Endpoint.subscribe(topic(player.game_id))
 
@@ -58,7 +58,7 @@ defmodule CopiWeb.PlayerLive.Show do
 
   @impl true
   def handle_info(%{topic: _message_topic, event: "game:updated", payload: updated_game}, socket) do
-    case Player.find(socket.assigns.player.id) do
+    case player_module().find(socket.assigns.player.id) do
       {:ok, updated_player} ->
         {:noreply, socket |> assign(:game, updated_game) |> assign(:player, updated_player)}
       {:error, _reason} ->
@@ -80,7 +80,7 @@ defmodule CopiWeb.PlayerLive.Show do
       Copi.Cornucopia.update_game(game, %{finished_at: DateTime.truncate(DateTime.utc_now(), :second)} )
     end
 
-    {:ok, updated_game} = Game.find(game.id)
+    {:ok, updated_game} = game_module().find(game.id)
 
     CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
 
@@ -112,7 +112,7 @@ defmodule CopiWeb.PlayerLive.Show do
         Copi.Cornucopia.update_game(game, %{finished_at: DateTime.truncate(DateTime.utc_now(), :second)} )
       end
 
-      {:ok, updated_game} = Game.find(game.id)
+      {:ok, updated_game} = game_module().find(game.id)
 
       CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
 
@@ -138,7 +138,7 @@ defmodule CopiWeb.PlayerLive.Show do
       Copi.Repo.insert(%Copi.Cornucopia.ContinueVote{player_id: player.id, game_id: game.id})
     end
 
-    {:ok, updated_game} = Game.find(game.id)
+    {:ok, updated_game} = game_module().find(game.id)
 
     CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
 
@@ -150,7 +150,7 @@ defmodule CopiWeb.PlayerLive.Show do
     game = socket.assigns.game
     player = socket.assigns.player
 
-    case DealtCard.find(dealt_card_id) do
+    case dealt_card_module().find(dealt_card_id) do
       {:ok, dealt_card} ->
         game_card_ids = game.players
           |> Enum.flat_map(fn p -> p.dealt_cards end)
@@ -172,7 +172,7 @@ defmodule CopiWeb.PlayerLive.Show do
             end
           end
 
-          {:ok, updated_game} = Game.find(game.id)
+          {:ok, updated_game} = game_module().find(game.id)
           CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
           {:noreply, assign(socket, :game, updated_game)}
         else
@@ -276,6 +276,18 @@ defmodule CopiWeb.PlayerLive.Show do
          |> put_flash(:error, "Temporary issue loading player/game. Please try again.")
          |> redirect(to: "/games")}
     end
+  end
+
+  defp player_module do
+    Application.get_env(:copi, :player_live_show_player_module, Player) || Player
+  end
+
+  defp game_module do
+    Application.get_env(:copi, :player_live_show_game_module, Game) || Game
+  end
+
+  defp dealt_card_module do
+    Application.get_env(:copi, :player_live_show_dealt_card_module, DealtCard) || DealtCard
   end
 
 end

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
@@ -4,7 +4,7 @@
 
   <h2>Thanks for playing, <%= @player.name %>! This game finished at <%= @player.game.finished_at %></h2>
 
-  <.link patch={~p"/games/#{@player.game_id}"} class="mt-3 inline-block rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+  <.link navigate={~p"/games/#{@player.game_id}"} class="mt-3 inline-block rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
     Go to game summary
   </.link>
 <% else %>

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
@@ -4,7 +4,9 @@
 
   <h2>Thanks for playing, <%= @player.name %>! This game finished at <%= @player.game.finished_at %></h2>
 
-  <span class="button"><a href={~p"/games/#{@player.game_id}"}>Go to game summary</a></span>
+  <.link patch={~p"/games/#{@player.game_id}"}>
+    <.primary_button class="mt-3">Go to game summary</.primary_button>
+  </.link>
 <% else %>
 
   <%= if @player.game.started_at do %>

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
@@ -4,8 +4,8 @@
 
   <h2>Thanks for playing, <%= @player.name %>! This game finished at <%= @player.game.finished_at %></h2>
 
-  <.link patch={~p"/games/#{@player.game_id}"}>
-    <.primary_button class="mt-3">Go to game summary</.primary_button>
+  <.link patch={~p"/games/#{@player.game_id}"} class="mt-3 inline-block rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+    Go to game summary
   </.link>
 <% else %>
 

--- a/copi.owasp.org/lib/copi_web/resilience.ex
+++ b/copi.owasp.org/lib/copi_web/resilience.ex
@@ -1,0 +1,27 @@
+defmodule CopiWeb.Resilience do
+  @moduledoc false
+
+  @defaults [
+    retry_delay_ms: 750,
+    max_game_load_retries: 2,
+    max_player_load_retries: 2
+  ]
+
+  def retry_delay_ms do
+    config(:retry_delay_ms)
+  end
+
+  def max_game_load_retries do
+    config(:max_game_load_retries)
+  end
+
+  def max_player_load_retries do
+    config(:max_player_load_retries)
+  end
+
+  defp config(key) do
+    :copi
+    |> Application.get_env(:resilience, @defaults)
+    |> Keyword.get(key, Keyword.fetch!(@defaults, key))
+  end
+end

--- a/copi.owasp.org/test/copi/cornucopia_test.exs
+++ b/copi.owasp.org/test/copi/cornucopia_test.exs
@@ -185,6 +185,11 @@ defmodule Copi.CornucopiaTest do
       assert player.name == "Early Player"
       assert player.game_id == game.id
     end
+
+    test "Player.find/1 returns error for non-existent player" do
+      assert {:error, :not_found} =
+               Copi.Cornucopia.Player.find("00000000000000000000000099")
+    end
   end
 
   describe "cards" do

--- a/copi.owasp.org/test/copi/encrypted/binary_test.exs
+++ b/copi.owasp.org/test/copi/encrypted/binary_test.exs
@@ -119,4 +119,21 @@ defmodule Copi.Encrypted.BinaryTest do
     assert :error = EncryptedBinary.load(%{})
   end
 
+  test "dump raises when encryption key is invalid base64" do
+    System.put_env("COPI_ENCRYPTION_KEY", "%%%not-base64%%%")
+
+    assert_raise ArgumentError, fn ->
+      EncryptedBinary.dump("anything")
+    end
+  end
+
+  test "dump raises when encryption key has wrong decoded length" do
+    short_key = :crypto.strong_rand_bytes(16) |> Base.encode64()
+    System.put_env("COPI_ENCRYPTION_KEY", short_key)
+
+    assert_raise ArgumentError, fn ->
+      EncryptedBinary.dump("anything")
+    end
+  end
+
 end

--- a/copi.owasp.org/test/copi/ip_helper_test.exs
+++ b/copi.owasp.org/test/copi/ip_helper_test.exs
@@ -322,5 +322,28 @@ defmodule Copi.IPHelperTest do
 
       assert IPHelper.get_ip_from_socket(socket) == {203, 0, 113, 4}
     end
+
+    test "returns non-tuple peer_data address as-is for LiveView socket" do
+      socket = %Phoenix.LiveView.Socket{private: %{connect_info: %{peer_data: %{address: "10.0.9.9"}}}}
+      assert IPHelper.get_ip_from_socket(socket) == "10.0.9.9"
+    end
+
+    test "handles unknown connect_info type by falling back to localhost" do
+      socket = %Phoenix.LiveView.Socket{private: %{connect_info: :unexpected}}
+      assert IPHelper.get_ip_from_socket(socket) == {127, 0, 0, 1}
+    end
+
+    test "get_ip_from_connect_info handles request_header key and invalid headers_in shape" do
+      assert IPHelper.get_ip_from_connect_info(%{request_header: [{"x-forwarded-for", "10.10.10.10"}]}) == {10, 10, 10, 10}
+      assert IPHelper.get_ip_from_connect_info(%{headers_in: {"x-forwarded-for", "10.10.10.11"}}) == nil
+    end
+
+    test "Phoenix.Socket transport with dead pid falls back to localhost" do
+      pid = spawn(fn -> :ok end)
+      :timer.sleep(10)
+
+      socket = %Phoenix.Socket{transport_pid: pid}
+      assert IPHelper.get_ip_from_socket(socket) == {127, 0, 0, 1}
+    end
   end
 end

--- a/copi.owasp.org/test/copi/ip_helper_test.exs
+++ b/copi.owasp.org/test/copi/ip_helper_test.exs
@@ -307,5 +307,20 @@ defmodule Copi.IPHelperTest do
       assert IPHelper.get_ip_from_connect_info(%{x_headers: "invalid_string_ip"}) == nil
       assert IPHelper.get_ip_from_connect_info(%{headers: [{"x-forwarded-for", "invalid_ip"}]}) == nil
     end
+
+    test "uses Plug.Conn remote_ip when no forwarded header and no peer_data" do
+      conn = %Plug.Conn{remote_ip: {172, 16, 0, 10}, private: %{}}
+      socket = %Phoenix.LiveView.Socket{private: %{connect_info: conn}}
+
+      assert IPHelper.get_ip_from_socket(socket) == {172, 16, 0, 10}
+    end
+
+    test "prefers first ip in forwarded list in LiveView connect_info map" do
+      socket = %Phoenix.LiveView.Socket{
+        private: %{connect_info: %{x_headers: [{"x-forwarded-for", "203.0.113.4, 10.0.0.2"}]}}
+      }
+
+      assert IPHelper.get_ip_from_socket(socket) == {203, 0, 113, 4}
+    end
   end
 end

--- a/copi.owasp.org/test/copi/release_test.exs
+++ b/copi.owasp.org/test/copi/release_test.exs
@@ -1,8 +1,20 @@
 defmodule Copi.ReleaseTest do
   use ExUnit.Case, async: false
 
-  test "release module exports migration tasks" do
-    assert function_exported?(Copi.Release, :migrate, 0)
-    assert function_exported?(Copi.Release, :rollback, 2)
+  test "migrate runs with empty repo list" do
+    old_repos = Application.get_env(:copi, :ecto_repos)
+
+    try do
+      Application.put_env(:copi, :ecto_repos, [])
+      assert [] == Copi.Release.migrate()
+    after
+      Application.put_env(:copi, :ecto_repos, old_repos || [])
+    end
+  end
+
+  test "rollback delegates to migrator for given repo" do
+    assert_raise UndefinedFunctionError, fn ->
+      Copi.Release.rollback(Copi.NoSuchRepo, 1)
+    end
   end
 end

--- a/copi.owasp.org/test/copi/release_test.exs
+++ b/copi.owasp.org/test/copi/release_test.exs
@@ -1,5 +1,6 @@
 defmodule Copi.ReleaseTest do
   use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
 
   test "migrate runs with empty repo list" do
     old_repos = Application.get_env(:copi, :ecto_repos)
@@ -16,5 +17,40 @@ defmodule Copi.ReleaseTest do
     assert_raise UndefinedFunctionError, fn ->
       Copi.Release.rollback(Copi.NoSuchRepo, 1)
     end
+  end
+
+  test "migrate executes migrator loop for configured repo" do
+    old_repos = Application.get_env(:copi, :ecto_repos)
+
+    try do
+      Application.put_env(:copi, :ecto_repos, [Copi.NoSuchRepo])
+
+      assert_raise UndefinedFunctionError, fn ->
+        Copi.Release.migrate()
+      end
+    after
+      Application.put_env(:copi, :ecto_repos, old_repos || [])
+    end
+  end
+
+  test "rollback with real repo without sandbox ownership fails in expected way" do
+    capture_log(fn ->
+      failure_mode =
+        try do
+          Copi.Release.rollback(Copi.Repo, 9_999_999_999)
+          :unexpected_success
+        rescue
+          DBConnection.OwnershipError -> :ownership_error
+        catch
+          :exit, reason ->
+            if inspect(reason) =~ "owner" and inspect(reason) =~ "exited" do
+              :owner_exited
+            else
+              reraise "Unexpected exit reason: #{inspect(reason)}", __STACKTRACE__
+            end
+        end
+
+      assert failure_mode in [:ownership_error, :owner_exited]
+    end)
   end
 end

--- a/copi.owasp.org/test/copi/release_test.exs
+++ b/copi.owasp.org/test/copi/release_test.exs
@@ -1,0 +1,8 @@
+defmodule Copi.ReleaseTest do
+  use ExUnit.Case, async: false
+
+  test "release module exports migration tasks" do
+    assert function_exported?(Copi.Release, :migrate, 0)
+    assert function_exported?(Copi.Release, :rollback, 2)
+  end
+end

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -95,4 +95,24 @@ defmodule CopiWeb.ApiControllerTest do
 
     assert json_response(conn, 404)["error"] == "Player not found in this game"
   end
+
+  test "play_card returns 404 when game does not exist", %{conn: conn, player: player, dealt_card: dealt_card} do
+    conn = put(conn, "/api/games/00000000000000000000000099/players/#{player.id}/card", %{
+      "game_id" => "00000000000000000000000099",
+      "player_id" => player.id,
+      "dealt_card_id" => to_string(dealt_card.id)
+    })
+
+    assert json_response(conn, 404)["error"] == "Could not find game"
+  end
+
+  test "play_card returns 404 when dealt card id is missing for valid player", %{conn: conn, game: game, player: player} do
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id,
+      "dealt_card_id" => "999999"
+    })
+
+    assert json_response(conn, 404)["error"] == "Could not find player and dealt card"
+  end
 end

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -46,14 +46,6 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 406)["error"] == "Card already played"
   end
 
-  test "play_card returns 404 when game not found", %{conn: conn} do
-    conn = put(conn, "/api/games/00000000000000000000000001/players/fakeplayer/card", %{
-      "dealt_card_id" => "999"
-    })
-
-    assert json_response(conn, 404)["error"] == "Could not find game"
-  end
-
   test "play_card returns 404 when dealt card not found for player", %{conn: conn, game: game} do
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: other_game.id})

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -4,7 +4,40 @@ defmodule CopiWeb.ApiControllerTest do
   alias Copi.Cornucopia
   alias Copi.Cornucopia.DealtCard
 
+  defmodule GameStub do
+    def find(id) do
+      case Application.get_env(:copi, :api_game_stub_mode, :real) do
+        :real -> Copi.Cornucopia.Game.find(id)
+        :initial_not_found -> {:error, :not_found}
+        :initial_transient -> {:error, :temporary}
+        :second_not_found ->
+          step = Application.get_env(:copi, :api_game_stub_step, 0)
+          Application.put_env(:copi, :api_game_stub_step, step + 1)
+          if step == 0, do: Copi.Cornucopia.Game.find(id), else: {:error, :not_found}
+        :second_transient ->
+          step = Application.get_env(:copi, :api_game_stub_step, 0)
+          Application.put_env(:copi, :api_game_stub_step, step + 1)
+          if step == 0, do: Copi.Cornucopia.Game.find(id), else: {:error, :temporary}
+      end
+    end
+  end
+
+  defmodule RepoStub do
+    def update(changeset) do
+      case Application.get_env(:copi, :api_repo_stub_mode, :real) do
+        :real -> Copi.Repo.update(changeset)
+        :error -> {:error, Ecto.Changeset.add_error(changeset, :played_in_round, "invalid")}
+      end
+    end
+  end
+
   setup do
+    old_game_mod = Application.get_env(:copi, :api_game_module)
+    old_repo_mod = Application.get_env(:copi, :api_repo_module)
+    old_game_mode = Application.get_env(:copi, :api_game_stub_mode)
+    old_repo_mode = Application.get_env(:copi, :api_repo_stub_mode)
+    old_step = Application.get_env(:copi, :api_game_stub_step)
+
     {:ok, game} = Cornucopia.create_game(%{name: "Test Game"})
     {:ok, player} = Cornucopia.create_player(%{name: "Test Player", game_id: game.id})
 
@@ -17,6 +50,14 @@ defmodule CopiWeb.ApiControllerTest do
     })
 
     {:ok, dealt_card} = Repo.insert(%DealtCard{player_id: player.id, card_id: card.id})
+
+    on_exit(fn ->
+      Application.put_env(:copi, :api_game_module, old_game_mod)
+      Application.put_env(:copi, :api_repo_module, old_repo_mod)
+      Application.put_env(:copi, :api_game_stub_mode, old_game_mode)
+      Application.put_env(:copi, :api_repo_stub_mode, old_repo_mode)
+      Application.put_env(:copi, :api_game_stub_step, old_step)
+    end)
 
     %{game: game, player: player, dealt_card: dealt_card}
   end
@@ -114,5 +155,65 @@ defmodule CopiWeb.ApiControllerTest do
     })
 
     assert json_response(conn, 404)["error"] == "Could not find player and dealt card"
+  end
+
+  test "play_card returns 503 when initial game lookup is transient", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    Application.put_env(:copi, :api_game_module, GameStub)
+    Application.put_env(:copi, :api_game_stub_mode, :initial_transient)
+
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id,
+      "dealt_card_id" => to_string(dealt_card.id)
+    })
+
+    assert json_response(conn, 503)["error"] == "Temporary service issue. Please retry."
+  end
+
+  test "play_card returns 404 when game disappears after update", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    Application.put_env(:copi, :api_game_module, GameStub)
+    Application.put_env(:copi, :api_repo_module, RepoStub)
+    Application.put_env(:copi, :api_game_stub_mode, :second_not_found)
+    Application.put_env(:copi, :api_repo_stub_mode, :real)
+    Application.put_env(:copi, :api_game_stub_step, 0)
+
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id,
+      "dealt_card_id" => to_string(dealt_card.id)
+    })
+
+    assert json_response(conn, 404)["error"] == "Could not find game"
+  end
+
+  test "play_card returns 503 when game reload after update is transient", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    Application.put_env(:copi, :api_game_module, GameStub)
+    Application.put_env(:copi, :api_repo_module, RepoStub)
+    Application.put_env(:copi, :api_game_stub_mode, :second_transient)
+    Application.put_env(:copi, :api_repo_stub_mode, :real)
+    Application.put_env(:copi, :api_game_stub_step, 0)
+
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id,
+      "dealt_card_id" => to_string(dealt_card.id)
+    })
+
+    assert json_response(conn, 503)["error"] == "Temporary service issue. Please retry."
+  end
+
+  test "play_card returns 422 when dealt card update fails", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    Application.put_env(:copi, :api_game_module, GameStub)
+    Application.put_env(:copi, :api_repo_module, RepoStub)
+    Application.put_env(:copi, :api_game_stub_mode, :real)
+    Application.put_env(:copi, :api_repo_stub_mode, :error)
+
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id,
+      "dealt_card_id" => to_string(dealt_card.id)
+    })
+
+    assert json_response(conn, 422)["error"] == "Could not play card"
   end
 end

--- a/copi.owasp.org/test/copi_web/controllers/health_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/health_controller_test.exs
@@ -1,8 +1,46 @@
 defmodule CopiWeb.HealthControllerTest do
   use CopiWeb.ConnCase
 
+  defmodule RepoStub do
+    def query(_sql, _params, _opts) do
+      case Application.get_env(:copi, :health_repo_stub_mode, :ok) do
+        :ok -> {:ok, :ok}
+        :raise -> raise "boom"
+        :throw -> throw(:boom)
+      end
+    end
+  end
+
+  setup do
+    old_repo_mod = Application.get_env(:copi, :health_repo_module)
+    old_mode = Application.get_env(:copi, :health_repo_stub_mode)
+
+    on_exit(fn ->
+      Application.put_env(:copi, :health_repo_module, old_repo_mod)
+      Application.put_env(:copi, :health_repo_stub_mode, old_mode)
+    end)
+
+    :ok
+  end
+
   test "GET /health returns 200 when DB is healthy", %{conn: conn} do
     conn = get(conn, "/health")
     assert response(conn, 200) =~ "healthy"
+  end
+
+  test "index returns 503 when repo query raises", %{conn: conn} do
+    Application.put_env(:copi, :health_repo_module, RepoStub)
+    Application.put_env(:copi, :health_repo_stub_mode, :raise)
+
+    conn = CopiWeb.HealthController.index(conn, %{})
+    assert response(conn, 503) =~ "not ready"
+  end
+
+  test "index returns 503 when repo query throws", %{conn: conn} do
+    Application.put_env(:copi, :health_repo_module, RepoStub)
+    Application.put_env(:copi, :health_repo_stub_mode, :throw)
+
+    conn = CopiWeb.HealthController.index(conn, %{})
+    assert response(conn, 503) =~ "not ready"
   end
 end

--- a/copi.owasp.org/test/copi_web/copi_web_test.exs
+++ b/copi.owasp.org/test/copi_web/copi_web_test.exs
@@ -1,0 +1,20 @@
+defmodule CopiWebTest do
+  use ExUnit.Case, async: true
+
+  test "static_paths returns expected defaults" do
+    paths = CopiWeb.static_paths()
+
+    assert "assets" in paths
+    assert "images" in paths
+    assert "favicon.ico" in paths
+  end
+
+  test "__using__/1 can inject controller macros" do
+    defmodule ControllerConsumer do
+      use CopiWeb, :controller
+    end
+
+    assert Code.ensure_loaded?(ControllerConsumer)
+    assert function_exported?(ControllerConsumer, :__info__, 1)
+  end
+end

--- a/copi.owasp.org/test/copi_web/live/game_live/create_game_form_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/create_game_form_test.exs
@@ -77,5 +77,17 @@ defmodule CopiWeb.GameLive.CreateGameFormTest do
       # Form should still be present (no redirect on error)
       assert has_element?(view, "#game-form")
     end
+
+    test "validate updates form when edition changes", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/games/new")
+
+      html =
+        view
+        |> form("#game-form", game: %{name: "A", edition: "mobileapp", suits: [""]})
+        |> render_change()
+
+      assert is_binary(html)
+      assert html =~ "Create the game"
+    end
   end
 end

--- a/copi.owasp.org/test/copi_web/live/game_live/game_form_helpers_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/game_form_helpers_test.exs
@@ -276,5 +276,24 @@ defmodule CopiWeb.GameLive.GameFormHelpersTest do
       assert GameFormHelpers.show_companion_suits?(%{form: %{source: %{changes: %{edition: "mobileapp"}}}})
       refute GameFormHelpers.show_companion_suits?(%{form: %{source: %{changes: %{edition: "eop"}}}})
     end
+
+    test "display_appropriate_suits_list keeps companion-only suits for host editions" do
+      suits = ["companion-Large Language Models"]
+      assert GameFormHelpers.display_appropriate_suits_list("webapp", suits) == suits
+    end
+
+    test "display_appropriate_suits_list falls back when companion-only suits used on non-host edition" do
+      result = GameFormHelpers.display_appropriate_suits_list("eop", ["companion-Large Language Models"])
+
+      assert is_list(result)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "eop-") end)
+    end
+
+    test "display_appropriate_suits_list falls back when suit has no edition prefix" do
+      result = GameFormHelpers.display_appropriate_suits_list("webapp", ["authentication"])
+
+      assert is_list(result)
+      assert Enum.any?(result, fn suit -> String.starts_with?(suit, "webapp-") end)
+    end
   end
 end

--- a/copi.owasp.org/test/copi_web/live/game_live/game_form_helpers_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/game_form_helpers_test.exs
@@ -250,4 +250,31 @@ defmodule CopiWeb.GameLive.GameFormHelpersTest do
       end)
     end
   end
+
+  describe "companion helpers" do
+    test "format_companion_suits_for_checkbox returns companion suits for supported edition" do
+      result = GameFormHelpers.format_companion_suits_for_checkbox("webapp")
+
+      assert is_list(result)
+      assert Enum.all?(result, fn {key, _label} -> String.starts_with?(key, "companion-") end)
+    end
+
+    test "format_companion_suits_for_checkbox returns empty list for unsupported edition" do
+      assert GameFormHelpers.format_companion_suits_for_checkbox("eop") == []
+    end
+
+    test "get_companion_suits_from_selected_deck returns companion suits for selected host edition" do
+      assigns = %{form: %{source: %{changes: %{edition: "mobileapp"}}}}
+      result = GameFormHelpers.get_companion_suits_from_selected_deck(assigns)
+
+      assert is_list(result)
+      assert Enum.all?(result, fn {key, _label} -> String.starts_with?(key, "companion-") end)
+    end
+
+    test "show_companion_suits? true only for host editions" do
+      assert GameFormHelpers.show_companion_suits?(%{form: %{source: %{changes: %{edition: "webapp"}}}})
+      assert GameFormHelpers.show_companion_suits?(%{form: %{source: %{changes: %{edition: "mobileapp"}}}})
+      refute GameFormHelpers.show_companion_suits?(%{form: %{source: %{changes: %{edition: "eop"}}}})
+    end
+  end
 end

--- a/copi.owasp.org/test/copi_web/live/game_live/show_pure_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_pure_test.exs
@@ -34,4 +34,12 @@ defmodule CopiWeb.GameLive.ShowPureTest do
     assert {:cont, socket} = Show.put_uri_hook(%{}, "http://localhost/games/1", socket)
     assert socket.assigns.uri == "http://localhost/games/1"
   end
+
+  test "on_mount default raises when not mounted via router live/3" do
+    socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+
+    assert_raise RuntimeError, ~r/view was not mounted at the router with the live\/3 macro/, fn ->
+      Show.on_mount(:default, %{}, %{}, socket)
+    end
+  end
 end

--- a/copi.owasp.org/test/copi_web/live/game_live/show_pure_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_pure_test.exs
@@ -27,4 +27,11 @@ defmodule CopiWeb.GameLive.ShowPureTest do
     assert Show.topic(42) == "game:42"
     assert Show.topic("abc") == "game:abc"
   end
+
+  test "put_uri_hook assigns uri and continues" do
+    socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+
+    assert {:cont, socket} = Show.put_uri_hook(%{}, "http://localhost/games/1", socket)
+    assert socket.assigns.uri == "http://localhost/games/1"
+  end
 end

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -158,11 +158,6 @@ defmodule CopiWeb.GameLive.ShowTest do
       assert render(show_live) =~ game.name
     end
 
-    test "redirects to /error when game_id is not found", %{conn: conn} do
-      assert {:error, {:redirect, %{to: "/error"}}} =
-               live(conn, "/games/00000000000000000000000001")
-    end
-
     test "handle_params uses rounds_played directly for finished game", %{conn: conn, game: game} do
       {:ok, finished_game} =
         Cornucopia.update_game(game, %{

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -183,5 +183,16 @@ defmodule CopiWeb.GameLive.ShowTest do
       :timer.sleep(50)
       assert render(show_live) =~ game.name
     end
+
+    test "redirects to /games when game does not exist", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Game not found."}}}} =
+               live(conn, "/games/00000000000000000000000099")
+    end
+
+    test "invalid round value falls back to current round and stays on page", %{conn: conn, game: game} do
+      {:ok, _view, html} = live(conn, "/games/#{game.id}?round=999")
+      assert html =~ game.name
+      assert html =~ "Invalid round value. Showing current round instead."
+    end
   end
 end

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -5,6 +5,29 @@ defmodule CopiWeb.GameLive.ShowTest do
 
   alias Copi.Cornucopia
 
+  defmodule GameStub do
+    def find(id) do
+      case Application.get_env(:copi, :game_live_show_stub_mode, :real) do
+        :real -> Copi.Cornucopia.Game.find(id)
+        :not_found -> {:error, :not_found}
+        :transient -> {:error, :temporary}
+        {:sequence, list} ->
+          case list do
+            [head | tail] ->
+              Application.put_env(:copi, :game_live_show_stub_mode, {:sequence, tail})
+              resolve(head, id)
+
+            [] ->
+              Copi.Cornucopia.Game.find(id)
+          end
+      end
+    end
+
+    defp resolve(:real, id), do: Copi.Cornucopia.Game.find(id)
+    defp resolve(:not_found, _id), do: {:error, :not_found}
+    defp resolve(:transient, _id), do: {:error, :temporary}
+  end
+
   @game_attrs %{name: "Edge Case Test Game", edition: "webapp", suits: ["hearts", "clubs"]}
 
   defp create_game(_) do
@@ -14,6 +37,18 @@ defmodule CopiWeb.GameLive.ShowTest do
 
   describe "Show - Edge Cases" do
     setup [:create_game]
+
+    setup do
+      old_game_mod = Application.get_env(:copi, :game_live_show_game_module)
+      old_mode = Application.get_env(:copi, :game_live_show_stub_mode)
+
+      on_exit(fn ->
+        Application.put_env(:copi, :game_live_show_game_module, old_game_mod)
+        Application.put_env(:copi, :game_live_show_stub_mode, old_mode)
+      end)
+
+      :ok
+    end
 
     test "prevents starting game with fewer than 3 players", %{conn: conn, game: game} do
       # Test with 0 players
@@ -61,6 +96,45 @@ defmodule CopiWeb.GameLive.ShowTest do
       # Verify game was started
       {:ok, updated_game} = Cornucopia.Game.find(game.id)
       assert updated_game.started_at != nil
+    end
+
+    test "start_game deals cards when deck has cards", %{conn: conn, game: game} do
+      {:ok, _player1} = Cornucopia.create_player(%{name: "Player 1", game_id: game.id})
+      {:ok, _player2} = Cornucopia.create_player(%{name: "Player 2", game_id: game.id})
+      {:ok, _player3} = Cornucopia.create_player(%{name: "Player 3", game_id: game.id})
+
+      for i <- 1..3 do
+        {:ok, _card} =
+          Cornucopia.create_card(%{
+            category: if(rem(i, 2) == 0, do: "clubs", else: "hearts"),
+            value: "V#{i}",
+            description: "D",
+            edition: "webapp",
+            version: "3.0",
+            external_id: "GS#{i}",
+            language: "en",
+            misc: "m",
+            owasp_scp: [],
+            owasp_devguide: [],
+            owasp_asvs: [],
+            owasp_appsensor: [],
+            capec: [],
+            safecode: [],
+            owasp_mastg: [],
+            owasp_masvs: []
+          })
+      end
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}")
+      view |> element("button", "Start Game") |> render_click()
+
+      {:ok, started_game} = Cornucopia.Game.find(game.id)
+      dealt_count =
+        started_game.players
+        |> Enum.flat_map(& &1.dealt_cards)
+        |> Enum.count()
+
+      assert dealt_count > 0
     end
 
     test "does not restart an already started game", %{conn: conn, game: game} do
@@ -196,6 +270,31 @@ defmodule CopiWeb.GameLive.ShowTest do
     test "redirects to /games when game does not exist", %{conn: conn} do
       assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Game not found."}}}} =
                live(conn, "/games/00000000000000000000000099")
+    end
+
+    test "redirects to /games on transient load when no previous game assign", %{conn: conn, game: game} do
+      Application.put_env(:copi, :game_live_show_game_module, GameStub)
+      Application.put_env(:copi, :game_live_show_stub_mode, :transient)
+
+      assert {:error, {:redirect, %{to: "/games"}}} = live(conn, "/games/#{game.id}")
+    end
+
+    test "retry flow increments counter then stops retrying", %{conn: conn, game: game} do
+      Application.put_env(:copi, :game_live_show_game_module, GameStub)
+      Application.put_env(:copi, :game_live_show_stub_mode, :real)
+
+      {:ok, show_live, _html} = live(conn, "/games/#{game.id}")
+
+      Application.put_env(:copi, :game_live_show_stub_mode, :transient)
+
+      send(show_live.pid, {:retry_game_load, %{"game_id" => game.id}})
+      :timer.sleep(50)
+      send(show_live.pid, {:retry_game_load, %{"game_id" => game.id}})
+      :timer.sleep(50)
+      send(show_live.pid, {:retry_game_load, %{"game_id" => game.id}})
+      :timer.sleep(50)
+
+      assert render(show_live) =~ "Temporary issue loading game"
     end
 
     test "invalid round value falls back to current round and stays on page", %{conn: conn, game: game} do

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -184,6 +184,15 @@ defmodule CopiWeb.GameLive.ShowTest do
       assert render(show_live) =~ game.name
     end
 
+    test "retry handle_info does not crash and keeps view active", %{conn: conn, game: game} do
+      {:ok, show_live, _html} = live(conn, "/games/#{game.id}")
+
+      send(show_live.pid, {:retry_game_load, %{"game_id" => game.id}})
+      :timer.sleep(50)
+
+      assert render(show_live) =~ game.name
+    end
+
     test "redirects to /games when game does not exist", %{conn: conn} do
       assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Game not found."}}}} =
                live(conn, "/games/00000000000000000000000099")

--- a/copi.owasp.org/test/copi_web/live/game_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live_test.exs
@@ -133,10 +133,6 @@ defmodule CopiWeb.GameLiveTest do
       assert render(show_live) =~ game.name
     end
 
-    test "redirects to error when game not found", %{conn: conn} do
-      assert {:error, {:redirect, %{to: "/error"}}} = live(conn, "/games/01ARZ3NDEKTSV4RRFFQ69G5FAV")
-    end
-
     test "displays finished game using rounds_played for current_round", %{conn: conn, game: game} do
       # Set finished_at so handle_params uses game.rounds_played (not +1) for current_round
       {:ok, game} = Cornucopia.update_game(game, %{
@@ -146,10 +142,6 @@ defmodule CopiWeb.GameLiveTest do
       })
       {:ok, _show_live, html} = live(conn, Routes.game_show_path(conn, :show, game))
       assert html =~ game.name
-    end
-
-    test "redirects to error when round parameter is invalid", %{conn: conn, game: game} do
-      assert {:error, {:redirect, %{to: "/error"}}} = live(conn, "/games/#{game.id}?round=abc")
     end
 
     test "displays past round", %{conn: conn, game: game} do
@@ -207,13 +199,6 @@ defmodule CopiWeb.GameLiveTest do
       assert html =~ "At least 3 players are required"
     end
 
-    test "redirects to error on invalid round param", %{conn: conn, game: game} do
-      {:ok, _} = Cornucopia.create_player(%{name: "P1", game_id: game.id})
-      {:ok, game} = Cornucopia.update_game(game, %{started_at: DateTime.truncate(DateTime.utc_now(), :second)})
-
-      # round=999 is way beyond current_round, should redirect to /error
-      assert {:error, {:redirect, %{to: "/error"}}} = live(conn, "/games/#{game.id}?round=999")
-    end
   end
 
   describe "Helper functions" do

--- a/copi.owasp.org/test/copi_web/live/player_live/form_component_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/form_component_test.exs
@@ -2,6 +2,8 @@ defmodule CopiWeb.PlayerLive.FormComponentTest do
   use CopiWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
   alias Copi.Cornucopia
+  alias Copi.Cornucopia.Player
+  alias CopiWeb.PlayerLive.FormComponent
   alias Copi.RateLimiter
 
   setup %{conn: conn} do
@@ -151,6 +153,28 @@ defmodule CopiWeb.PlayerLive.FormComponentTest do
       # The view should have navigated away (push_navigate to /games/:id)
       # The flash message should indicate the game has started
       assert_redirect(view, "/games/#{game.id}")
+    end
+  end
+
+  describe "direct component callbacks" do
+    test "update with nil player assigns nil form" do
+      socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+
+      assert {:ok, updated_socket} = FormComponent.update(%{player: nil, title: "x"}, socket)
+      assert updated_socket.assigns.form == nil
+    end
+
+    test "handle validate event returns socket with form", %{game: game} do
+      {:ok, player} = Cornucopia.create_player(%{name: "Val", game_id: game.id})
+
+      socket =
+        %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+        |> Phoenix.Component.assign(:player, player)
+
+      assert {:noreply, updated_socket} =
+               FormComponent.handle_event("validate", %{"player" => %{"name" => ""}}, socket)
+
+      assert updated_socket.assigns.form != nil
     end
   end
 end

--- a/copi.owasp.org/test/copi_web/live/player_live/form_component_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/form_component_test.exs
@@ -2,7 +2,6 @@ defmodule CopiWeb.PlayerLive.FormComponentTest do
   use CopiWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
   alias Copi.Cornucopia
-  alias Copi.Cornucopia.Player
   alias CopiWeb.PlayerLive.FormComponent
   alias Copi.RateLimiter
 

--- a/copi.owasp.org/test/copi_web/live/player_live/form_component_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/form_component_test.exs
@@ -152,13 +152,5 @@ defmodule CopiWeb.PlayerLive.FormComponentTest do
       # The flash message should indicate the game has started
       assert_redirect(view, "/games/#{game.id}")
     end
-
-    test "shows error when trying to join non-existent game", %{conn: conn} do
-      fake_game_id = Ecto.ULID.generate()
-
-      assert_raise Ecto.NoResultsError, fn ->
-        live(conn, "/games/#{fake_game_id}/players/new")
-      end
-    end
   end
 end

--- a/copi.owasp.org/test/copi_web/live/player_live/index_pure_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/index_pure_test.exs
@@ -1,5 +1,5 @@
 defmodule CopiWeb.PlayerLive.IndexPureTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias CopiWeb.PlayerLive.Index
 

--- a/copi.owasp.org/test/copi_web/live/player_live/index_pure_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/index_pure_test.exs
@@ -1,0 +1,44 @@
+defmodule CopiWeb.PlayerLive.IndexPureTest do
+  use ExUnit.Case, async: true
+
+  alias CopiWeb.PlayerLive.Index
+
+  defmodule GameStub do
+    def find(_id) do
+      case Application.get_env(:copi, :player_live_index_pure_mode, :not_found) do
+        :not_found -> {:error, :not_found}
+        :transient -> {:error, :temporary}
+      end
+    end
+  end
+
+  setup do
+    old_game_mod = Application.get_env(:copi, :player_live_index_game_module)
+    old_mode = Application.get_env(:copi, :player_live_index_pure_mode)
+
+    Application.put_env(:copi, :player_live_index_game_module, GameStub)
+
+    on_exit(fn ->
+      Application.put_env(:copi, :player_live_index_game_module, old_game_mod)
+      Application.put_env(:copi, :player_live_index_pure_mode, old_mode)
+    end)
+
+    :ok
+  end
+
+  test "handle_params not_found branch returns noreply" do
+    Application.put_env(:copi, :player_live_index_pure_mode, :not_found)
+
+    socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, live_action: :index, flash: %{}}}
+
+    assert {:noreply, _socket} = Index.handle_params(%{"game_id" => "missing"}, nil, socket)
+  end
+
+  test "handle_params transient true branch redirects when no game assign exists" do
+    Application.put_env(:copi, :player_live_index_pure_mode, :transient)
+
+    socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, live_action: :index, flash: %{}}}
+
+    assert {:noreply, _socket} = Index.handle_params(%{"game_id" => "any"}, nil, socket)
+  end
+end

--- a/copi.owasp.org/test/copi_web/live/player_live/index_pure_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/index_pure_test.exs
@@ -4,7 +4,9 @@ defmodule CopiWeb.PlayerLive.IndexPureTest do
   alias CopiWeb.PlayerLive.Index
 
   defmodule GameStub do
-    def find(_id) do
+    def find(id), do: find_basic(id)
+
+    def find_basic(_id) do
       case Application.get_env(:copi, :player_live_index_pure_mode, :not_found) do
         :not_found -> {:error, :not_found}
         :transient -> {:error, :temporary}

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -444,6 +444,15 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       assert render(view) =~ "Card not found. Please refresh and try again."
     end
 
+    test "shows error flash when toggling vote with invalid dealt card id format", %{conn: conn} do
+      {game1, player1, _dc1} = create_game_with_dealt_card("Auth Game Five", "AUTH_G5_C1")
+
+      {:ok, view, _html} = live(conn, "/games/#{game1.id}/players/#{player1.id}")
+      render_click(view, "toggle_vote", %{"dealt_card_id" => "invalid_card_id"})
+
+      assert render(view) =~ "Invalid card format. Please refresh and try again."
+    end
+
     test "returns 404 when player does not exist", %{conn: conn} do
       assert_error_sent 404, fn ->
         get(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -444,9 +444,10 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       assert render(view) =~ "Card not found. Please refresh and try again."
     end
 
-    test "redirects to /games when player does not exist", %{conn: conn} do
-      assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Player not found."}}}} =
-               live(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")
+    test "returns 404 when player does not exist", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")
+      end
     end
   end
 

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -331,4 +331,21 @@ defmodule CopiWeb.PlayerLive.ShowTest do
                live(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")
     end
   end
+
+  describe "handle_info game updated" do
+    test "keeps socket when player no longer exists", %{conn: conn} do
+      {game, player, dc} = create_game_with_dealt_card("HandleInfo Missing Player", "HI_MP_1")
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}/players/#{player.id}")
+
+      Copi.Repo.delete!(dc)
+      {:ok, _} = Copi.Cornucopia.delete_player(player)
+      {:ok, updated_game} = Game.find(game.id)
+
+      send(view.pid, %{topic: "game:#{game.id}", event: "game:updated", payload: updated_game})
+      :timer.sleep(50)
+
+      assert render(view) =~ game.name
+    end
+  end
 end

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -316,5 +316,19 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, refreshed_card} = DealtCard.find(dc1.id)
       assert Enum.any?(refreshed_card.votes, fn v -> v.player_id == player1.id end)
     end
+
+    test "shows not found flash when toggling vote with missing dealt card", %{conn: conn} do
+      {game1, player1, _dc1} = create_game_with_dealt_card("Auth Game Four", "AUTH_G4_C1")
+
+      {:ok, view, _html} = live(conn, "/games/#{game1.id}/players/#{player1.id}")
+      render_click(view, "toggle_vote", %{"dealt_card_id" => "999999"})
+
+      assert render(view) =~ "Card not found. Please refresh and try again."
+    end
+
+    test "redirects to /games when player does not exist", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Player not found."}}}} =
+               live(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")
+    end
   end
 end

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -7,6 +7,41 @@ defmodule CopiWeb.PlayerLive.ShowTest do
   alias Copi.Cornucopia.Game
   alias Copi.Cornucopia.DealtCard
 
+  defmodule PlayerStub do
+    def find(id) do
+      case Application.get_env(:copi, :player_live_show_player_stub_mode, :real) do
+        :real -> Copi.Cornucopia.Player.find(id)
+        :not_found -> {:error, :not_found}
+        :transient -> {:error, :temporary}
+      end
+    end
+  end
+
+  defmodule GameStub do
+    def find(id) do
+      case Application.get_env(:copi, :player_live_show_game_stub_mode, :real) do
+        :real -> Copi.Cornucopia.Game.find(id)
+        :not_found -> {:error, :not_found}
+        :transient -> {:error, :temporary}
+      end
+    end
+  end
+
+  defmodule DealtCardStub do
+    def find(id) do
+      case Application.get_env(:copi, :player_live_show_dealt_card_stub_mode, :real) do
+        :real -> Copi.Cornucopia.DealtCard.find(id)
+        :not_found -> {:error, :not_found}
+        :transient -> {:error, :temporary}
+        :vote_conflict ->
+          case Copi.Cornucopia.DealtCard.find(id) do
+            {:ok, dealt_card} -> {:ok, %{dealt_card | votes: []}}
+            other -> other
+          end
+      end
+    end
+  end
+
   @game_attrs %{name: "show test game"}
 
   defp create_player(_) do
@@ -36,6 +71,26 @@ defmodule CopiWeb.PlayerLive.ShowTest do
 
   describe "Show - additional coverage" do
     setup [:create_player]
+
+    setup do
+      old_player_mod = Application.get_env(:copi, :player_live_show_player_module)
+      old_game_mod = Application.get_env(:copi, :player_live_show_game_module)
+      old_dealt_mod = Application.get_env(:copi, :player_live_show_dealt_card_module)
+      old_player_mode = Application.get_env(:copi, :player_live_show_player_stub_mode)
+      old_game_mode = Application.get_env(:copi, :player_live_show_game_stub_mode)
+      old_dealt_mode = Application.get_env(:copi, :player_live_show_dealt_card_stub_mode)
+
+      on_exit(fn ->
+        Application.put_env(:copi, :player_live_show_player_module, old_player_mod)
+        Application.put_env(:copi, :player_live_show_game_module, old_game_mod)
+        Application.put_env(:copi, :player_live_show_dealt_card_module, old_dealt_mod)
+        Application.put_env(:copi, :player_live_show_player_stub_mode, old_player_mode)
+        Application.put_env(:copi, :player_live_show_game_stub_mode, old_game_mode)
+        Application.put_env(:copi, :player_live_show_dealt_card_stub_mode, old_dealt_mode)
+      end)
+
+      :ok
+    end
 
     test "handle_info :proceed_to_next_round advances rounds_played", %{conn: conn, player: player} do
       game_id = player.game_id
@@ -291,6 +346,69 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, updated_dealt2} = Copi.Cornucopia.DealtCard.find(to_string(dealt.id))
       assert length(updated_dealt2.votes) == 0
     end
+
+    test "redirects when game lookup for valid player returns not_found", %{conn: conn, player: player} do
+      Application.put_env(:copi, :player_live_show_player_module, PlayerStub)
+      Application.put_env(:copi, :player_live_show_game_module, GameStub)
+      Application.put_env(:copi, :player_live_show_player_stub_mode, :real)
+      Application.put_env(:copi, :player_live_show_game_stub_mode, :not_found)
+
+      assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Game not found."}}}} =
+               live(conn, "/games/#{player.game_id}/players/#{player.id}")
+    end
+
+    test "redirects on transient player load when no existing assigns", %{conn: conn, player: player} do
+      Application.put_env(:copi, :player_live_show_player_module, PlayerStub)
+      Application.put_env(:copi, :player_live_show_player_stub_mode, :transient)
+
+      assert {:error, {:redirect, %{to: "/games"}}} =
+               live(conn, "/games/#{player.game_id}/players/#{player.id}")
+    end
+
+    test "toggle_vote shows temporary issue when dealt card lookup transient", %{conn: conn} do
+      {game, player, dealt} = create_game_with_dealt_card("Transient DC", "TDC_1")
+
+      Application.put_env(:copi, :player_live_show_dealt_card_module, DealtCardStub)
+      Application.put_env(:copi, :player_live_show_dealt_card_stub_mode, :transient)
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}/players/#{player.id}")
+      render_click(view, "toggle_vote", %{"dealt_card_id" => to_string(dealt.id)})
+
+      assert render(view) =~ "Temporary issue loading card. Please try again."
+    end
+
+    test "retry load with existing assigns shows retry flash then stable failure flash", %{conn: conn} do
+      {game, player, _dealt} = create_game_with_dealt_card("Retry Player Show Branch", "RPS_1")
+
+      Application.put_env(:copi, :player_live_show_player_module, PlayerStub)
+      Application.put_env(:copi, :player_live_show_player_stub_mode, :real)
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}/players/#{player.id}")
+
+      Application.put_env(:copi, :player_live_show_player_stub_mode, :transient)
+      send(view.pid, {:retry_player_show_load, player.id})
+      :timer.sleep(50)
+      send(view.pid, {:retry_player_show_load, player.id})
+      :timer.sleep(50)
+      send(view.pid, {:retry_player_show_load, player.id})
+      :timer.sleep(50)
+
+      assert render(view) =~ "Temporary issue loading player/game"
+    end
+
+    test "toggle_vote hits insert error branch when vote conflicts", %{conn: conn} do
+      {game, player, dealt} = create_game_with_dealt_card("Vote Conflict", "VC_1")
+
+      Copi.Repo.insert!(%Copi.Cornucopia.Vote{player_id: player.id, dealt_card_id: dealt.id})
+
+      Application.put_env(:copi, :player_live_show_dealt_card_module, DealtCardStub)
+      Application.put_env(:copi, :player_live_show_dealt_card_stub_mode, :vote_conflict)
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}/players/#{player.id}")
+      render_click(view, "toggle_vote", %{"dealt_card_id" => to_string(dealt.id)})
+
+      assert render(view) =~ game.name
+    end
   end
 
   describe "toggle_vote authorization" do
@@ -343,6 +461,16 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       {:ok, updated_game} = Game.find(game.id)
 
       send(view.pid, %{topic: "game:#{game.id}", event: "game:updated", payload: updated_game})
+      :timer.sleep(50)
+
+      assert render(view) =~ game.name
+    end
+
+    test "retry player show load message does not crash", %{conn: conn} do
+      {game, player, _dc} = create_game_with_dealt_card("Retry Player Show", "HI_RETRY_1")
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}/players/#{player.id}")
+      send(view.pid, {:retry_player_show_load, player.id})
       :timer.sleep(50)
 
       assert render(view) =~ game.name

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -37,11 +37,6 @@ defmodule CopiWeb.PlayerLive.ShowTest do
   describe "Show - additional coverage" do
     setup [:create_player]
 
-    test "handle_params redirects to /error for nonexistent player_id", %{conn: conn, player: _player} do
-      assert {:error, {:redirect, %{to: "/error"}}} =
-               live(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")
-    end
-
     test "handle_info :proceed_to_next_round advances rounds_played", %{conn: conn, player: player} do
       game_id = player.game_id
       {:ok, game} = Cornucopia.Game.find(game_id)

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -449,6 +449,24 @@ defmodule CopiWeb.PlayerLive.ShowTest do
         get(conn, "/games/00000000000000000000000001/players/00000000000000000000000002")
       end
     end
+
+    test "returns 400 when player id is malformed", %{conn: conn} do
+      assert_error_sent 400, fn ->
+        get(conn, "/games/00000000000000000000000001/players/invalid_ulid")
+      end
+    end
+
+    test "returns 400 when player id is too short", %{conn: conn} do
+      assert_error_sent 400, fn ->
+        get(conn, "/games/00000000000000000000000001/players/short")
+      end
+    end
+
+    test "returns 400 when player id has invalid characters", %{conn: conn} do
+      assert_error_sent 400, fn ->
+        get(conn, "/games/00000000000000000000000001/players/invalid!@#$%^&*()1234567890")
+      end
+    end
   end
 
   describe "handle_info game updated" do

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -251,11 +251,6 @@ defmodule CopiWeb.PlayerLiveTest do
       assert updated_game.rounds_played >= 0
     end
 
-    test "redirects to error when player not found", %{conn: conn} do
-      assert {:error, {:redirect, %{to: "/error"}}} =
-               live(conn, "/games/01ARZ3NDEKTSV4RRFFQ69G5FAV/players/01ARZ3NDEKTSV4RRFFQ69G5FAV")
-    end
-
     test "next_round when round is closed advances rounds and sets finished_at", %{conn: conn, player: player} do
       game_id = player.game_id
       {:ok, game} = Cornucopia.Game.find(game_id)

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -7,6 +7,29 @@ defmodule CopiWeb.PlayerLiveTest do
   alias Copi.Cornucopia
   alias Copi.RateLimiter
 
+  defmodule IndexGameStub do
+    def find(id) do
+      case Application.get_env(:copi, :player_live_index_stub_mode, :real) do
+        :real -> Copi.Cornucopia.Game.find(id)
+        :not_found -> {:error, :not_found}
+        :transient -> {:error, :temporary}
+        {:sequence, list} ->
+          case list do
+            [head | tail] ->
+              Application.put_env(:copi, :player_live_index_stub_mode, {:sequence, tail})
+              resolve(head, id)
+
+            [] ->
+              Copi.Cornucopia.Game.find(id)
+          end
+      end
+    end
+
+    defp resolve(:real, id), do: Copi.Cornucopia.Game.find(id)
+    defp resolve(:not_found, _id), do: {:error, :not_found}
+    defp resolve(:transient, _id), do: {:error, :temporary}
+  end
+
   @game_attrs %{name: "some name"}
   # @create_attrs %{name: "some name", game_id: ""}
   # @update_attrs %{name: "some updated name"}
@@ -17,6 +40,15 @@ defmodule CopiWeb.PlayerLiveTest do
     RateLimiter.clear_ip({127, 0, 0, 1})
     # Set up IP address for rate limiting tests
     conn = Plug.Conn.put_private(conn, :connect_info, %{peer_data: %{address: {127, 0, 0, 1}}})
+
+    old_game_mod = Application.get_env(:copi, :player_live_index_game_module)
+    old_mode = Application.get_env(:copi, :player_live_index_stub_mode)
+
+    on_exit(fn ->
+      Application.put_env(:copi, :player_live_index_game_module, old_game_mod)
+      Application.put_env(:copi, :player_live_index_stub_mode, old_mode)
+    end)
+
     {:ok, conn: conn}
   end
 
@@ -156,6 +188,31 @@ defmodule CopiWeb.PlayerLiveTest do
       :timer.sleep(50)
 
       assert is_binary(render(view))
+    end
+
+    test "mount redirects on transient game load failure", %{conn: conn, player: player} do
+      Application.put_env(:copi, :player_live_index_game_module, IndexGameStub)
+      Application.put_env(:copi, :player_live_index_stub_mode, :transient)
+
+      assert {:error, {:redirect, %{to: "/games"}}} = live(conn, "/games/#{player.game_id}/players")
+    end
+
+    test "retry transitions from retrying to please try again state", %{conn: conn, player: player} do
+      Application.put_env(:copi, :player_live_index_game_module, IndexGameStub)
+      Application.put_env(:copi, :player_live_index_stub_mode, :real)
+
+      {:ok, view, _html} = live(conn, "/games/#{player.game_id}/players/new")
+
+      Application.put_env(:copi, :player_live_index_stub_mode, :transient)
+
+      send(view.pid, {:retry_player_index_load, %{"game_id" => player.game_id}})
+      :timer.sleep(50)
+      send(view.pid, {:retry_player_index_load, %{"game_id" => player.game_id}})
+      :timer.sleep(50)
+      send(view.pid, {:retry_player_index_load, %{"game_id" => player.game_id}})
+      :timer.sleep(50)
+
+      assert render(view) =~ "Temporary issue loading game"
     end
   end
 

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -8,9 +8,11 @@ defmodule CopiWeb.PlayerLiveTest do
   alias Copi.RateLimiter
 
   defmodule IndexGameStub do
-    def find(id) do
+    def find(id), do: find_basic(id)
+
+    def find_basic(id) do
       case Application.get_env(:copi, :player_live_index_stub_mode, :real) do
-        :real -> Copi.Cornucopia.Game.find(id)
+        :real -> Copi.Cornucopia.Game.find_basic(id)
         :not_found -> {:error, :not_found}
         :transient -> {:error, :temporary}
         {:sequence, list} ->
@@ -20,12 +22,12 @@ defmodule CopiWeb.PlayerLiveTest do
               resolve(head, id)
 
             [] ->
-              Copi.Cornucopia.Game.find(id)
+              Copi.Cornucopia.Game.find_basic(id)
           end
       end
     end
 
-    defp resolve(:real, id), do: Copi.Cornucopia.Game.find(id)
+    defp resolve(:real, id), do: Copi.Cornucopia.Game.find_basic(id)
     defp resolve(:not_found, _id), do: {:error, :not_found}
     defp resolve(:transient, _id), do: {:error, :temporary}
   end

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -128,6 +128,35 @@ defmodule CopiWeb.PlayerLiveTest do
       # Verify the rate limiter actually blocked the request
       assert {:error, :rate_limit_exceeded} = RateLimiter.check_rate(test_ip, :player_creation)
     end
+
+    test "redirects when game does not exist", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/games", flash: %{"error" => "Game not found."}}}} =
+               live(conn, "/games/00000000000000000000000099/players")
+    end
+
+    test "new player route redirects when game is started", %{conn: conn, player: player} do
+      {:ok, _started_game} =
+        Cornucopia.update_game(
+          Cornucopia.get_game!(player.game_id),
+          %{started_at: DateTime.truncate(DateTime.utc_now(), :second)}
+        )
+
+      assert {:error, {:redirect, %{to: "/games"}}} = live(conn, "/games/#{player.game_id}/players/new")
+    end
+
+    test "edit player route renders edit page title", %{conn: conn, player: player} do
+      {:ok, _view, html} = live(conn, "/games/#{player.game_id}/players/#{player.id}/edit")
+      assert html =~ "Edit Player"
+    end
+
+    test "retry message is handled without crashing", %{conn: conn, player: player} do
+      {:ok, view, _html} = live(conn, "/games/#{player.game_id}/players")
+
+      send(view.pid, {:retry_player_index_load, %{"game_id" => player.game_id}})
+      :timer.sleep(50)
+
+      assert is_binary(render(view))
+    end
   end
 
   describe "Show" do

--- a/copi.owasp.org/test/copi_web/resilience_test.exs
+++ b/copi.owasp.org/test/copi_web/resilience_test.exs
@@ -1,5 +1,5 @@
 defmodule CopiWeb.ResilienceTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias CopiWeb.Resilience
 

--- a/copi.owasp.org/test/copi_web/resilience_test.exs
+++ b/copi.owasp.org/test/copi_web/resilience_test.exs
@@ -1,0 +1,38 @@
+defmodule CopiWeb.ResilienceTest do
+  use ExUnit.Case, async: true
+
+  alias CopiWeb.Resilience
+
+  test "returns configured resilience values" do
+    old = Application.get_env(:copi, :resilience)
+
+    Application.put_env(:copi, :resilience,
+      retry_delay_ms: 321,
+      max_game_load_retries: 7,
+      max_player_load_retries: 5
+    )
+
+    assert Resilience.retry_delay_ms() == 321
+    assert Resilience.max_game_load_retries() == 7
+    assert Resilience.max_player_load_retries() == 5
+
+    if old do
+      Application.put_env(:copi, :resilience, old)
+    else
+      Application.delete_env(:copi, :resilience)
+    end
+  end
+
+  test "falls back to defaults when config is missing" do
+    old = Application.get_env(:copi, :resilience)
+    Application.delete_env(:copi, :resilience)
+
+    assert Resilience.retry_delay_ms() == 750
+    assert Resilience.max_game_load_retries() == 2
+    assert Resilience.max_player_load_retries() == 2
+
+    if old do
+      Application.put_env(:copi, :resilience, old)
+    end
+  end
+end


### PR DESCRIPTION


### Description

- Making copi.owasp.org more stable by adding retry logic when there are glitches.
- Also adding a see result button when the game finishes.
- Adding error handling for 400 Bad Request.
- Adding ULID validation and logging instead of propagating errors if there are temporary issues.

<img width="947" height="358" alt="game summary" src="https://github.com/user-attachments/assets/c162e365-fab0-411b-bbea-17b259bf70c8" />

Created with ai. Here is the chat:

[conversation-transcript.txt](https://github.com/user-attachments/files/28116109/conversation-transcript.txt)

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
