### PR TITLE
Fix/vote count display 3104

### DIFF
--- a/copi.owasp.org/lib/copi_web/components/core_components/table_components.ex
+++ b/copi.owasp.org/lib/copi_web/components/core_components/table_components.ex
@@ -46,7 +46,7 @@ defmodule CopiWeb.CoreComponents.TableComponents do
     <%= if @player_card != nil do %>
     <div class="my-2 flex flex-row justify-start items-center">
         <.icon name="hero-hand-thumb-up" class="h-8 w-8" />
-        <p class="badge ml-4"><%= Enum.count(@player_card.votes) %> / <%= Enum.count(@game.players) - 1 %></p>
+        <p class="badge ml-4"><%= Enum.count(@player_card.votes) %> / <%= Enum.count(@game.players) %></p>
     </div>
     <% end %>
     """

--- a/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.html.heex
@@ -128,7 +128,7 @@
                   <div phx-click="toggle_vote" phx-value-dealt_card_id={player_card.id}  class="cursor-pointer my-2 flex flex-row justify-start items-center" class={["vote"] ++ [(if get_vote(player_card, @player), do: "voted")]}>
                   <.icon name="hero-hand-thumb-up" class="h-8 w-8" />
                   
-                  <p class="badge ml-4"><%= Enum.count(player_card.votes) %> / <%= Enum.count(@game.players) - 1 %></p>
+                  <p class="badge ml-4"><%= Enum.count(player_card.votes) %> / <%= Enum.count(@game.players) %></p>
                 </div>
               <% end %>
               <% end %>


### PR DESCRIPTION
### Description

Fixes #3104

- Vote thumbs was showing one less than the actual player count with 4 players it showed 0/3 instead of 0/4.
- Turned out there were two spots doing this, not one. Fixed the thumbs up for other players' cards, and also the one used for your own card (different component, same -1 mistake).

### Testing
Tested with 4 players locally, checked the thumb badge in every player's tab including the one who played the card.

### Screenshots

<img width="272" height="366" alt="image" src="https://github.com/user-attachments/assets/fa0b40cf-773c-4be9-a788-947c5e00ac17" />
and 
<img width="280" height="374" alt="image" src="https://github.com/user-attachments/assets/e69fc1da-65a8-45b4-b85b-c8a24482b18b" />

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
