### PR TITLE
Prevent self-voting server-side in toggle_vote handler

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -177,7 +177,7 @@ defmodule CopiWeb.PlayerLive.Show do
           |> Enum.flat_map(fn p -> p.dealt_cards end)
           |> Enum.map(fn dc -> dc.id end)
 
-        if dealt_card.id in game_card_ids do
+        if dealt_card.id in game_card_ids and dealt_card.player_id != player.id do
           vote = get_vote(dealt_card, player)
 
           if vote do

--- a/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live/show_test.exs
@@ -316,6 +316,7 @@ defmodule CopiWeb.PlayerLive.ShowTest do
       game_id = player.game_id
       {:ok, game} = Cornucopia.Game.find(game_id)
 
+      {:ok, other_player} = Cornucopia.create_player(%{name: "Other Player", game_id: game_id})
       Copi.Repo.update!(
         Ecto.Changeset.change(game, started_at: DateTime.truncate(DateTime.utc_now(), :second))
       )
@@ -329,9 +330,8 @@ defmodule CopiWeb.PlayerLive.ShowTest do
         })
 
       dealt = Copi.Repo.insert!(%Copi.Cornucopia.DealtCard{
-        player_id: player.id, card_id: card.id, played_in_round: 1
+        player_id: other_player.id, card_id: card.id, played_in_round: 1
       })
-
       {:ok, show_live, _html} = live(conn, "/games/#{game_id}/players/#{player.id}")
 
       render_click(show_live, "toggle_vote", %{"dealt_card_id" => to_string(dealt.id)})
@@ -426,12 +426,22 @@ defmodule CopiWeb.PlayerLive.ShowTest do
     end
 
     test "allows a player to vote on a card belonging to their own game", %{conn: conn} do
-      {game1, player1, dc1} = create_game_with_dealt_card("Auth Game Three", "AUTH_G3_C1")
+      {game1, player1, _dc1} = create_game_with_dealt_card("Auth Game Three", "AUTH_G3_C1")
+      {:ok, card2} = Cornucopia.create_card(%{
+        category: "C", value: "AUTH_G3_C2", description: "D", edition: "webapp",
+        version: "3.0", external_id: "AUTH_G3_C2", language: "en", misc: "m",
+        owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
+        capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
+      })
+      {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: game1.id})
+      dc2 = Copi.Repo.insert!(%Copi.Cornucopia.DealtCard{
+        player_id: other_player.id, card_id: card2.id, played_in_round: 1
+      })
 
       {:ok, view, _html} = live(conn, "/games/#{game1.id}/players/#{player1.id}")
-      render_click(view, "toggle_vote", %{"dealt_card_id" => to_string(dc1.id)})
+      render_click(view, "toggle_vote", %{"dealt_card_id" => to_string(dc2.id)})
 
-      {:ok, refreshed_card} = DealtCard.find(dc1.id)
+      {:ok, refreshed_card} = DealtCard.find(dc2.id)
       assert Enum.any?(refreshed_card.votes, fn v -> v.player_id == player1.id end)
     end
 

--- a/copi.owasp.org/test/copi_web/live/player_live_test.exs
+++ b/copi.owasp.org/test/copi_web/live/player_live_test.exs
@@ -389,6 +389,22 @@ defmodule CopiWeb.PlayerLiveTest do
       show_live |> element("[phx-click=\"toggle_vote\"][phx-value-dealt_card_id=\"#{dealt.id}\"]") |> render_click()
       refute Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: dealt.id, player_id: player.id)
     end
+
+    test "prevents self-voting on own dealt card", %{conn: conn, player: player} do
+      game_id = player.game_id
+      {:ok, game} = Cornucopia.Game.find(game_id)
+      Copi.Repo.update!(Ecto.Changeset.change(game, started_at: DateTime.truncate(DateTime.utc_now(), :second)))
+      {:ok, card} = Cornucopia.create_card(%{
+        category: "C", value: "V", description: "D", edition: "webapp",
+        version: "3.0", external_id: "EXT2", language: "en",
+        misc: "misc", owasp_scp: [], owasp_devguide: [], owasp_asvs: [],
+        owasp_appsensor: [], capec: [], safecode: [], owasp_mastg: [], owasp_masvs: []
+      })
+      {:ok, dealt} = Copi.Repo.insert(%Copi.Cornucopia.DealtCard{player_id: player.id, card_id: card.id, played_in_round: 1})
+      {:ok, show_live, _html} = live(conn, "/games/#{game_id}/players/#{player.id}")
+      render_click(show_live, "toggle_vote", %{"dealt_card_id" => "#{dealt.id}"})
+      refute Copi.Repo.get_by(Copi.Cornucopia.Vote, dealt_card_id: dealt.id, player_id: player.id)
+    end
   end
 
   describe "Helper functions" do
@@ -474,5 +490,6 @@ defmodule CopiWeb.PlayerLiveTest do
       assert Show.get_vote(dealt_card, player).id == 99
       assert is_nil(Show.get_vote(%{votes: []}, player))
     end
+
   end
 end


### PR DESCRIPTION
Fixes #2561

### Description

- The frontend already hides the vote button for your own card, but nothing on the server actually enforced it. Anyone could open the browser console and fire the toggle_vote event directly with their own card's id and it would go through.
- Added a single check in handle_toggle_vote if the card belongs to the current player, it gets rejected the same way an out-of-game card would.
- Test bypasses the UI and sends the event directly to cover the actual attack vector, then checks no vote was created.

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
