### PR TITLE
fix: redirect to game summary when finished game is refreshed

### DIFF
--- a/copi.owasp.org/lib/copi_web/live/player_live/show.ex
+++ b/copi.owasp.org/lib/copi_web/live/player_live/show.ex
@@ -54,7 +54,7 @@ defmodule CopiWeb.PlayerLive.Show do
             end
 
           {:ok, _player} ->
-            redirect_to_public_game(socket, game_id)
+            redirect_finished_game_or_public(socket, game_id)
 
           {:error, :not_found} ->
             raise Ecto.NoResultsError, queryable: Player
@@ -347,6 +347,19 @@ defmodule CopiWeb.PlayerLive.Show do
 
   defp authorized_player_url?(socket, %{"game_id" => game_id, "id" => player_id}) do
     PlayerSessions.authorized?(socket.assigns.player_sessions, game_id, player_id)
+  end
+
+  defp redirect_finished_game_or_public(socket, game_id) do
+    case game_module().find(game_id) do
+      {:ok, %{finished_at: finished_at}} when not is_nil(finished_at) ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "This game has finished. Showing the game summary.")
+         |> redirect(to: "/games/#{game_id}")}
+
+      _ ->
+        redirect_to_public_game(socket, game_id)
+    end
   end
 
   defp redirect_to_public_game(socket, game_id) do


### PR DESCRIPTION
### Description

when a player refreshes their player page after the game finishes, they were getting an error. added redirect_finished_game_or_public/2 which checks if the game has a finished_at timestamp and redirects to the game summary page with an info flash instead of showing an error.

fixed issue: #3316 

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
