### PR TITLE
fix: prevent sponsors link from being clipped on mobile navbar

### DIFF
--- a/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
+++ b/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
@@ -4,17 +4,17 @@
       <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
         <div class="border-b border-gray-700">
           <div class="flex h-16 items-center justify-between px-4 sm:px-0">
-            <div class="flex items-center">
-              <div class="block">
-                <div class="flex items-baseline flex-wrap gap-1 sm:gap-3">
+            <div class="flex items-center w-full">
+              <div class="block w-full">
+                <div class="flex items-baseline flex-wrap justify-between gap-y-1 sm:gap-3 w-full">
                   <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
-                  <a href="/" class="bg-gray-900 text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
-                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
-                  <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
-                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
-                  <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
-                  <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
-                  <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>
+                  <a href="/" class="bg-gray-900 text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
+                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
+                  <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
+                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
+                  <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
+                  <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
+                  <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>
                 </div>
               </div>
             </div>

--- a/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
+++ b/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
@@ -4,21 +4,21 @@
       <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
         <div class="border-b border-gray-700">
           <div class="flex h-16 items-center justify-between px-4 sm:px-0">
-            <div class="flex items-center w-full">
-              <div class="block w-full">
-                <div class="flex items-baseline flex-wrap justify-between gap-y-1 sm:gap-3 w-full">
+            <div class="flex items-center">
+              <div class="block">
+                <div class="flex items-baseline whitespace-nowrap gap-1 sm:gap-3">
                   <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
-                  <a href="/" class="bg-gray-900 text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
-                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
-                  <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
-                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
-                  <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
-                  <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
-                  <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-0.5 text-[9px] sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>
+                  <a href="/" class="bg-gray-900 text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
+                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
+                  <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
+                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
+                  <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
+                  <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
+                  <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>
                 </div>
               </div>
             </div>
-            <div class="hidden sm:block">
+            <div class="hidden min-[730px]:block">
               <div class="ml-4 flex items-center md:ml-6">
                 <!-- Copi Link -->
                 <div class="relative">

--- a/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
+++ b/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
@@ -6,7 +6,7 @@
           <div class="flex h-16 items-center justify-between px-4 sm:px-0">
             <div class="flex items-center">
               <div class="block">
-                <div class="flex items-baseline whitespace-nowrap gap-1 sm:gap-3">
+                <div class="flex items-baseline flex-wrap gap-1 sm:gap-3">
                   <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
                   <a href="/" class="bg-gray-900 text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
                   <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>

--- a/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
+++ b/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
@@ -8,13 +8,13 @@
               <div class="block">
                 <div class="flex items-baseline flex-wrap gap-1 sm:gap-3">
                   <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
-                  <a href="/" class="bg-gray-900 text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
-                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
-                  <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
-                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
-                  <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
-                  <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
-                  <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>
+                  <a href="/" class="bg-gray-900 text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
+                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
+                  <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
+                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
+                  <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
+                  <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
+                  <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-1 py-1 text-[10px] sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>
                 </div>
               </div>
             </div>

--- a/copi.owasp.org/lib/copi_web/controllers/page_html/home.html.heex
+++ b/copi.owasp.org/lib/copi_web/controllers/page_html/home.html.heex
@@ -117,7 +117,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="hidden sm:block">
+                <div class="hidden min-[730px]:block">
                   <div class="ml-4 flex items-center md:ml-6">
                     <!-- Copi Link -->
                     <div class="relative">


### PR DESCRIPTION
## Description

 fixed issue: #3085 

On mobile, the navbar clips the "Sponsors" link due to whitespace-nowrap on the flex container.

### Solution

- Replaced whitespace-nowrap with flex-wrap on the links container div in app.html.heex.
- Reduced nav link font size and padding further to fit all links in a single line on 360px screens (Samsung S8)
- Stretched the nav container to full width so links spread evenly across the navbar on all mobile viewports

### Change

- copi.owasp.org/lib/copi_web/components/layouts/app.html.heex 

### screenshot
<img width="259" height="398" alt="image" src="https://github.com/user-attachments/assets/b12bb34c-dd20-4e9d-b7d1-a9a9418c78ea" />


### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
