### PR TITLE
fix(copi): add game lifecycle guard to play_card API endpoint

### DIFF
--- a/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
+++ b/copi.owasp.org/lib/copi_web/controllers/api_controller.ex
@@ -103,52 +103,61 @@ defmodule CopiWeb.ApiController do
 
     case game_mod.find(game_id) do
       {:ok, game} ->
-        player = Enum.find(game.players, fn player -> player.id == player_id end)
+        cond do
+          is_nil(game.started_at) ->
+            conn |> put_status(:unprocessable_entity) |> json(%{"error" => "Game has not started yet"})
 
-        if player do
-          dealt_card = Enum.find(player.dealt_cards, fn dealt_card -> Integer.to_string(dealt_card.id) == dealt_card_id end)
+          not is_nil(game.finished_at) ->
+            conn |> put_status(:unprocessable_entity) |> json(%{"error" => "Game has already ended"})
 
-          if dealt_card do
-            current_round = game.rounds_played + 1
+          true ->
+            player = Enum.find(game.players, fn player -> player.id == player_id end)
 
-            cond do
-              dealt_card.played_in_round ->
-                conn |> put_status(:not_acceptable) |> json(%{"error" => "Card already played"})
+            if player do
+              dealt_card = Enum.find(player.dealt_cards, fn dealt_card -> Integer.to_string(dealt_card.id) == dealt_card_id end)
 
-              Enum.find(player.dealt_cards, fn dealt_card -> dealt_card.played_in_round == current_round end) ->
-                conn |> put_status(:forbidden) |> json(%{"error" => "Player already played a card in this round"})
+              if dealt_card do
+                current_round = game.rounds_played + 1
 
-              true ->
-                dealt_card_changeset = Ecto.Changeset.change(dealt_card, played_in_round: current_round)
+                cond do
+                  dealt_card.played_in_round ->
+                    conn |> put_status(:not_acceptable) |> json(%{"error" => "Card already played"})
 
-                case repo_mod.update(dealt_card_changeset) do
-                  {:ok, updated_dealt_card} ->
-                    case game_mod.find(game.id) do
-                      {:ok, updated_game} ->
-                        CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
-                        conn |> json(%{"id" => updated_dealt_card.id})
+                  Enum.find(player.dealt_cards, fn dealt_card -> dealt_card.played_in_round == current_round end) ->
+                    conn |> put_status(:forbidden) |> json(%{"error" => "Player already played a card in this round"})
 
-                      {:error, :not_found} ->
-                        Logger.warning("Game disappeared after card update: #{inspect(game.id)}")
-                        conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
+                  true ->
+                    dealt_card_changeset = Ecto.Changeset.change(dealt_card, played_in_round: current_round)
 
-                      {:error, reason} ->
-                        Logger.warning("Transient game reload failure after card update for game_id=#{inspect(game.id)}, reason=#{inspect(reason)}")
-                        conn |> put_status(:service_unavailable) |> json(%{"error" => "Temporary service issue. Please retry."})
+                    case repo_mod.update(dealt_card_changeset) do
+                      {:ok, updated_dealt_card} ->
+                        case game_mod.find(game.id) do
+                          {:ok, updated_game} ->
+                            CopiWeb.Endpoint.broadcast(topic(game.id), "game:updated", updated_game)
+                            conn |> json(%{"id" => updated_dealt_card.id})
+
+                          {:error, :not_found} ->
+                            Logger.warning("Game disappeared after card update: #{inspect(game.id)}")
+                            conn |> put_status(:not_found) |> json(%{"error" => "Could not find game"})
+
+                          {:error, reason} ->
+                            Logger.warning("Transient game reload failure after card update for game_id=#{inspect(game.id)}, reason=#{inspect(reason)}")
+                            conn |> put_status(:service_unavailable) |> json(%{"error" => "Temporary service issue. Please retry."})
+                        end
+
+                      {:error, changeset} ->
+                        Logger.warning("Card update failed for dealt_card_id=#{inspect(dealt_card.id)}, player_id=#{inspect(player_id)}, game_id=#{inspect(game_id)}, errors=#{inspect(changeset.errors)}")
+                        conn |> put_status(:unprocessable_entity) |> json(%{"error" => "Could not play card"})
                     end
-
-                  {:error, changeset} ->
-                    Logger.warning("Card update failed for dealt_card_id=#{inspect(dealt_card.id)}, player_id=#{inspect(player_id)}, game_id=#{inspect(game_id)}, errors=#{inspect(changeset.errors)}")
-                    conn |> put_status(:unprocessable_entity) |> json(%{"error" => "Could not play card"})
                 end
+              else
+                Logger.debug("Dealt card #{inspect(dealt_card_id)} not found for player: #{inspect(player_id)}")
+                conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
+              end
+            else
+              Logger.debug("Player #{inspect(player_id)} not found in game: #{inspect(game_id)}")
+              conn |> put_status(:not_found) |> json(%{"error" => "Player not found in this game"})
             end
-          else
-            Logger.debug("Dealt card #{inspect(dealt_card_id)} not found for player: #{inspect(player_id)}")
-            conn |> put_status(:not_found) |> json(%{"error" => "Could not find player and dealt card"})
-          end
-        else
-          Logger.debug("Player #{inspect(player_id)} not found in game: #{inspect(game_id)}")
-          conn |> put_status(:not_found) |> json(%{"error" => "Player not found in this game"})
         end
 
       {:error, :not_found} ->

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -137,7 +137,7 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 401)["error"] == "Valid player session required"
   end
 
-  test "play_card fails if player already played in round", %{conn:conn, game: game, player: player, dealt_card: dealt_card} do
+  test "play_card fails if player already played in round", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
       edition: "webapp", external_id: "2", language: "en", version: "1",

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -40,11 +40,12 @@ defmodule CopiWeb.ApiControllerTest do
     old_step = Application.get_env(:copi, :api_game_stub_step)
 
     {:ok, game} = Cornucopia.create_game(%{name: "Test Game"})
-    {:ok, player} = Cornucopia.create_player(%{name: "Test Player", game_id: game.id})
+    {:ok, game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
+    {:ok, player} = Cornucopia.create_player(%{name: "Test Player",game_id: game.id})
 
     {:ok, card} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "A", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "1", language: "en", version: "1",
+      edition: "webapp", external_id: "1", language: "en", version:"1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
@@ -116,7 +117,8 @@ defmodule CopiWeb.ApiControllerTest do
 
   test "play_card rejects a player from another game", %{conn: conn, game: game} do
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
-    {:ok, other_player} = Cornucopia.create_player(%{name: "Other", game_id: other_game.id})
+    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
+    {:ok, other_player} = Cornucopia.create_player(%{name: "Other",game_id: other_game.id})
     {:ok, card2} = Cornucopia.create_card(%{
       category: "C", value: "Q", description: "d", misc: "m",
       edition: "webapp", external_id: "99", language: "en", version: "1",
@@ -135,10 +137,10 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 401)["error"] == "Valid player session required"
   end
 
-  test "play_card fails if player already played in round", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+  test "play_card fails if player already played in round", %{conn:conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "2", language: "en", version: "1",
+      edition: "webapp", external_id: "2", language: "en", version:"1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
@@ -199,7 +201,7 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 400)["error"] == "Invalid request parameters"
   end
 
-  test "play_card returns 503 when initial game lookup is transient", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+  test "play_card returns 503 when initial game lookup is transient", %{conn: conn, game: game, player: player, dealt_card: dealt_card}do
     Application.put_env(:copi, :api_game_module, GameStub)
     Application.put_env(:copi, :api_game_stub_mode, :initial_transient)
 
@@ -259,6 +261,44 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 422)["error"] == "Could not play card"
   end
 
+  test "play_card returns 422 when game has not started", %{conn: conn} do
+    {:ok, unstarted_game} = Cornucopia.create_game(%{name: "Unstarted Game"})
+    {:ok, player} = Cornucopia.create_player(%{name: "Player", game_id: unstarted_game.id})
+    {:ok, card} = Cornucopia.create_card(%{
+      category: "Cornucopia", value: "A", description: "desc", misc: "misc",
+      edition: "webapp", external_id: "1", language: "en", version: "1",
+      owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
+      capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
+      biml: "biml", url: "http://example.com"
+    })
+    {:ok, dealt_card} = Repo.insert(%DealtCard{player_id: player.id, card_id: card.id})
+
+    conn =
+      conn
+      |> init_test_session(%{
+        "resume_player_session" => %{"game_id" => unstarted_game.id, "player_id" => player.id}
+      })
+      |> put("/api/games/#{unstarted_game.id}/players/#{player.id}/card", %{
+        "game_id" => unstarted_game.id,
+        "player_id" => player.id,
+        "dealt_card_id" => to_string(dealt_card.id)
+      })
+
+    assert json_response(conn, 422)["error"] == "Game has not started yet"
+  end
+
+  test "play_card returns 422 when game has already ended", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    {:ok, _} = Cornucopia.update_game(game, %{finished_at: DateTime.utc_now()})
+
+    conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
+      "game_id" => game.id,
+      "player_id" => player.id,
+      "dealt_card_id" => to_string(dealt_card.id)
+    })
+
+    assert json_response(conn, 422)["error"] == "Game has already ended"
+  end
+
   test "exchange stores an encrypted player capability in the session", %{conn: conn, game: game, player: player} do
     capability = CopiWeb.PlayerCapability.sign(game.id, player.id)
 
@@ -274,12 +314,12 @@ defmodule CopiWeb.ApiControllerTest do
     assert get_resp_header(conn, "cache-control") == ["no-store"]
   end
 
-  test "exchange adds a capability and returns a clean player URL", %{
+  test "exchange adds a capability and returns a clean player URL",%{
     conn: conn,
     game: game,
     player: player
   } do
-    {:ok, second_player} = Cornucopia.create_player(%{name: "Second Player", game_id: game.id})
+    {:ok, second_player} = Cornucopia.create_player(%{name: "SecondPlayer", game_id: game.id})
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other Player", game_id: other_game.id})
 
@@ -316,7 +356,7 @@ defmodule CopiWeb.ApiControllerTest do
   } do
     conn = post(conn, "/api/player-capabilities/exchange", %{"capability" => "invalid"})
 
-    assert json_response(conn, 401)["error"] == "Invalid or expired player capability"
+    assert json_response(conn, 401)["error"] == "Invalid or expiredplayer capability"
     assert get_session(conn, "resume_player_session") == %{
              "game_id" => game.id,
              "player_id" => player.id
@@ -341,7 +381,7 @@ defmodule CopiWeb.ApiControllerTest do
         "capability" => expired_capability
       })
 
-    assert json_response(conn, 401)["error"] == "Invalid or expired player capability"
+    assert json_response(conn, 401)["error"] == "Invalid or expiredplayer capability"
   end
 
   test "exchange adds capabilities for the same game and other games", %{
@@ -349,7 +389,7 @@ defmodule CopiWeb.ApiControllerTest do
     game: game,
     player: player
   } do
-    {:ok, second_player} = Cornucopia.create_player(%{name: "Second Player", game_id: game.id})
+    {:ok, second_player} = Cornucopia.create_player(%{name: "SecondPlayer", game_id: game.id})
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other Game Player", game_id: other_game.id})
 
@@ -368,7 +408,7 @@ defmodule CopiWeb.ApiControllerTest do
              %{"game_id" => game.id, "player_id" => player.id}
            ]
 
-    other_capability = CopiWeb.PlayerCapability.sign(other_game.id, other_player.id)
+    other_capability = CopiWeb.PlayerCapability.sign(other_game.id,other_player.id)
 
     other_conn =
       build_conn()
@@ -390,10 +430,11 @@ defmodule CopiWeb.ApiControllerTest do
     player: player,
     dealt_card: dealt_card
   } do
-    {:ok, second_player} = Cornucopia.create_player(%{name: "Second Player", game_id: game.id})
+    {:ok, second_player} = Cornucopia.create_player(%{name: "SecondPlayer", game_id: game.id})
     second_dealt_card = Repo.insert!(%DealtCard{player_id: second_player.id, card_id: dealt_card.card_id})
 
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
+    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other Game Player", game_id: other_game.id})
     other_dealt_card = Repo.insert!(%DealtCard{player_id: other_player.id, card_id: dealt_card.card_id})
 

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -45,7 +45,7 @@ defmodule CopiWeb.ApiControllerTest do
 
     {:ok, card} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "A", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "1", language: "en", version:"1",
+      edition: "webapp", external_id: "1", language: "en", version: "1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
@@ -140,7 +140,7 @@ defmodule CopiWeb.ApiControllerTest do
   test "play_card fails if player already played in round", %{conn:conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "2", language: "en", version:"1",
+      edition: "webapp", external_id: "2", language: "en", version: "1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -40,8 +40,8 @@ defmodule CopiWeb.ApiControllerTest do
     old_step = Application.get_env(:copi, :api_game_stub_step)
 
     {:ok, game} = Cornucopia.create_game(%{name: "Test Game"})
-    {:ok, game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
     {:ok, player} = Cornucopia.create_player(%{name: "Test Player",game_id: game.id})
+    {:ok, game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
 
     {:ok, card} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "A", description: "desc", misc: "misc",
@@ -117,8 +117,8 @@ defmodule CopiWeb.ApiControllerTest do
 
   test "play_card rejects a player from another game", %{conn: conn, game: game} do
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
-    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other",game_id: other_game.id})
+    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     {:ok, card2} = Cornucopia.create_card(%{
       category: "C", value: "Q", description: "d", misc: "m",
       edition: "webapp", external_id: "99", language: "en", version: "1",
@@ -434,8 +434,8 @@ defmodule CopiWeb.ApiControllerTest do
     second_dealt_card = Repo.insert!(%DealtCard{player_id: second_player.id, card_id: dealt_card.card_id})
 
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
-    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other Game Player", game_id: other_game.id})
+    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     other_dealt_card = Repo.insert!(%DealtCard{player_id: other_player.id, card_id: dealt_card.card_id})
 
     sessions = [

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -41,11 +41,10 @@ defmodule CopiWeb.ApiControllerTest do
 
     {:ok, game} = Cornucopia.create_game(%{name: "Test Game"})
     {:ok, player} = Cornucopia.create_player(%{name: "Test Player",game_id: game.id})
-    {:ok, game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
 
     {:ok, card} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "A", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "1", language: "en", version: "1",
+      edition: "webapp", external_id: "1", language: "en", version:"1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
@@ -69,6 +68,8 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card success", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
+
     conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
       "game_id" => game.id,
       "player_id" => player.id,
@@ -105,6 +106,7 @@ defmodule CopiWeb.ApiControllerTest do
 
   test "play_card fails if card already played", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, _} = Repo.update(Ecto.Changeset.change(dealt_card, played_in_round: 1))
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
 
     conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
       "game_id" => game.id,
@@ -118,7 +120,6 @@ defmodule CopiWeb.ApiControllerTest do
   test "play_card rejects a player from another game", %{conn: conn, game: game} do
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other",game_id: other_game.id})
-    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     {:ok, card2} = Cornucopia.create_card(%{
       category: "C", value: "Q", description: "d", misc: "m",
       edition: "webapp", external_id: "99", language: "en", version: "1",
@@ -137,15 +138,16 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 401)["error"] == "Valid player session required"
   end
 
-  test "play_card fails if player already played in round", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+  test "play_card fails if player already played in round", %{conn:conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "2", language: "en", version: "1",
+      edition: "webapp", external_id: "2", language: "en", version:"1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
     })
     Repo.insert!(%DealtCard{player_id: player.id, card_id: card2.id, played_in_round: 1})
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
 
     conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
       "game_id" => game.id,
@@ -177,6 +179,8 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card returns 404 when dealt card id is missing for valid player", %{conn: conn, game: game, player: player} do
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
+
     conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
       "game_id" => game.id,
       "player_id" => player.id,
@@ -215,6 +219,7 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card returns 404 when game disappears after update", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
     Application.put_env(:copi, :api_game_module, GameStub)
     Application.put_env(:copi, :api_repo_module, RepoStub)
     Application.put_env(:copi, :api_game_stub_mode, :second_not_found)
@@ -231,6 +236,7 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card returns 503 when game reload after update is transient", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
     Application.put_env(:copi, :api_game_module, GameStub)
     Application.put_env(:copi, :api_repo_module, RepoStub)
     Application.put_env(:copi, :api_game_stub_mode, :second_transient)
@@ -247,6 +253,7 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card returns 422 when dealt card update fails", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
     Application.put_env(:copi, :api_game_module, GameStub)
     Application.put_env(:copi, :api_repo_module, RepoStub)
     Application.put_env(:copi, :api_game_stub_mode, :real)
@@ -266,7 +273,7 @@ defmodule CopiWeb.ApiControllerTest do
     {:ok, player} = Cornucopia.create_player(%{name: "Player", game_id: unstarted_game.id})
     {:ok, card} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "A", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "1", language: "en", version: "1",
+      edition: "webapp", external_id: "1000", language: "en", version: "1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
@@ -288,7 +295,8 @@ defmodule CopiWeb.ApiControllerTest do
   end
 
   test "play_card returns 422 when game has already ended", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
-    {:ok, _} = Cornucopia.update_game(game, %{finished_at: DateTime.utc_now()})
+    {:ok, game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
+    {:ok, _game} = Cornucopia.update_game(game, %{finished_at: DateTime.utc_now()})
 
     conn = put(conn, "/api/games/#{game.id}/players/#{player.id}/card", %{
       "game_id" => game.id,
@@ -356,7 +364,7 @@ defmodule CopiWeb.ApiControllerTest do
   } do
     conn = post(conn, "/api/player-capabilities/exchange", %{"capability" => "invalid"})
 
-    assert json_response(conn, 401)["error"] == "Invalid or expiredplayer capability"
+    assert json_response(conn, 401)["error"] == "Invalid or expired player capability"
     assert get_session(conn, "resume_player_session") == %{
              "game_id" => game.id,
              "player_id" => player.id
@@ -381,7 +389,7 @@ defmodule CopiWeb.ApiControllerTest do
         "capability" => expired_capability
       })
 
-    assert json_response(conn, 401)["error"] == "Invalid or expiredplayer capability"
+    assert json_response(conn, 401)["error"] == "Invalid or expired player capability"
   end
 
   test "exchange adds capabilities for the same game and other games", %{
@@ -435,8 +443,10 @@ defmodule CopiWeb.ApiControllerTest do
 
     {:ok, other_game} = Cornucopia.create_game(%{name: "Other Game"})
     {:ok, other_player} = Cornucopia.create_player(%{name: "Other Game Player", game_id: other_game.id})
-    {:ok, other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
     other_dealt_card = Repo.insert!(%DealtCard{player_id: other_player.id, card_id: dealt_card.card_id})
+
+    {:ok, _game} = Cornucopia.update_game(game, %{started_at: DateTime.utc_now()})
+    {:ok, _other_game} = Cornucopia.update_game(other_game, %{started_at: DateTime.utc_now()})
 
     sessions = [
       %{"game_id" => game.id, "player_id" => player.id},

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -138,7 +138,7 @@ defmodule CopiWeb.ApiControllerTest do
     assert json_response(conn, 401)["error"] == "Valid player session required"
   end
 
-  test "play_card fails if player already played in round", %{conn:conn, game: game, player: player, dealt_card: dealt_card} do
+  test "play_card fails if player already played in round", %{conn: conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
       edition: "webapp", external_id: "2", language: "en", version: "1",

--- a/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
+++ b/copi.owasp.org/test/copi_web/controllers/api_controller_test.exs
@@ -44,7 +44,7 @@ defmodule CopiWeb.ApiControllerTest do
 
     {:ok, card} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "A", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "1", language: "en", version:"1",
+      edition: "webapp", external_id: "1", language: "en", version: "1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"
@@ -141,7 +141,7 @@ defmodule CopiWeb.ApiControllerTest do
   test "play_card fails if player already played in round", %{conn:conn, game: game, player: player, dealt_card: dealt_card} do
     {:ok, card2} = Cornucopia.create_card(%{
       category: "Cornucopia", value: "K", description: "desc", misc: "misc",
-      edition: "webapp", external_id: "2", language: "en", version:"1",
+      edition: "webapp", external_id: "2", language: "en", version: "1",
       owasp_scp: [], owasp_devguide: [], owasp_asvs: [], owasp_appsensor: [],
       capec: [], safecode: [], owasp_mastg: [], owasp_masvs: [],
       biml: "biml", url: "http://example.com"


### PR DESCRIPTION
Resolves #2631

## Summary
The `PUT /api/games/:game_id/players/:player_id/card` endpoint had no check on game lifecycle state. It only validated whether the card was already played and whether the player had already played in the current round — never `game.started_at` or `game.finished_at`. This meant a script could call the API to play cards before a game starts (lobby phase, `started_at == nil`) or after it ends (`finished_at != nil`), corrupting game state.

## Changes
Scoped strictly to the two files needed for this fix:

- `lib/copi_web/controllers/api_controller.ex`: added a lifecycle `cond` at the top of the game-found branch in `play_card_as/4`,
  returning `422 Unprocessable Entity` when `game.started_at` is nil or `game.finished_at` is set, before any player/card lookups     
occur. All existing checks proceed unchanged once lifecycle is confirmed.
- `test/copi_web/controllers/api_controller_test.exs`:
  - Updated the shared test `game` (and two ad-hoc `other_game`    instances) to set `started_at`, since none of the existing tests
    previously accounted for game lifecycle and would otherwise now fail against the new guard
  - Added two new tests: `422` when the game has not started, `422`  when the game has already ended

## Testing
Opening as a draft PR to let CI run `mix test` and verify before requesting review, since Elixir isn't set up locally on my machine
yet. Will mark ready for review once all checks pass.

## Related
A prior attempt at this fix (#2708) took the same core approach but also touched unrelated files (`player_live/show.ex`, `encrypted/binary.ex`, `ip_helper.ex`) and had unresolved merge conflicts. This PR keeps strictly to the two files above.