### PR TITLE
fix(cornucopia.owasp.org): enforce pnpm usage and prevent npm installs

### DIFF
--- a/cornucopia.owasp.org/package.json
+++ b/cornucopia.owasp.org/package.json
@@ -2,7 +2,9 @@
 	"name": "cornucopia-website",
 	"version": "0.0.1",
 	"private": true,
+	"packageManager": "pnpm@10.0.0",
 	"scripts": {
+		"preinstall": "npx only-allow pnpm",
 		"dev": "vite dev",
 		"prebuild": "echo I run before the build script",
 		"productionbuild": "vite build && node ./script/headers.js && npx svelte-sitemap --domain https://cornucopia.owasp.org --ignore 404 --ignore cards/COM* --ignore cards/DVE* --ignore cards/AC* --ignore cards/CO*",


### PR DESCRIPTION
Resolves #2623

## Summary
The project uses pnpm for dependency management, but nothing prevented contributors from accidentally running `npm install`, which creates a conflicting `package-lock.json` alongside the existing `pnpm-lock.yaml` and can produce inconsistent dependency trees between contributors.

## Changes
Scoped to `cornucopia.owasp.org/` only:
- Added `"packageManager": "pnpm@<version>"` to `package.json`
- Added a `preinstall` script using `only-allow pnpm` to block npm/yarn installs
- Updated README references from `npm install`/`npm run` to the `pnpm` equivalents

## Testing
- `npm install` inside `cornucopia.owasp.org/` now fails as expected via the preinstall guard
- `pnpm install` still works normally

## Notes
A prior PR (#2624) attempted this fix but was closed for inactivity before two small requested changes were addressed (an unrelated `.pre-commit-config.yaml` version bump, and a duplicate README headline). This PR keeps strictly to the three changes above and avoids both of those.