### PR TITLE
fix: shorten nav labels to fit Sponsors link on mobile

### DIFF
--- a/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
+++ b/copi.owasp.org/lib/copi_web/components/layouts/app.html.heex
@@ -9,9 +9,9 @@
                 <div class="flex items-baseline whitespace-nowrap gap-1 sm:gap-3">
                   <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
                   <a href="/" class="bg-gray-900 text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium" aria-current="page">Home</a>
-                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Start A Game</a>
+                  <a href="/games/new" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Play</a>
                   <%!-- <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Join A Game</a> --%>
-                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Game Cards</a>
+                  <a href="/cards" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Cards</a>
                   <a href="/resources" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Resources</a>
                   <a href="/privacy" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Privacy</a>
                   <a href="/sponsors" class="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-2 py-1 text-xs sm:px-3 sm:py-2 sm:text-sm font-medium">Sponsors</a>

--- a/copi.owasp.org/test/copi_web/live/game_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live_test.exs
@@ -45,7 +45,7 @@ defmodule CopiWeb.GameLiveTest do
 
       {:ok, games_new, html_games_new} = live(new_conn, "/games/new")
 
-      assert html_games_new =~ "Start A Game"
+      assert html_games_new =~ "Play"
 
       assert games_new
              |> form("#game-form", game: @invalid_attrs)


### PR DESCRIPTION
Fixes #3103

## Changes
- Renamed "Start A Game" to "Play"
- Renamed "Game Cards" to "Cards"

This ensures all nav items including Sponsors are visible on mobile view without reducing font size and looking nicer.

## File changed
- copi.owasp.org/lib/copi_web/components/layouts/app.html.heex

## Screenshots
<img width="266" height="386" alt="image" src="https://github.com/user-attachments/assets/af36712b-d934-45d8-bef8-9090651de56d" />


### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines

## Additional info 
This idea to change "Start A Game" to "Play" and "Game Cards" to "Cards" was given by @sydseter because i was reducing the font size in one pr to get sponsors visible but this was reducing too much font size so @sydseter  suggested me this approach and now everything is clearly visible on mobile view , Thanks sydseter for this idea.