### PR TITLE
fix: mirror finished_at check in handle_info for requested_round

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/game_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/show.ex
@@ -75,10 +75,15 @@ defmodule CopiWeb.GameLive.Show do
   def handle_info(%{topic: message_topic, event: "game:updated", payload: updated_game}, socket) do
     cond do
       topic(updated_game.id) == message_topic ->
+        current_round = if updated_game.finished_at do
+          updated_game.rounds_played
+        else
+          updated_game.rounds_played + 1
+        end
         {:noreply,
          socket
          |> assign_game(updated_game)
-         |> assign(:requested_round, updated_game.rounds_played + 1)}
+         |> assign(:requested_round, current_round)}
 
       true ->
         {:noreply, socket}

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -175,6 +175,27 @@ defmodule CopiWeb.GameLive.ShowTest do
       assert render(show_live) =~ game.name
     end
 
+    test "handle_info sets requested_round to rounds_played for finished game", %{conn: conn, game: game} do
+      {:ok, finished_game} =
+        Cornucopia.update_game(game, %{
+          started_at: DateTime.truncate(DateTime.utc_now(), :second),
+          finished_at: DateTime.truncate(DateTime.utc_now(), :second),
+          rounds_played: 3
+        })
+
+      {:ok, finished_game_loaded} = Cornucopia.Game.find(finished_game.id)
+      {:ok, show_live, _html} = live(conn, "/games/#{finished_game_loaded.id}")
+
+      send(show_live.pid, %{
+        topic: "game:#{finished_game_loaded.id}",
+        event: "game:updated",
+        payload: finished_game_loaded
+      })
+
+      :timer.sleep(50)
+      refute render(show_live) =~ "Round 4:"
+    end
+
     test "display_game_session/1 returns correct label for each edition", %{conn: _conn, game: _game} do
       alias CopiWeb.GameLive.Show
       assert Show.display_game_session("webapp")    == "Cornucopia Web Session:"


### PR DESCRIPTION
### Description
When a game finishes, the summary page breaks if any game:updated broadcast arrives.This happens because handle_info always adds +1 to rounds_played, even for finished games, pointing to a round that does not exist.

## Fix
Added the same finished_at check that handle_params already uses, so handle_info now uses rounds_played directly for finished games instead of rounds_played + 1.

## Changes
- copi.owasp.org/lib/copi_web/live/game_live/show.ex
- copi.owasp.org/test/copi_web/live/game_live/show_test.exs

fixed issue: #2548 

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
