### PR TITLE
Fix issue with player getting thrown out of the game

### DIFF
--- a/copi.owasp.org/assets/js/app.js
+++ b/copi.owasp.org/assets/js/app.js
@@ -28,11 +28,24 @@ Hooks.DragDrop = {
   mounted() {
     const drake = dragula([document.querySelector('#hand'), document.querySelector('#table')], {
       invalid: function (el, handle) {
-        // Don't allow dragging cards off the table
-        return el.className === 'card-player' || document.querySelector('#round-played');
+        // Only allow dragging actual hand cards while a round is active.
+        const roundPlayed = document.querySelector('#round-played');
+        const isPlayerZone = el.classList && el.classList.contains('card-player');
+        const hasRequiredDataset = !!(el.dataset && el.dataset.game && el.dataset.player && el.dataset.dealtcard);
+
+        return !!roundPlayed || isPlayerZone || !hasRequiredDataset;
       },
       accepts: function (el, target, source, sibling) {
         console.log('accepts called', {target: target?.id, source: source?.id});
+
+        // Only hand cards can be dropped on the table.
+        if (!source || source.id !== 'hand') {
+          return false;
+        }
+
+        if (!el.dataset || !el.dataset.game || !el.dataset.player || !el.dataset.dealtcard) {
+          return false;
+        }
         
         // Only allow dropping on table
         if (target && target.id === 'table') {
@@ -64,6 +77,20 @@ Hooks.DragDrop = {
       console.log('Drop event', {target: target?.id});
       
       if (target && target.id === 'table') {
+        const gameId = element?.dataset?.game;
+        const playerId = element?.dataset?.player;
+        const dealtCardId = element?.dataset?.dealtcard;
+
+        if (!gameId || !playerId || !dealtCardId) {
+          console.error('Blocked invalid card play request due to missing identifiers', {
+            gameId,
+            playerId,
+            dealtCardId
+          });
+          drake.cancel(true);
+          return;
+        }
+
         fetch('/api/games/' + element.dataset.game + '/players/' + element.dataset.player + '/card', {
           method: 'PUT',
           headers: {
@@ -74,9 +101,13 @@ Hooks.DragDrop = {
           })
         }).then(response => {
           console.log('API response:', response.ok);
+          if (!response.ok) {
+            drake.cancel(true);
+          }
           return response.ok;
         }).catch(err => {
           console.error('API error:', err);
+          drake.cancel(true);
         });
       }
     });

--- a/copi.owasp.org/assets/js/app.js
+++ b/copi.owasp.org/assets/js/app.js
@@ -36,13 +36,12 @@ Hooks.DragDrop = {
 
     const drake = dragula([document.querySelector('#hand'), document.querySelector('#table')], {
       invalid: function (el, handle) {
-        // Only allow dragging actual hand cards while a round is active.
-        const roundPlayed = document.querySelector('#round-played');
+        // Only allow dragging actual hand cards (with required data attributes) from non-player zones.
         const isPlayerZone = el.classList && el.classList.contains('card-player');
         const draggableCard = getCardElement(handle) || getCardElement(el) || el;
         const hasRequiredDataset = !!(draggableCard.dataset && draggableCard.dataset.game && draggableCard.dataset.player && draggableCard.dataset.dealtcard);
 
-        return !!roundPlayed || isPlayerZone || !hasRequiredDataset;
+        return isPlayerZone || !hasRequiredDataset;
       },
       accepts: function (el, target, source, sibling) {
         console.log('accepts called', {target: target?.id, source: source?.id});

--- a/copi.owasp.org/assets/js/app.js
+++ b/copi.owasp.org/assets/js/app.js
@@ -101,13 +101,15 @@ Hooks.DragDrop = {
           })
         }).then(response => {
           console.log('API response:', response.ok);
-          if (!response.ok) {
-            drake.cancel(true);
+          if (!response.ok && source) {
+            source.appendChild(element);
           }
           return response.ok;
         }).catch(err => {
           console.error('API error:', err);
-          drake.cancel(true);
+          if (source) {
+            source.appendChild(element);
+          }
         });
       }
     });

--- a/copi.owasp.org/assets/js/app.js
+++ b/copi.owasp.org/assets/js/app.js
@@ -26,24 +26,34 @@ import dragula from "../vendor/dragula"
 let Hooks = {}
 Hooks.DragDrop = {
   mounted() {
+    const getCardElement = (node) => {
+      if (!node || typeof node.closest !== 'function') {
+        return null;
+      }
+
+      return node.closest('[data-game][data-player][data-dealtcard]');
+    };
+
     const drake = dragula([document.querySelector('#hand'), document.querySelector('#table')], {
       invalid: function (el, handle) {
         // Only allow dragging actual hand cards while a round is active.
         const roundPlayed = document.querySelector('#round-played');
         const isPlayerZone = el.classList && el.classList.contains('card-player');
-        const hasRequiredDataset = !!(el.dataset && el.dataset.game && el.dataset.player && el.dataset.dealtcard);
+        const draggableCard = getCardElement(handle) || getCardElement(el) || el;
+        const hasRequiredDataset = !!(draggableCard.dataset && draggableCard.dataset.game && draggableCard.dataset.player && draggableCard.dataset.dealtcard);
 
         return !!roundPlayed || isPlayerZone || !hasRequiredDataset;
       },
       accepts: function (el, target, source, sibling) {
         console.log('accepts called', {target: target?.id, source: source?.id});
+        const draggableCard = getCardElement(el) || el;
 
         // Only hand cards can be dropped on the table.
         if (!source || source.id !== 'hand') {
           return false;
         }
 
-        if (!el.dataset || !el.dataset.game || !el.dataset.player || !el.dataset.dealtcard) {
+        if (!draggableCard.dataset || !draggableCard.dataset.game || !draggableCard.dataset.player || !draggableCard.dataset.dealtcard) {
           return false;
         }
         
@@ -77,9 +87,10 @@ Hooks.DragDrop = {
       console.log('Drop event', {target: target?.id});
       
       if (target && target.id === 'table') {
-        const gameId = element?.dataset?.game;
-        const playerId = element?.dataset?.player;
-        const dealtCardId = element?.dataset?.dealtcard;
+        const draggableCard = getCardElement(element) || element;
+        const gameId = draggableCard?.dataset?.game;
+        const playerId = draggableCard?.dataset?.player;
+        const dealtCardId = draggableCard?.dataset?.dealtcard;
 
         if (!gameId || !playerId || !dealtCardId) {
           console.error('Blocked invalid card play request due to missing identifiers', {
@@ -91,13 +102,13 @@ Hooks.DragDrop = {
           return;
         }
 
-        fetch('/api/games/' + element.dataset.game + '/players/' + element.dataset.player + '/card', {
+        fetch('/api/games/' + gameId + '/players/' + playerId + '/card', {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({
-            dealt_card_id: element.dataset.dealtcard
+            dealt_card_id: dealtCardId
           })
         }).then(response => {
           console.log('API response:', response.ok);

--- a/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
@@ -68,6 +68,24 @@ defmodule CopiWeb.ApiController do
     end
   end
 
+  def play_card(conn, %{"game_id" => game_id, "player_id" => player_id}) do
+    Logger.warning(
+      "Missing dealt_card_id for play_card request: game_id=#{inspect(game_id)}, player_id=#{inspect(player_id)}"
+    )
+
+    conn
+    |> put_status(:bad_request)
+    |> json(%{"error" => "Missing required parameter: dealt_card_id"})
+  end
+
+  def play_card(conn, params) do
+    Logger.warning("Invalid play_card request params: #{inspect(params)}")
+
+    conn
+    |> put_status(:bad_request)
+    |> json(%{"error" => "Invalid request parameters"})
+  end
+
   def topic(game_id) do
     "game:#{game_id}"
   end

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -157,6 +157,15 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 404)["error"] == "Could not find player and dealt card"
   end
 
+  test "play_card returns 400 when dealt_card_id parameter is missing", %{conn: conn, game: game, player: player} do
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id
+    })
+
+    assert json_response(conn, 400)["error"] == "Missing required parameter: dealt_card_id"
+  end
+
   test "play_card returns 503 when initial game lookup is transient", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
     Application.put_env(:copi, :api_game_module, GameStub)
     Application.put_env(:copi, :api_game_stub_mode, :initial_transient)


### PR DESCRIPTION
### Description

These changes fix the “players get kicked out / stuck after game start” issue by preventing bad card-play requests and handling them safely when they still happen.

- Frontend fix in [app.js](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html): only real hand cards can be dragged/dropped, and requests are blocked if game/player/card IDs are missing. This stops calls like PUT /api/games/undefined/players/undefined/card.
- Frontend recovery in [app.js](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html): if the API call fails, the drag is canceled so the UI doesn’t drift into a broken state.
- API hardening in [api_controller.ex](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html): missing or invalid params now return explicit 400 JSON errors instead of ambiguous behavior.

Net effect: fewer broken turns, clearer errors, and players are much less likely to feel like their session vanished.

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Github CoPilor`
    - LLMs and versions: `GPT-5.5`
    - Prompts: `Some players have reported that they get thrown out of the game after the game is started. I am getting the following logs:

The call: PUT /api/games/undefined/players/undefined/card

seems to indicate that something has gone wrong for the player, but what?

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
