### PR TITLE
feat: add JSON-LD structured data to homepage and fix CSP nonce hook …

### DIFF
--- a/cornucopia.owasp.org/src/hooks.server.js
+++ b/cornucopia.owasp.org/src/hooks.server.js
@@ -19,7 +19,7 @@ export const handle = async ({ event, resolve }) => {
 
   // Add html `lang` attribute
   const response = await resolve({ ...event, locals: { lang: userLocale, translation: translations.get()[userLocale], fallbackTranslation: translations.get()[defaultLocale] } }, {
-    transformPageChunk: ({ html }) => html.replace(/<html.*>/, `<html lang="${userLocale}">`).replaceAll(/<script[^>]*>/gi, `<script nonce="DhcnhD3khTMePgXw">`),
+    transformPageChunk: ({ html }) => html.replace(/<html.*>/, `<html lang="${userLocale}">`).replaceAll(/<script([^>]*)>/gi, `<script nonce="DhcnhD3khTMePgXw"$1>`),
   });
 
   const securityHeaders = {

--- a/cornucopia.owasp.org/src/routes/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/+page.svelte
@@ -20,6 +20,7 @@
         return langSuits || data.suits.get('webapp-en') as Suit[];
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let structuredData = $derived(JSON.stringify({
         "@context": "https://schema.org",
         "@graph": [
@@ -38,7 +39,6 @@
             }
         ]
     }).replace(/</g, '\\u003c'));
-    let jsonLdScript = $derived(`<script type="application/ld+json">${structuredData}</scr` + `ipt>`);
 </script>
 <svelte:head>
     	<title>{$t('layout.title')}</title>
@@ -49,8 +49,7 @@
         <meta property="og:description" content="{$t('layout.description')}">
         <meta name="twitter:title" content="{$t('layout.title')}">
         <meta name="twitter:description" content="{$t('layout.description')}">
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-        {@html jsonLdScript}
+        <script type="application/ld+json">{@html structuredData}</script>
 </svelte:head>
 
 <Hero cards={data.cards} {suits} mapping={data.mappingData.get('webapp')}></Hero>

--- a/cornucopia.owasp.org/src/routes/+page.svelte
+++ b/cornucopia.owasp.org/src/routes/+page.svelte
@@ -19,6 +19,26 @@
         const langSuits = data.suits.get(`webapp-${$lang}`);
         return langSuits || data.suits.get('webapp-en') as Suit[];
     });
+
+    let structuredData = $derived(JSON.stringify({
+        "@context": "https://schema.org",
+        "@graph": [
+            {
+                "@type": "Organization",
+                "name": "OWASP Cornucopia",
+                "url": "https://cornucopia.owasp.org",
+                "logo": "https://cornucopia.owasp.org/images/cornucopia_logo_in_devs_we_trust.svg",
+                "sameAs": ["https://github.com/OWASP/cornucopia"]
+            },
+            {
+                "@type": "WebSite",
+                "name": $t('layout.title'),
+                "url": "https://cornucopia.owasp.org",
+                "description": $t('layout.description')
+            }
+        ]
+    }).replace(/</g, '\\u003c'));
+    let jsonLdScript = $derived(`<script type="application/ld+json">${structuredData}</scr` + `ipt>`);
 </script>
 <svelte:head>
     	<title>{$t('layout.title')}</title>
@@ -29,6 +49,8 @@
         <meta property="og:description" content="{$t('layout.description')}">
         <meta name="twitter:title" content="{$t('layout.title')}">
         <meta name="twitter:description" content="{$t('layout.description')}">
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html jsonLdScript}
 </svelte:head>
 
 <Hero cards={data.cards} {suits} mapping={data.mappingData.get('webapp')}></Hero>


### PR DESCRIPTION
## Description

Fixes #2194

- Added Organization + WebSite JSON-LD structured data to the homepage 
for SEO. Validated on schema.org and no errors were there

- While testing I noticed the CSP nonce hook in hooks.server.js was wiping all attributes from every script tag sitewide, not just injecting the nonce. The JSON-LD tag needs type="application/ld+json" to work, so I fixed the regex to preserve existing attributes.

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
