### PR TITLE
Add name format validation to player and game changesets

### DIFF
--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -58,7 +58,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-                    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -58,7 +58,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
+        |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -58,7 +58,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-            |> validate_format(:name, ~r/^[a-zA-Z0-9\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E} ._-]+$/u, message: "contains invalid characters")
+                    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -58,7 +58,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
+            |> validate_format(:name, ~r/^[\p{L}\p{M}\p{N}. _-]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -58,7 +58,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
-        |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/game.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/game.ex
@@ -58,6 +58,7 @@ defmodule Copi.Cornucopia.Game do
     game
     |> cast(attrs, [:name, :created_at, :edition, :started_at, :finished_at, :rounds_played, :suits, :round_open])
     |> validate_required([:name], message: "No really, give your game session a name")
+            |> validate_format(:name, ~r/^[a-zA-Z0-9\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E} ._-]+$/u, message: "contains invalid characters")
   end
 
   def continue_vote_count(game) do

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -37,6 +37,6 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-                    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -37,6 +37,6 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
+        |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -37,6 +37,6 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-            |> validate_format(:name, ~r/^[a-zA-Z0-9\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E} ._-]+$/u, message: "contains invalid characters")
+                    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}a-zA-Z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -37,6 +37,6 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
+            |> validate_format(:name, ~r/^[\p{L}\p{M}\p{N}. _-]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -37,6 +37,6 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
-        |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
+    |> validate_format(:name, ~r/^[\x{0600}-\x{06FF}\x{0750}-\x{077F}\x{08A0}-\x{08FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}\x{FDF2}\x{FDF3}\x{FDF4}\x{FDFD}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF66}-\x{FF9F}\x{3400}-\x{4DBF}\x{F900}-\x{FAFF}\x{0900}-\x{097F}\x{0621}-\x{064A}\x{0660}-\x{0669}\x{0E00}-\x{0E7F}\x{0400}-\x{04FF}\x{0500}-\x{052F}\x{2DE0}-\x{2DFF}\x{A640}-\x{A69F}\x{0370}-\x{03FF}\x{1F00}-\x{1FFF}A-Za-z\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E}0-9._\- ]+$/u, message: "contains invalid characters. Only letters, numbers, spaces, and ._- are allowed.")
   end
 end

--- a/copi.owasp.org/lib/copi/cornucopia/player.ex
+++ b/copi.owasp.org/lib/copi/cornucopia/player.ex
@@ -37,5 +37,6 @@ defmodule Copi.Cornucopia.Player do
     |> cast(attrs, [:name, :game_id])
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
+            |> validate_format(:name, ~r/^[a-zA-Z0-9\x{00C0}-\x{00D6}\x{00D8}-\x{00F6}\x{00F8}-\x{00FF}\x{0100}-\x{017E} ._-]+$/u, message: "contains invalid characters")
   end
 end

--- a/copi.owasp.org/test/copi/cornucopia/player_game_name_validation_test.exs
+++ b/copi.owasp.org/test/copi/cornucopia/player_game_name_validation_test.exs
@@ -1,0 +1,70 @@
+defmodule Copi.Cornucopia.NameValidationTest do
+  use Copi.DataCase
+
+  alias Copi.Cornucopia.Player
+  alias Copi.Cornucopia.Game
+
+  describe "player name validation" do
+    test "accepts Latin characters" do
+      changeset = Player.changeset(%Player{}, %{name: "Alice"})
+      assert changeset.valid?
+    end
+
+    test "accepts Arabic characters" do
+      changeset = Player.changeset(%Player{}, %{name: "محمد"})
+      assert changeset.valid?
+    end
+
+    test "accepts Japanese characters" do
+      changeset = Player.changeset(%Player{}, %{name: "田中"})
+      assert changeset.valid?
+    end
+
+    test "accepts Cyrillic characters" do
+      changeset = Player.changeset(%Player{}, %{name: "Иван"})
+      assert changeset.valid?
+    end
+
+    test "accepts Greek characters" do
+      changeset = Player.changeset(%Player{}, %{name: "Νίκος"})
+      assert changeset.valid?
+    end
+
+    test "accepts Thai characters" do
+      changeset = Player.changeset(%Player{}, %{name: "สมชาย"})
+      assert changeset.valid?
+    end
+
+    test "rejects HTML tags" do
+      changeset = Player.changeset(%Player{}, %{name: "<script>alert('XSS')</script>"})
+      refute changeset.valid?
+    end
+
+    test "rejects JavaScript injection" do
+      changeset = Player.changeset(%Player{}, %{name: "javascript:alert(1)"})
+      refute changeset.valid?
+    end
+  end
+
+  describe "game name validation" do
+    test "accepts Latin characters" do
+      changeset = Game.changeset(%Game{}, %{name: "My Game"})
+      assert changeset.valid?
+    end
+
+    test "accepts Arabic characters" do
+      changeset = Game.changeset(%Game{}, %{name: "لعبة"})
+      assert changeset.valid?
+    end
+
+    test "rejects HTML tags" do
+      changeset = Game.changeset(%Game{}, %{name: "<b>bold</b>"})
+      refute changeset.valid?
+    end
+
+    test "rejects JavaScript injection" do
+      changeset = Game.changeset(%Game{}, %{name: "<img src=x onerror=alert(1)>"})
+      refute changeset.valid?
+    end
+  end
+end


### PR DESCRIPTION

### Description
Player and game names were accepting raw HTML/JS input like <script>alert('XSS')</script> with no validation. Phoenix auto-escapes output so nothing executes now, but the raw content was still being stored in the database.

- The original regex in the issue uses \uXXXX syntax which Elixir's PCRE2 engine does not support. Converted all ranges to \x{XXXX} format. All scripts from regex are covered Arabic, Japanese, Cyrillic, Greek, Thai, Latin, extended Latin etc.
- All test cases are passing.

Fixes #2555

### AI Tool Disclosure

- [X] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [X] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
