### PR TITLE
upgrade node version to 26 in all workflow files

### DIFF
--- a/.github/workflows/build-website-staging.yml
+++ b/.github/workflows/build-website-staging.yml
@@ -35,7 +35,7 @@
           - name: Install Node.js
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
-              node-version: 20.18.2
+              node-version: '26'
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -37,7 +37,7 @@
           - name: Install Node.js
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
-              node-version: '22.12'
+              node-version: '26'
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/copi-build.yml
+++ b/.github/workflows/copi-build.yml
@@ -67,7 +67,7 @@
         - name: Set up Node.js
           uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
           with:
-            node-version: '22.12'
+            node-version: '26'
             cache: 'npm'
             cache-dependency-path: copi.owasp.org/assets/package-lock.json
         - name: Run frontend tests with coverage

--- a/.github/workflows/deploy-website-production.yml
+++ b/.github/workflows/deploy-website-production.yml
@@ -35,7 +35,7 @@
           - name: Install Node.js
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
-              node-version: 20.18.2
+              node-version: '26'
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/deploy-website-staging.yml
+++ b/.github/workflows/deploy-website-staging.yml
@@ -42,7 +42,7 @@
           - name: Install Node.js
             uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
             with:
-              node-version: 20.18.2
+              node-version: '26'
           - name: Build
             working-directory: cornucopia.owasp.org
             run: |

--- a/.github/workflows/sbom-generate.yml
+++ b/.github/workflows/sbom-generate.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: '20'
+          node-version: '26'
 
       - name: Install cdxgen
         run: npm install -g @cyclonedx/cdxgen


### PR DESCRIPTION
### Description

Fixes #3244

Updated node-version to '26' in all six workflow files that use actions/setup-node. Versions were inconsistent across files (20, 22.12, 20.18.2)I am standardizing everything to node version 26.

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
