### PR TITLE
fix: add optional card property to Card type

### DIFF
--- a/cornucopia.owasp.org/src/domain/card/card.ts
+++ b/cornucopia.owasp.org/src/domain/card/card.ts
@@ -17,5 +17,6 @@ export type Card =
     url : string,
     value : string,
     version : string,
-    language : string
+    language : string,
+    card?: string
 }


### PR DESCRIPTION
## Description
This PR addresses a type mismatch issue that was causing `svelte-check` errors during static analysis, specifically related to the rendering of Joker cards in the `cardPreview.svelte` component. 

The YAML data correctly populates the `card` property at runtime for Joker cards, but the TypeScript `Card` type definition was missing this property.

## Changes Made
- Added the optional property `card?: string` to the `Card` type defined in `src/domain/card/card.ts`.

## Verification
- Verified that `pnpm run check` (running `svelte-check`) now executes successfully without the `Property 'card' does not exist on type 'Card'` error.

issue -[#2823](https://github.com/OWASP/cornucopia/issues/2823)
