### PR TITLE
Fix enforce test coverage for pdf generation

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -47,6 +47,8 @@
               pipenv run coverage xml -o converter/coverage/cobertura.xml
           - name: Check test coverage - Report
             run: pipenv run coverage report --fail-under 85 scripts/convert*
+          - name: Check PDF generation test coverage - Report
+            run: pipenv run coverage report --fail-under 55 scripts/pdf_generation/*.py
           # Upload Code Coverage for Codeclimate
           - uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
             with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Get Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: 'pipenv' # caching pip dependencies
       - name: Install dependencies
         run: |
@@ -41,6 +41,8 @@ jobs:
         run: pipenv run coverage xml
       - name: Check test coverage - Report
         run: pipenv run coverage report --fail-under 95 scripts/convert*
+      - name: Check PDF generation test coverage - Report
+        run: pipenv run coverage report --fail-under 55 scripts/pdf_generation/*.py
       # Check formatting of files
       - name: Check formatting of files with Black
         run: pipenv run black --line-length=120 --check .

--- a/scripts/pdf_generation/check_environment.py
+++ b/scripts/pdf_generation/check_environment.py
@@ -93,8 +93,8 @@ def report():
 
     add("")
     add("Packages this interpreter needs:")
-    lines, missing = check_required(in_scribus)
-    add("\n".join(lines))
+    package_lines, missing = check_required(in_scribus)
+    add("\n".join(package_lines))
 
     add("")
     add("Optional:")

--- a/tests/scripts/pdf_generation_utest.py
+++ b/tests/scripts/pdf_generation_utest.py
@@ -14,6 +14,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 # The generator adds its own directory to sys.path at runtime and imports its
 # modules flat. Doing the same here exercises the real import path.
@@ -23,6 +24,7 @@ if _PDF_GENERATION not in sys.path:
     sys.path.insert(0, _PDF_GENERATION)
 
 import cornucopia_common as cc  # noqa: E402  (needs the sys.path line above)
+import check_environment  # noqa: E402
 import merge_pdfs  # noqa: E402
 
 # Repeated fixture values, named once so a change lands in one place.
@@ -537,6 +539,59 @@ class TestCleanIntermediates(unittest.TestCase):
         os.remove(self.cards[0])
         removed, _freed = self._clean()
         self.assertEqual(removed, 8)
+
+
+class TestCheckEnvironment(unittest.TestCase):
+    def test_check_required_marks_other_interpreter_modules_as_not_needed(self) -> None:
+        original_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name in {"qrcode", "png", "pymupdf"}:
+                raise ImportError("missing for test")
+            return original_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            lines, missing = check_environment.check_required(False)
+
+        self.assertTrue(any("not needed  qrcode" in line for line in lines))
+        self.assertTrue(any("not needed  png" in line for line in lines))
+        self.assertIn("pymupdf", missing)
+
+    def test_check_optional_reports_missing_modules_without_failing(self) -> None:
+        original_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "defusedxml":
+                raise ImportError("missing for test")
+            return original_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            lines = check_environment.check_optional()
+
+        self.assertTrue(any("not found   defusedxml" in line for line in lines))
+
+    def test_report_includes_interpreter_context_and_package_section(self) -> None:
+        with mock.patch.object(check_environment, "check_required", return_value=(["  found       yaml"], [])):
+            with mock.patch.object(check_environment, "check_optional", return_value=["  found       defusedxml"]):
+                text = check_environment.report()
+
+        self.assertIn("Running inside: plain Python (not Scribus)", text)
+        self.assertIn("Python version :", text)
+        self.assertIn("Where this interpreter looks for packages:", text)
+        self.assertIn("Packages this interpreter needs:", text)
+        self.assertIn("  found       yaml", text)
+        self.assertIn("Optional:", text)
+        self.assertIn("All packages this interpreter needs are present.", text)
+
+    def test_report_explains_missing_packages(self) -> None:
+        with mock.patch.object(
+            check_environment, "check_required", return_value=(["  MISSING     yaml      install pyyaml"], ["yaml"])
+        ):
+            with mock.patch.object(check_environment, "check_optional", return_value=[]):
+                text = check_environment.report()
+
+        self.assertIn("Missing: yaml", text)
+        self.assertIn("These must be installed into THIS interpreter", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

This contain fix for enforcing 56% test coverage for the pdf generation

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `GitHub CoPilot`
    - LLMs and versions: `GPT-5.4`
    - Prompts:

```
The test coverage should be enforced for this in the same way as the converter. 
Please make the necessary changes. Also make sure that running the tests from the workflows installs the needed dependencies.
```

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/owasp/cornucopia/blob/master/CONTRIBUTING.md) guidelines
