### PR TITLE
fix(copi): wrap game start and card dealing in a database transaction

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/game_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/game_live/show.ex
@@ -137,21 +137,42 @@ defmodule CopiWeb.GameLive.Show do
         all_cards = Copi.Cornucopia.list_cards_shuffled(game.edition, game.suits, latest_version(game.edition))
         players = game.players
         player_count = length(players)
+        repo = repo_module()
 
-        # Deal cards to players in round-robin fashion
-        all_cards
-        |> Enum.with_index()
-        |> Enum.each(fn {card, i} ->
-          Copi.Repo.insert!(%DealtCard{
-            card_id: card.id,
-            player_id: Enum.at(players, rem(i, player_count)).id
-          })
-        end)
+        # Deal cards and start the game atomically: either everything
+        # succeeds, or nothing is persisted, preventing partial card
+        # distribution if a failure occurs mid-loop.
+        transaction_result =
+          repo.transaction(fn ->
+            all_cards
+            |> Enum.with_index()
+            |> Enum.each(fn {card, i} ->
+              case repo.insert(%DealtCard{
+                     card_id: card.id,
+                     player_id: Enum.at(players, rem(i, player_count)).id
+                   }) do
+                {:ok, _dealt_card} -> :ok
+                {:error, changeset} -> repo.rollback(changeset)
+              end
+            end)
 
-        # Update game with start time
-        {:ok, updated_game} = Copi.Cornucopia.update_game(game, %{started_at: DateTime.truncate(DateTime.utc_now(), :second)})
-        CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
-        {:noreply, assign(socket, :game, updated_game)}
+            case Copi.Cornucopia.update_game(game, %{started_at: DateTime.truncate(DateTime.utc_now(), :second)}) do
+              {:ok, updated_game} -> updated_game
+              {:error, changeset} -> repo.rollback(changeset)
+            end
+          end)
+
+        case transaction_result do
+          {:ok, updated_game} ->
+            CopiWeb.Endpoint.broadcast(topic(updated_game.id), "game:updated", updated_game)
+            {:noreply, assign(socket, :game, updated_game)}
+
+          {:error, _reason} ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Failed to start game due to a system error. Please try again.")
+             |> assign(:game, game)}
+        end
     end
   end
 
@@ -193,6 +214,10 @@ defmodule CopiWeb.GameLive.Show do
 
   defp game_module do
     Application.get_env(:copi, :game_live_show_game_module, Game) || Game
+  end
+
+  defp repo_module do
+    Application.get_env(:copi, :game_live_show_repo_module, Copi.Repo) || Copi.Repo
   end
 
   defp assign_game(socket, game) do

--- a/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
+++ b/copi.owasp.org/test/copi_web/live/game_live/show_test.exs
@@ -28,6 +28,21 @@ defmodule CopiWeb.GameLive.ShowTest do
     defp resolve(:transient, _id), do: {:error, :temporary}
   end
 
+  defmodule RepoStub do
+    def transaction(fun) do
+      Copi.Repo.transaction(fun)
+    end
+
+    def insert(struct) do
+      case Application.get_env(:copi, :game_live_show_repo_stub_mode, :real) do
+        :fail_on_insert -> Copi.Repo.rollback(:simulated_insert_failure)
+        _ -> Copi.Repo.insert(struct)
+      end
+    end
+
+    def rollback(reason), do: Copi.Repo.rollback(reason)
+  end
+
   @game_attrs %{name: "Edge Case Test Game", edition: "webapp", suits: ["hearts", "clubs"]}
 
   defp create_game(_) do
@@ -41,10 +56,14 @@ defmodule CopiWeb.GameLive.ShowTest do
     setup do
       old_game_mod = Application.get_env(:copi, :game_live_show_game_module)
       old_mode = Application.get_env(:copi, :game_live_show_stub_mode)
+      old_repo_mod = Application.get_env(:copi, :game_live_show_repo_module)
+      old_repo_mode = Application.get_env(:copi, :game_live_show_repo_stub_mode)
 
       on_exit(fn ->
         Application.put_env(:copi, :game_live_show_game_module, old_game_mod)
         Application.put_env(:copi, :game_live_show_stub_mode, old_mode)
+        Application.put_env(:copi, :game_live_show_repo_module, old_repo_mod)
+        Application.put_env(:copi, :game_live_show_repo_stub_mode, old_repo_mode)
       end)
 
       :ok
@@ -158,6 +177,51 @@ defmodule CopiWeb.GameLive.ShowTest do
       # Verify started_at timestamp hasn't changed
       {:ok, updated_game} = Cornucopia.Game.find(started_game.id)
       assert DateTime.compare(updated_game.started_at, original_time) == :eq
+    end
+
+    test "start_game rolls back and shows an error when card dealing fails", %{conn: conn, game: game} do
+      {:ok, _player1} = Cornucopia.create_player(%{name: "Player 1", game_id: game.id})
+      {:ok, _player2} = Cornucopia.create_player(%{name: "Player 2", game_id: game.id})
+      {:ok, _player3} = Cornucopia.create_player(%{name: "Player 3", game_id: game.id})
+
+      {:ok, _card} =
+        Cornucopia.create_card(%{
+          category: "hearts",
+          value: "V1",
+          description: "D",
+          edition: "webapp",
+          version: "3.0",
+          external_id: "RB1",
+          language: "en",
+          misc: "m",
+          owasp_scp: [],
+          owasp_devguide: [],
+          owasp_asvs: [],
+          owasp_appsensor: [],
+          capec: [],
+          safecode: [],
+          owasp_mastg: [],
+          owasp_masvs: []
+        })
+
+      {:ok, view, _html} = live(conn, "/games/#{game.id}")
+
+      Application.put_env(:copi, :game_live_show_repo_module, RepoStub)
+      Application.put_env(:copi, :game_live_show_repo_stub_mode, :fail_on_insert)
+
+      render_click(view, "start_game", %{})
+
+      assert render(view) =~ "Failed to start game due to a system error"
+
+      {:ok, unchanged_game} = Cornucopia.Game.find(game.id)
+      assert unchanged_game.started_at == nil
+
+      dealt_count =
+        unchanged_game.players
+        |> Enum.flat_map(& &1.dealt_cards)
+        |> Enum.count()
+
+      assert dealt_count == 0
     end
 
     test "handle_info updates game when matching topic received", %{conn: conn, game: game} do


### PR DESCRIPTION
## Summary

This PR adds transaction protection to the game start flow to prevent partial card dealing when a database operation fails.

Previously, if an insert failed while dealing cards, some players could receive cards while others would not, leaving the game in an inconsistent and unplayable state. This change ensures that all database operations complete successfully or are rolled back together.

## Changes

- Wrap the game start workflow in a database transaction.
- Roll back all changes if any card insertion fails.
- Add repository abstraction to enable transaction failure testing.
- Display a user-friendly error message when a transaction fails.
- Add a LiveView test covering rollback behavior and verifying that no cards are dealt after a failed transaction.

## Testing

- Added a test that simulates a repository insert failure.
- Verified that:
  - the transaction is rolled back,
  - `started_at` remains unchanged,
  - no cards are dealt,
  - an error message is displayed to the user.

## Fixes

Fixes #2343