### PR TITLE
fix(scripts): return None from get_docx_document on missing template

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -11,7 +11,7 @@ import yaml
 import zipfile
 import xml.etree.ElementTree as ElTree
 from defusedxml import ElementTree as DefusedElTree
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 from operator import itemgetter
 from itertools import groupby
 from pathlib import Path
@@ -381,9 +381,12 @@ def create_edition_from_template(
         if file_extension == ".docx":
             # Get the input (template) document
             doc = get_docx_document(template_doc)
-            if doc:
+            if doc is not None:
                 doc = replace_docx_inline_text(doc, language_dict)
                 doc.save(output_file)
+            else:
+                logging.error("Cannot create output file: template document not found at %s", template_doc)
+                return
         else:
             save_odt_file(template_doc, language_dict, output_file)
 
@@ -653,16 +656,15 @@ def get_document_paragraphs(doc: Any) -> List[Any]:
     return paragraphs
 
 
-def get_docx_document(docx_file: str) -> Any:
-    """Open the file and return the docx document."""
-    import docx  # type: ignore
+def get_docx_document(docx_file: str) -> Optional[Any]:
+    """Open the file and return the docx document, or None if the file is not found."""
+    import docx  # type: ignore[import-untyped]
 
     if os.path.isfile(docx_file):
         return docx.Document(docx_file)
     else:
         logging.error("Could not find file at: %s", str(docx_file))
-        # Create a blank document if it fails
-        return docx.Document()
+        return None
 
 
 def get_files_from_of_type(path: str, ext: str) -> List[str]:

--- a/tests/scripts/convert_utest.py
+++ b/tests/scripts/convert_utest.py
@@ -1250,16 +1250,12 @@ class TestGetDocxDocument(unittest.TestCase):
         file = os.path.join(
             c.convert_vars.BASE_PATH, "tests", "test_files", "owasp_cornucopia_webapp_ver_guide_bridge_lang.d"
         )
-        want_type = type(docx.Document())
-        want_len_paragraphs = 0
         want_logging_error_message = [f"ERROR:root:Could not find file at: {file}"]
 
         with self.assertLogs(logging.getLogger(), logging.ERROR) as ll:
             got_file = c.get_docx_document(file)
         self.assertEqual(ll.output, want_logging_error_message)
-        self.assertIsInstance(got_file, want_type)
-        got_len_paragraphs = len(got_file.paragraphs)
-        self.assertEqual(want_len_paragraphs, got_len_paragraphs)
+        self.assertIsNone(got_file)
 
 
 class TestGetReplacementDict(unittest.TestCase):
@@ -2439,6 +2435,42 @@ class TestConvertUncovered(unittest.TestCase):
 
         c.create_edition_from_template("cards")
         self.assertTrue(mock_doc.save.called)
+
+    @patch("scripts.convert.convert_vars.args", new=type("obj", (), {"pdf": False}))
+    @patch("scripts.convert.ensure_folder_exists")
+    @patch("scripts.convert.replace_docx_inline_text")
+    @patch("scripts.convert.get_docx_document")
+    @patch("scripts.convert.rename_output_file", return_value="/tmp/out.docx")
+    @patch("scripts.convert.get_template_for_edition", return_value="template.docx")
+    @patch("scripts.convert.get_meta_data", return_value={"key": "val"})
+    @patch("scripts.convert.map_language_data_to_template", return_value={})
+    @patch("scripts.convert.get_language_data", return_value={})
+    @patch("scripts.convert.get_mapping_for_edition", return_value={})
+    @patch("scripts.convert.get_files_from_of_type", return_value=["file.yaml"])
+    def test_create_edition_from_template_docx_none_doc_returns_early(
+        self,
+        mock_files,
+        mock_map,
+        mock_lang,
+        mock_map2,
+        mock_meta,
+        mock_template,
+        mock_rename,
+        mock_get_doc,
+        mock_replace,
+        mock_ensure,
+    ):
+        # get_docx_document returns None when the template file is missing.
+        mock_get_doc.return_value = None
+        want_logging_error_message = [
+            "ERROR:root:Cannot create output file: template document not found at template.docx"
+        ]
+
+        with self.assertLogs(logging.getLogger(), logging.ERROR) as ll:
+            c.create_edition_from_template("cards")
+
+        self.assertEqual(ll.output, want_logging_error_message)
+        mock_replace.assert_not_called()
 
     # ---------- main ----------
 


### PR DESCRIPTION
Resolves #2490

## Summary
`get_docx_document()` was returning a blank `docx.Document()` object when the template file could not be found. Because a blank `docx.Document()` is always truthy in Python, the caller's `if doc:` check in `create_edition_from_template()` always passed — so a missing template silently produced an empty, corrupt `.docx` output file instead of failing with a clear error.

## Fix
- `get_docx_document()` now returns `None` instead of a blank document  when the file is missing. Return type updated from `Any` to  `Optional[Any]` to reflect this.
- `create_edition_from_template()` now checks `if doc is not None:`  instead of `if doc:`, and adds an `else` branch that logs a clear error (`Cannot create output file: template document not found at %s`) and returns early — so no empty file gets written.

## Scope
Only `scripts/convert.py` and `tests/scripts/convert_utest.py` are touched. No unrelated files, formatting, or refactors are included.

## Testing
Ran locally before opening this PR:
- `pytest tests/scripts/convert_utest.py` — 149/149 pass on Linux
- `mypy --namespace-packages --strict ./scripts/` — clean
- `flake8 --max-line-length=120 --max-complexity=10` — clean
- `black --check` — clean

One note: on Windows, `test_get_template_abs_path` fails locally due to path-separator handling unrelated to this change (fails identically on `master` without this PR applied) — flagging it here for visibility, happy to open a separate issue for it if useful.

---
This is my first PR to Cornucopia — feedback very welcome, and happy to adjust anything that doesn't fit the project's conventions.