### PR TITLE
fix: switch rate limiter to Fly-Client-IP for fly deployments (closes…

### DIFF
--- a/copi.owasp.org/lib/copi/ip_helper.ex
+++ b/copi.owasp.org/lib/copi/ip_helper.ex
@@ -100,18 +100,27 @@ defmodule Copi.IPHelper do
   # Private helpers
 
   defp get_forwarded_ip(conn) do
-    # Get X-Forwarded-For header (rightmost IP is most recent proxy, leftmost is original client)
-    case Plug.Conn.get_req_header(conn, "x-forwarded-for") do
-      [] -> nil
-      [forwarded | _] ->
-        # Take the first (leftmost) IP from the comma-separated list
-        forwarded
-        |> String.split(",")
-        |> List.first()
-        |> String.trim()
-        |> parse_ip_string()
-      _ -> nil
+    if fly_client_ip_enabled?() do
+      case Plug.Conn.get_req_header(conn, "fly-client-ip") do
+        [ip | _] -> parse_ip_string(String.trim(ip))
+        [] -> nil
+      end
+    else
+      case Plug.Conn.get_req_header(conn, "x-forwarded-for") do
+        [] -> nil
+        [forwarded | _] ->
+          forwarded
+          |> String.split(",")
+          |> List.first()
+          |> String.trim()
+          |> parse_ip_string()
+        _ -> nil
+      end
     end
+  end
+
+  defp fly_client_ip_enabled? do
+    System.get_env("USE_FLY_CLIENT_IP", "false") |> String.downcase() == "true"
   end
 
   defp parse_ip_string(ip_string) do
@@ -184,10 +193,15 @@ defmodule Copi.IPHelper do
         end
 
       map when is_map(map) ->
-        # connect_info may be a map for some sockets. Try to extract
-        # X-Forwarded-For from common locations, then peer_data.
         forwarded =
           cond do
+            fly_client_ip_enabled?() ->
+              headers = Map.get(map, :x_headers, [])
+              Enum.find_value(headers, fn
+                {"fly-client-ip", v} -> parse_ip_string(String.trim(v))
+                _ -> nil
+              end)
+
             headers = Map.get(map, :req_headers) -> get_forwarded_from_req_headers(headers)
             xh = Map.get(map, :x_headers) -> get_forwarded_from_x_headers(xh)
             true -> nil
@@ -245,32 +259,26 @@ defmodule Copi.IPHelper do
   end
 
   defp extract_first_ip_from_headers(value) do
+    target_header = if fly_client_ip_enabled?(), do: "fly-client-ip", else: "x-forwarded-for"
+
     cond do
       is_list(value) ->
-        # list of {k,v} tuples or list of strings
         Enum.find_value(value, fn
           {k, v} when is_binary(k) ->
-            case String.downcase(k) do
-              "x-forwarded-for" -> extract_first_ip(v)
-              _ -> nil
-            end
+            if String.downcase(k) == target_header, do: extract_first_ip(v), else: nil
           {k, v} when is_atom(k) ->
-            case Atom.to_string(k) |> String.downcase() do
-              "x-forwarded-for" -> extract_first_ip(v)
-              _ -> nil
-            end
+            if Atom.to_string(k) |> String.downcase() == target_header, do: extract_first_ip(v), else: nil
           v when is_binary(v) -> extract_first_ip(v)
           _ -> nil
         end)
 
       is_map(value) ->
-        case Map.get(value, "x-forwarded-for") || Map.get(value, :"x-forwarded-for") do
+        case Map.get(value, target_header) || Map.get(value, String.to_atom(target_header)) do
           nil -> nil
           v -> extract_first_ip(v)
         end
 
       is_binary(value) -> extract_first_ip(value)
-
       true -> nil
     end
   end

--- a/copi.owasp.org/lib/copi_web/endpoint.ex
+++ b/copi.owasp.org/lib/copi_web/endpoint.ex
@@ -13,12 +13,12 @@ defmodule CopiWeb.Endpoint do
   ]
 
   socket "/socket", CopiWeb.UserSocket,
-    websocket: [timeout: 45_000, connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for"]]],
-    longpoll: [connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for"]]]
+    websocket: [timeout: 45_000, connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for", "fly-client-ip"]]],
+    longpoll: [connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for", "fly-client-ip"]]]
 
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [timeout: 45_000, connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for"]]],
-    longpoll: [connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for"]]]
+    websocket: [timeout: 45_000, connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for", "fly-client-ip"]]],
+    longpoll: [connect_info: [:peer_data, session: @session_options, x_headers: ["x-forwarded-for", "fly-client-ip"]]]
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/copi.owasp.org/lib/copi_web/plugs/rate_limiter_plug.ex
+++ b/copi.owasp.org/lib/copi_web/plugs/rate_limiter_plug.ex
@@ -9,34 +9,37 @@ defmodule CopiWeb.Plugs.RateLimiterPlug do
   def call(conn, _opts) do
     case IPHelper.get_ip_source(conn) do
       {:forwarded, ip} ->
-        # Only enforce connection rate limits when we have a forwarded
-        # client IP (left-most value from X-Forwarded-For). This avoids
-        # rate-limiting on internal/transport addresses injected by the
-        # reverse proxy or adapter.
-        case RateLimiter.check_rate(ip, :connection) do
-          {:ok, _remaining} ->
-            # Persist the chosen client IP into the session so LiveView
-            # receives it on websocket connect (connect_info.session).
-            put_session(conn, "client_ip", IPHelper.ip_to_string(ip))
+        check_and_limit(conn, ip)
 
-          {:error, :rate_limit_exceeded} ->
-            Logger.warning("HTTP connection rate limit exceeded for IP: #{inspect(ip)}")
-            conn
-            |> put_resp_content_type("text/plain")
-            |> send_resp(429, "Too many connections, try again later.")
-            |> halt()
+      {:remote, ip} ->
+        if fly_mode?() do
+          check_and_limit(conn, ip)
+        else
+          Logger.debug("Skipping connection rate limiting: only transport IP available")
+          conn
         end
 
-      {:remote, _ip} ->
-        # We only have a transport (remote) IP; skip connection rate limiting
-        # to avoid false positives caused by proxies or adapter internals.
-        Logger.debug("Skipping connection rate limiting: only transport IP available")
-        conn
-
       {:none, _} ->
-        # No IP information available; be permissive and continue.
         Logger.debug("No IP information available for connection; skipping rate limiting")
         conn
     end
+  end
+
+  defp check_and_limit(conn, ip) do
+    case RateLimiter.check_rate(ip, :connection) do
+      {:ok, _remaining} ->
+        put_session(conn, "client_ip", IPHelper.ip_to_string(ip))
+
+      {:error, :rate_limit_exceeded} ->
+        Logger.warning("HTTP connection rate limit exceeded for IP: #{inspect(ip)}")
+        conn
+        |> put_resp_content_type("text/plain")
+        |> send_resp(429, "Too many connections, try again later.")
+        |> halt()
+    end
+  end
+
+  defp fly_mode? do
+    System.get_env("USE_FLY_CLIENT_IP", "false") |> String.downcase() == "true"
   end
 end

--- a/copi.owasp.org/test/copi/ip_helper_test.exs
+++ b/copi.owasp.org/test/copi/ip_helper_test.exs
@@ -346,4 +346,44 @@ defmodule Copi.IPHelperTest do
       assert IPHelper.get_ip_from_socket(socket) == {127, 0, 0, 1}
     end
   end
+
+  describe "fly-client-ip header support" do
+    setup do
+      System.put_env("USE_FLY_CLIENT_IP", "true")
+      on_exit(fn -> System.delete_env("USE_FLY_CLIENT_IP") end)
+      conn = %Plug.Conn{}
+      {:ok, conn: conn}
+    end
+
+    test "extracts IP from fly-client-ip header when fly mode enabled", %{conn: conn} do
+      conn = Plug.Conn.put_req_header(conn, "fly-client-ip", "10.1.2.3")
+      assert IPHelper.get_ip_from_conn(conn) == {10, 1, 2, 3}
+    end
+
+    test "get_ip_source returns forwarded when fly-client-ip present", %{conn: conn} do
+      conn = Plug.Conn.put_req_header(conn, "fly-client-ip", "10.1.2.3")
+      assert IPHelper.get_ip_source(conn) == {:forwarded, {10, 1, 2, 3}}
+    end
+
+    test "falls back to remote_ip when fly-client-ip missing", %{conn: conn} do
+      conn = %{conn | remote_ip: {10, 0, 0, 1}}
+      assert IPHelper.get_ip_from_conn(conn) == {10, 0, 0, 1}
+    end
+
+    test "extracts fly-client-ip from socket x_headers when fly mode enabled" do
+      socket = %Phoenix.LiveView.Socket{
+        private: %{
+          connect_info: %{
+            x_headers: [{"fly-client-ip", "10.2.3.4"}]
+          }
+        }
+      }
+      assert IPHelper.get_ip_from_socket(socket) == {10, 2, 3, 4}
+    end
+
+    test "get_ip_from_connect_info extracts fly-client-ip from x_headers" do
+      info = %{x_headers: [{"fly-client-ip", "10.3.4.5"}]}
+      assert IPHelper.get_ip_from_connect_info(info) == {10, 3, 4, 5}
+    end
+  end
 end

--- a/copi.owasp.org/test/copi_web/plugs/rate_limiter_plug_test.exs
+++ b/copi.owasp.org/test/copi_web/plugs/rate_limiter_plug_test.exs
@@ -82,6 +82,22 @@ defmodule CopiWeb.Plugs.RateLimiterPlugTest do
     refute conn.halted
   end
 
+  test "rate limits remote IP when fly mode is enabled" do
+    System.put_env("USE_FLY_CLIENT_IP", "true")
+    ip = {10, 0, 0, 1}
+    RateLimiter.clear_ip(ip)
+
+    conn =
+      conn(:get, "/")
+      |> Map.put(:remote_ip, ip)
+      |> init_test_session(%{})
+      |> RateLimiterPlug.call([])
+
+    assert conn.status != 429
+    refute conn.halted
+    System.delete_env("USE_FLY_CLIENT_IP")
+  end
+
   test "init/1 returns opts unchanged" do
     assert RateLimiterPlug.init([]) == []
     assert RateLimiterPlug.init(key: :value) == [key: :value]


### PR DESCRIPTION
closes #3227

### Description

- Fly.io doesn't strip X-Forwarded-For headers so attackers can spoof them and bypass the rate limiter. switched to Fly-Client-IP which Fly sets itself and can't be spoofed.

- configurable via USE_FLY_CLIENT_IP=true, defaults to X-Forwarded-For so nothing breaks on non-Fly setups.

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
