### PR TITLE
Remove mapping from card browser for companion and mobile decks

### DIFF
--- a/cornucopia.owasp.org/src/lib/components/cardPreview.svelte
+++ b/cornucopia.owasp.org/src/lib/components/cardPreview.svelte
@@ -2,13 +2,9 @@
     import type { Component } from "svelte";
     import type { Card } from "../../domain/card/card";
     import { cardColor } from "../../domain/card/cardColor";
-    import MobileAppCardMapping from "./mobileAppCardMapping.svelte";
-    import CompanionCardMapping from "./companionCardMapping.svelte";
     import EopCardMapping from "./eopCardMapping.svelte";
 
     const mappingComponents: Record<string, Component<any>> = {
-        mobileapp: MobileAppCardMapping,
-        companion: CompanionCardMapping,
         eop: EopCardMapping
     };
 


### PR DESCRIPTION
### Description

This PR removes the requirement mapping displayed on the card face in the card browser for the companion and mobile decks, so they match the webapp deck which already shows no mapping.

Changes in `cornucopia.owasp.org/src/lib/components/cardPreview.svelte`:
- Removed the `mobileapp` and `companion` entries from the `mappingComponents` map.
- Removed the now-unused imports of `MobileAppCardMapping` and `CompanionCardMapping`.

Resolved or fixed issue: #3317

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines