### PR TITLE
fix: correct Links folder name for mobileapp output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@
               mkdir -p output/cornucopia_mobileapp || echo "Ignore error"
               mkdir -p output/cornucopia_mobileapp/Links || echo "Ignore error"
               mkdir -p output/cornucopia_mobileapp/Fonts || echo "Ignore error"
-              cp -rf ./resources/templates/Links/cornucopia_webapp output/cornucopia_mobileapp/Links/
+              cp -rf ./resources/templates/Links/cornucopia_mobileapp output/cornucopia_mobileapp/Links/
               cp -rf ./resources/templates/Fonts/NotoSans/* output/cornucopia_mobileapp/Fonts/
               # Building Cornucopia Companion Edition
               mkdir -p output/cornucopia_companion || echo "Ignore error"

--- a/.github/workflows/run-tests-generate-output.yaml
+++ b/.github/workflows/run-tests-generate-output.yaml
@@ -108,7 +108,7 @@ jobs:
           mkdir -p output/cornucopia_mobileapp || echo "Ignore error"
           mkdir -p output/cornucopia_mobileapp/Links || echo "Ignore error"
           mkdir -p output/cornucopia_mobileapp/Fonts || echo "Ignore error"
-          cp -rf ./resources/templates/Links/cornucopia_webapp output/cornucopia_mobileapp/Links/
+          cp -rf ./resources/templates/Links/cornucopia_mobileapp output/cornucopia_mobileapp/Links/
           cp -rf ./resources/templates/Fonts/NotoSans/* output/cornucopia_mobileapp/Fonts/
            # Building Cornucopia Companion Edition
           mkdir -p output/cornucopia_companion || echo "Ignore error"


### PR DESCRIPTION
### Description

Fixes #3109

- The cp command in run-tests-generate-output.yaml was copying `Links/cornucopia_webapp` into the mobileapp output folder insteadof `Links/cornucopia_mobileapp`.

- InDesign falls back to looking for card back images in a Links subfolder relative to the IDML file. With the wrong folder name there, that resolution fails.

Actually, pre-release.yml already had the correct path. IDML templateswere not modified.

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
