### PR TITLE
add bridge layout IDML templates for all EoP files 

### DIFF
--- a/.github/workflows/run-tests-generate-output.yaml
+++ b/.github/workflows/run-tests-generate-output.yaml
@@ -87,13 +87,36 @@ jobs:
           mkdir -p output/eop-bridge-en/Links output/eop-bridge-en/Fonts
           mkdir -p output/eop-bridge-es/Links output/eop-bridge-es/Fonts
           cp -rf ./resources/templates/Links/eop output/eop-bridge-en/Links/
-          cp -rf ./resources/templates/Fonts/Selawik/* ./resources/templates/Fonts/OpenSans/* output/eop-bridge-en/Fonts/
+          cp -rf ./resources/templates/Fonts/Selawik/* output/eop-bridge-en/Fonts/
+          cp -rf ./resources/templates/Fonts/OpenSans/* output/eop-bridge-en/Fonts/
           cp -rf output/eop-bridge-en/Links output/eop-bridge-es/
           cp -rf output/eop-bridge-en/Fonts output/eop-bridge-es/
           pipenv run python scripts/convert.py -t bridge -l en -lt cards -v 5.0 -e eop -i ./resources/templates/eop_ver_cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-cards-bridge-en.idml
           pipenv run python scripts/convert.py -t bridge -l es -lt cards -v 5.0 -e eop -i ./resources/templates/eop_ver_cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-cards-bridge-es.idml
-          zip -r output/eop-5.0-cards-bridge-en.zip output/eop-bridge-en
-          zip -r output/eop-5.0-cards-bridge-es.zip output/eop-bridge-es
+          pipenv run python scripts/convert.py -t bridge -l en -lt about -v 5.0 -e eop -i ./resources/templates/eop_ver_about_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-about-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt about -v 5.0 -e eop -i ./resources/templates/eop_ver_about_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-about-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt instructions1 -v 5.0 -e eop -i ./resources/templates/eop_ver_instructions1_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-instructions1-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt instructions1 -v 5.0 -e eop -i ./resources/templates/eop_ver_instructions1_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-instructions1-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt instructions2 -v 5.0 -e eop -i ./resources/templates/eop_ver_instructions2_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-instructions2-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt instructions2 -v 5.0 -e eop -i ./resources/templates/eop_ver_instructions2_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-instructions2-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt strategy-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_strategy-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-strategy-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt strategy-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_strategy-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-strategy-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt threat-denialofsvc-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-denialofsvc-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-threat-denialofsvc-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt threat-denialofsvc-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-denialofsvc-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-threat-denialofsvc-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt threat-elevofpriv-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-elevofpriv-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-threat-elevofpriv-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt threat-elevofpriv-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-elevofpriv-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-threat-elevofpriv-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt threat-infodisclosure-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-infodisclosure-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-threat-infodisclosure-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt threat-infodisclosure-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-infodisclosure-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-threat-infodisclosure-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt threat-repudation-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-repudation-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-threat-repudation-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt threat-repudation-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-repudation-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-threat-repudation-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt threat-spoofing-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-spoofing-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-threat-spoofing-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt threat-spoofing-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-spoofing-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-threat-spoofing-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt threat-tampering-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-tampering-cards_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-threat-tampering-cards-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt threat-tampering-cards -v 5.0 -e eop -i ./resources/templates/eop_ver_threat-tampering-cards_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-threat-tampering-cards-bridge-es.idml
+          pipenv run python scripts/convert.py -t bridge -l en -lt deck -v 5.0 -e eop -i ./resources/templates/eop_ver_deck_bridge_lang.idml -o ./output/eop-bridge-en/eop-5.0-deck-bridge-en.idml
+          pipenv run python scripts/convert.py -t bridge -l es -lt deck -v 5.0 -e eop -i ./resources/templates/eop_ver_deck_bridge_lang.idml -o ./output/eop-bridge-es/eop-5.0-deck-bridge-es.idml
+          zip -r output/eop-5.0-bridge-en.zip output/eop-bridge-en
+          zip -r output/eop-5.0-bridge-es.zip output/eop-bridge-es
           pipenv run python scripts/convert.py -t tarot -l en -lt instructions1 -v 5.0 -e eop  -i ./resources/templates/eop_ver_instructions1_tarot_lang.idml -o ./output/eop/1_instructionCard1.idml
           pipenv run python scripts/convert.py -t tarot -l en -lt instructions2 -v 5.0 -e eop  -i ./resources/templates/eop_ver_instructions2_tarot_lang.idml -o ./output/eop/1_instructionCard2.idml
           pipenv run python scripts/convert.py -t tarot -l en -lt strategy-cards -v 5.0 -e eop  -i ./resources/templates/eop_ver_strategy-cards_tarot_lang.idml -o ./output/eop/2_StrategyCard.idml
@@ -149,8 +172,8 @@ jobs:
           zip -r output/owasp_cornucopia_webapp_3.0_en.zip output/cornucopia_webapp/Links/* output/cornucopia_webapp/Fonts/* output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_bridge_qr_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_cards_tarot_qr_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_bridge_en.idml output/cornucopia_webapp/owasp_cornucopia_webapp_3.0_leaflet_tarot_en.idml ./resources/templates/owasp_cornucopia_webapp_scoresheet.pdf
           zip output/cornucopia-build-files.zip -r \
             output/eop-5.0.zip \
-            output/eop-5.0-cards-bridge-en.zip \
-            output/eop-5.0-cards-bridge-es.zip \
+            output/eop-5.0-bridge-en.zip \
+            output/eop-5.0-bridge-es.zip \
             output/owasp_cornucopia_mobileapp_1.1_en.zip \
             output/owasp_cornucopia_webapp_3.0_en.zip \
             output/owasp_cornucopia_webapp_3.0_guide_bridge_en.odt \

--- a/resources/templates/eop_ver_about_bridge_lang.idml
+++ b/resources/templates/eop_ver_about_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5b85483837b400a5e67c5010fbb5cc89d8adadb6ab7c2af1069364beb5b7a8c
+size 69044

--- a/resources/templates/eop_ver_deck_bridge_lang.idml
+++ b/resources/templates/eop_ver_deck_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:817a0b65649418ba52616edc99017d68200489ec79d6d056c09bf80e6c621f3a
+size 1953645

--- a/resources/templates/eop_ver_instructions1_bridge_lang.idml
+++ b/resources/templates/eop_ver_instructions1_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ae2522661266a6a7cf82c88675e1658fedc61e54194c20d007b337c89e4de41
+size 60854

--- a/resources/templates/eop_ver_instructions2_bridge_lang.idml
+++ b/resources/templates/eop_ver_instructions2_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bf4835815fb0d72f3c0e5ea4e6aad98604b6edd6a43ad2d1d51e9669de052df
+size 62469

--- a/resources/templates/eop_ver_strategy-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_strategy-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02cc5a339437af815dfe0fe472e499a45d837412a877afe1f9c1c19d87187921
+size 81688

--- a/resources/templates/eop_ver_threat-denialofsvc-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_threat-denialofsvc-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b85bf13a60fe1b660999e2923ebdcfb665d43971ddc356a44aea6ac603fe039
+size 93988

--- a/resources/templates/eop_ver_threat-elevofpriv-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_threat-elevofpriv-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a01754f6477d95391bb134e1f2d2a72b7495b0b378633c0534b17a34c2020cc
+size 90954

--- a/resources/templates/eop_ver_threat-infodisclosure-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_threat-infodisclosure-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caca98c722fa9b40ca62af2c5f6b727bcd9bbb76e5de0e9eb54ad9869e878763
+size 88309

--- a/resources/templates/eop_ver_threat-repudation-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_threat-repudation-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b41ed287e8d7a3c92441e5d404e79eebbb66f40292a23da48d15bd5ba4191e77
+size 86965

--- a/resources/templates/eop_ver_threat-spoofing-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_threat-spoofing-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3be6aeb927ee729f9f8cb53e2c9da88b3af4e0e571f0a1b74b7366e1f3c5753
+size 89018

--- a/resources/templates/eop_ver_threat-tampering-cards_bridge_lang.idml
+++ b/resources/templates/eop_ver_threat-tampering-cards_bridge_lang.idml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:530838fd667d8d612d49de5929dcf77e3caefc9ccecf28879a380e21224adb42
+size 89331

--- a/scripts/export_idml_to_pdf.jsx
+++ b/scripts/export_idml_to_pdf.jsx
@@ -1,75 +1,95 @@
-/**
- * export_idml_to_pdf.jsx — InDesign ExtendScript
- *
- * Batch-exports all EoP bridge IDML templates to PDF for review.
- *
- * Usage (from InDesign's Scripts panel or Script Editor):
- *   1. Open Adobe InDesign (CC 2019 or later).
- *   2. Choose File > Scripts > Script Editor (or open the Scripts panel).
- *   3. Open this file and click Run (or drag it to the Scripts panel).
- *   4. PDFs will be written to the same folder as each .idml file,
- *      with the same base name and a .pdf extension.
- *
- * Alternatively, run via InDesign Server:
- *   indesignserver -script export_idml_to_pdf.jsx
- */
+// export_idml_to_pdf.jsx
+// InDesign ExtendScript to batch export IDML templates to PDF for review.
 
-var TEMPLATES_DIR = File($.fileName).parent.parent + "/resources/templates/";
+#target indesign
 
-var IDML_FILES = [
-    "eop_ver_about_bridge_lang.idml",
-    "eop_ver_instructions1_bridge_lang.idml",
-    "eop_ver_instructions2_bridge_lang.idml",
-    "eop_ver_strategy-cards_bridge_lang.idml",
-    "eop_ver_threat-denialofsvc-cards_bridge_lang.idml",
-    "eop_ver_threat-elevofpriv-cards_bridge_lang.idml",
-    "eop_ver_threat-infodisclosure-cards_bridge_lang.idml",
-    "eop_ver_threat-repudation-cards_bridge_lang.idml",
-    "eop_ver_threat-spoofing-cards_bridge_lang.idml",
-    "eop_ver_threat-tampering-cards_bridge_lang.idml",
-    "eop_ver_deck_bridge_lang.idml",
-];
-
-function exportToPDF(idmlPath) {
-    var idmlFile = File(idmlPath);
-    if (!idmlFile.exists) {
-        $.writeln("SKIP (not found): " + idmlPath);
-        return false;
+function main() {
+    // Check if documents are already open
+    if (app.documents.length > 0) {
+        alert("Please close all open documents before running this script.");
+        return;
     }
 
-    var pdfPath = idmlPath.replace(/\.idml$/, ".pdf");
-    var pdfFile = File(pdfPath);
+    // Set the source folder containing the templates
+    var scriptFile = new File($.fileName);
+    var rootDir = scriptFile.parent.parent;
+    var sourceFolder = new Folder(rootDir + "/resources/templates");
+    
+    if (!sourceFolder.exists) {
+        alert("Could not find the templates folder: " + sourceFolder.fsName);
+        return;
+    }
 
-    // Open the IDML document
-    var doc = app.open(idmlFile, false);  // false = don't show
+    // Set the output folder
+    var outFolder = new Folder(rootDir + "/output/pdf_reviews");
+    if (!outFolder.exists) {
+        outFolder.create();
+    }
 
-    try {
-        // Configure PDF export preset — use "High Quality Print" or "[Press Quality]"
-        var preset;
-        try {
-            preset = app.pdfExportPresets.itemByName("[Press Quality]");
-        } catch (e) {
-            preset = app.pdfExportPresets.itemByName("High Quality Print");
+    // We specifically want to review the newly created bridge layouts
+    var filesToProcess = [
+        "eop_ver_about_bridge_lang.idml",
+        "eop_ver_instructions1_bridge_lang.idml",
+        "eop_ver_instructions2_bridge_lang.idml",
+        "eop_ver_strategy-cards_bridge_lang.idml",
+        "eop_ver_threat-denialofsvc-cards_bridge_lang.idml",
+        "eop_ver_threat-elevofpriv-cards_bridge_lang.idml",
+        "eop_ver_threat-infodisclosure-cards_bridge_lang.idml",
+        "eop_ver_threat-repudation-cards_bridge_lang.idml",
+        "eop_ver_threat-spoofing-cards_bridge_lang.idml",
+        "eop_ver_threat-tampering-cards_bridge_lang.idml",
+        "eop_ver_deck_bridge_lang.idml"
+    ];
+
+    // Get a PDF export preset (High Quality Print is usually a safe default for review)
+    var myPDFExportPreset = app.pdfExportPresets.item("[High Quality Print]");
+    if (!myPDFExportPreset.isValid) {
+        // Fallback to the first available preset if HQ Print is not found
+        myPDFExportPreset = app.pdfExportPresets.item(0);
+    }
+
+    app.scriptPreferences.userInteractionLevel = UserInteractionLevels.NEVER_INTERACT;
+    var successCount = 0;
+    var errors = [];
+
+    for (var i = 0; i < filesToProcess.length; i++) {
+        var idmlFile = new File(sourceFolder + "/" + filesToProcess[i]);
+        if (!idmlFile.exists) {
+            errors.push("File not found: " + filesToProcess[i]);
+            continue;
         }
 
-        // Export
-        doc.exportFile(ExportFormat.PDF_TYPE, pdfFile, false, preset);
-        $.writeln("OK: " + pdfFile.fsName);
-        return true;
-    } catch (err) {
-        $.writeln("FAIL: " + idmlPath + " — " + err.message);
-        return false;
-    } finally {
-        doc.close(SaveOptions.NO);
+        try {
+            // Open the IDML file
+            var doc = app.open(idmlFile);
+            
+            // Generate the output PDF path
+            var baseName = filesToProcess[i].replace(/\.idml$/i, "");
+            var pdfFile = new File(outFolder + "/" + baseName + ".pdf");
+            
+            // Export the document to PDF
+            doc.exportFile(ExportFormat.PDF_TYPE, pdfFile, false, myPDFExportPreset);
+            
+            // Close the document without saving changes
+            doc.close(SaveOptions.NO);
+            
+            successCount++;
+        } catch (e) {
+            errors.push("Error processing " + filesToProcess[i] + ": " + e.message);
+            // Ensure doc is closed if it errored during export
+            if (app.documents.length > 0) {
+                app.activeDocument.close(SaveOptions.NO);
+            }
+        }
     }
+    
+    app.scriptPreferences.userInteractionLevel = UserInteractionLevels.INTERACT_WITH_ALL;
+
+    var msg = "Export complete. " + successCount + " files exported to PDF.\nOutput folder: " + outFolder.fsName;
+    if (errors.length > 0) {
+        msg += "\n\nErrors encountered:\n" + errors.join("\n");
+    }
+    alert(msg);
 }
 
-// Main
-var ok = 0, fail = 0;
-for (var i = 0; i < IDML_FILES.length; i++) {
-    var result = exportToPDF(TEMPLATES_DIR + IDML_FILES[i]);
-    if (result) ok++; else fail++;
-}
-
-alert("Export complete: " + ok + " succeeded, " + fail + " failed.\n" +
-      "PDFs are in resources/templates/");
+main();

--- a/scripts/export_idml_to_pdf.jsx
+++ b/scripts/export_idml_to_pdf.jsx
@@ -1,0 +1,75 @@
+/**
+ * export_idml_to_pdf.jsx — InDesign ExtendScript
+ *
+ * Batch-exports all EoP bridge IDML templates to PDF for review.
+ *
+ * Usage (from InDesign's Scripts panel or Script Editor):
+ *   1. Open Adobe InDesign (CC 2019 or later).
+ *   2. Choose File > Scripts > Script Editor (or open the Scripts panel).
+ *   3. Open this file and click Run (or drag it to the Scripts panel).
+ *   4. PDFs will be written to the same folder as each .idml file,
+ *      with the same base name and a .pdf extension.
+ *
+ * Alternatively, run via InDesign Server:
+ *   indesignserver -script export_idml_to_pdf.jsx
+ */
+
+var TEMPLATES_DIR = File($.fileName).parent.parent + "/resources/templates/";
+
+var IDML_FILES = [
+    "eop_ver_about_bridge_lang.idml",
+    "eop_ver_instructions1_bridge_lang.idml",
+    "eop_ver_instructions2_bridge_lang.idml",
+    "eop_ver_strategy-cards_bridge_lang.idml",
+    "eop_ver_threat-denialofsvc-cards_bridge_lang.idml",
+    "eop_ver_threat-elevofpriv-cards_bridge_lang.idml",
+    "eop_ver_threat-infodisclosure-cards_bridge_lang.idml",
+    "eop_ver_threat-repudation-cards_bridge_lang.idml",
+    "eop_ver_threat-spoofing-cards_bridge_lang.idml",
+    "eop_ver_threat-tampering-cards_bridge_lang.idml",
+    "eop_ver_deck_bridge_lang.idml",
+];
+
+function exportToPDF(idmlPath) {
+    var idmlFile = File(idmlPath);
+    if (!idmlFile.exists) {
+        $.writeln("SKIP (not found): " + idmlPath);
+        return false;
+    }
+
+    var pdfPath = idmlPath.replace(/\.idml$/, ".pdf");
+    var pdfFile = File(pdfPath);
+
+    // Open the IDML document
+    var doc = app.open(idmlFile, false);  // false = don't show
+
+    try {
+        // Configure PDF export preset — use "High Quality Print" or "[Press Quality]"
+        var preset;
+        try {
+            preset = app.pdfExportPresets.itemByName("[Press Quality]");
+        } catch (e) {
+            preset = app.pdfExportPresets.itemByName("High Quality Print");
+        }
+
+        // Export
+        doc.exportFile(ExportFormat.PDF_TYPE, pdfFile, false, preset);
+        $.writeln("OK: " + pdfFile.fsName);
+        return true;
+    } catch (err) {
+        $.writeln("FAIL: " + idmlPath + " — " + err.message);
+        return false;
+    } finally {
+        doc.close(SaveOptions.NO);
+    }
+}
+
+// Main
+var ok = 0, fail = 0;
+for (var i = 0; i < IDML_FILES.length; i++) {
+    var result = exportToPDF(TEMPLATES_DIR + IDML_FILES[i]);
+    if (result) ok++; else fail++;
+}
+
+alert("Export complete: " + ok + " succeeded, " + fail + " failed.\n" +
+      "PDFs are in resources/templates/");

--- a/scripts/generate_eop_bridge_templates.py
+++ b/scripts/generate_eop_bridge_templates.py
@@ -1,0 +1,326 @@
+"""Generate EoP Bridge IDML templates from their Tarot counterparts.
+
+This script replicates the page-dimension rescaling applied when
+eop_ver_cards_tarot_lang.idml was converted into
+eop_ver_cards_bridge_lang.idml and applies it to the remaining 11 EoP
+Tarot templates listed in GitHub issue #3409.
+
+Usage:
+    python scripts/generate_eop_bridge_templates.py
+
+Outputs are written to resources/templates/ alongside the existing templates.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import tempfile
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Dict, Tuple
+
+# ---------------------------------------------------------------------------
+# Card-size constants (points)
+# ---------------------------------------------------------------------------
+TAROT_H = 342.0   # height (taller dimension)
+TAROT_W = 198.0   # width
+BRIDGE_H = 246.614
+BRIDGE_W = 158.74
+BLEED_TAROT = 9.0
+BLEED_BRIDGE = 8.503937
+
+SCALE_H = BRIDGE_H / TAROT_H  # ≈ 0.720508…
+SCALE_W = BRIDGE_W / TAROT_W  # ≈ 0.801717…
+
+TEMPLATES_DIR = Path("resources/templates")
+
+# Source → Target pairs (tarot → bridge)
+TEMPLATE_PAIRS: list[Tuple[str, str]] = [
+    ("eop_ver_about_tarot_lang.idml",                      "eop_ver_about_bridge_lang.idml"),
+    ("eop_ver_instructions1_tarot_lang.idml",              "eop_ver_instructions1_bridge_lang.idml"),
+    ("eop_ver_instructions2_tarot_lang.idml",              "eop_ver_instructions2_bridge_lang.idml"),
+    ("eop_ver_strategy-cards_tarot_lang.idml",             "eop_ver_strategy-cards_bridge_lang.idml"),
+    ("eop_ver_threat-denialofsvc-cards_tarot_lang.idml",   "eop_ver_threat-denialofsvc-cards_bridge_lang.idml"),
+    ("eop_ver_threat-elevofpriv-cards_tarot_lang.idml",    "eop_ver_threat-elevofpriv-cards_bridge_lang.idml"),
+    ("eop_ver_threat-infodisclosure-cards_tarot_lang.idml","eop_ver_threat-infodisclosure-cards_bridge_lang.idml"),
+    ("eop_ver_threat-repudation-cards_tarot_lang.idml",    "eop_ver_threat-repudation-cards_bridge_lang.idml"),
+    ("eop_ver_threat-spoofing-cards_tarot_lang.idml",      "eop_ver_threat-spoofing-cards_bridge_lang.idml"),
+    ("eop_ver_threat-tampering-cards_tarot_lang.idml",     "eop_ver_threat-tampering-cards_bridge_lang.idml"),
+    ("eop_ver_deck_tarot_lang.idml",                       "eop_ver_deck_bridge_lang.idml"),
+]
+
+# ---------------------------------------------------------------------------
+# Reference transformation derived from cards tarot → bridge diff
+# ---------------------------------------------------------------------------
+
+def _fmt(v: float) -> str:
+    """Format a coordinate/size value, stripping insignificant trailing zeros."""
+    s = f"{v:.6f}".rstrip("0").rstrip(".")
+    return s
+
+
+def _scale_number(text: str, factor: float) -> str:
+    """Scale a single numeric string by factor."""
+    try:
+        return _fmt(float(text) * factor)
+    except ValueError:
+        return text
+
+
+def _scale_pair(pair_str: str, sx: float, sy: float) -> str:
+    """Scale a 'x y' coordinate pair."""
+    parts = pair_str.split()
+    if len(parts) != 2:
+        return pair_str
+    return f"{_scale_number(parts[0], sx)} {_scale_number(parts[1], sy)}"
+
+
+def _scale_4tuple(bounds_str: str) -> str:
+    """Scale a 'top left bottom right' bounds string (page bounds use H/W)."""
+    parts = bounds_str.split()
+    if len(parts) != 4:
+        return bounds_str
+    top    = _scale_number(parts[0], SCALE_H)
+    left   = _scale_number(parts[1], SCALE_W)
+    bottom = _scale_number(parts[2], SCALE_H)
+    right  = _scale_number(parts[3], SCALE_W)
+    return f"{top} {left} {bottom} {right}"
+
+
+def _rewrite_attr(xml: str, attr: str, new_val: str) -> str:
+    """Replace the value of a specific XML attribute (first occurrence only)."""
+    pat = re.compile(rf'\b{re.escape(attr)}="([^"]*)"')
+    return pat.sub(f'{attr}="{new_val}"', xml, count=1)
+
+
+def _rewrite_attr_all(xml: str, attr: str, transformer) -> str:
+    """Replace every occurrence of an XML attribute using transformer(value)."""
+    def replace(m: re.Match) -> str:
+        return f'{attr}="{transformer(m.group(1))}"'
+    return re.sub(rf'\b{re.escape(attr)}="([^"]*)"', replace, xml)
+
+
+# ---------------------------------------------------------------------------
+# Per-file transformation helpers
+# ---------------------------------------------------------------------------
+
+def _transform_preferences(xml: str) -> str:
+    """Scale DocumentPreference page size and bleed in Resources/Preferences.xml."""
+    xml = _rewrite_attr(xml, "PageHeight", _fmt(BRIDGE_H))
+    xml = _rewrite_attr(xml, "PageWidth",  _fmt(BRIDGE_W))
+    for bleed_attr in (
+        "DocumentBleedTopOffset", "DocumentBleedBottomOffset",
+        "DocumentBleedInsideOrLeftOffset", "DocumentBleedOutsideOrRightOffset",
+    ):
+        xml = _rewrite_attr(xml, bleed_attr, _fmt(BLEED_BRIDGE))
+    return xml
+
+
+def _scale_point_size(v: str) -> str:
+    """Scale a PointSize value using the height ratio (tarot is portrait)."""
+    try:
+        return _fmt(float(v) * SCALE_H)
+    except ValueError:
+        return v
+
+
+def _scale_stroke_weight(v: str) -> str:
+    try:
+        return _fmt(float(v) * SCALE_H)
+    except ValueError:
+        return v
+
+
+def _transform_styles(xml: str) -> str:
+    """Rescale point sizes, leading, stroke weights in Resources/Styles.xml."""
+    # Regenerate StyleUniqueId so InDesign treats bridge as a distinct document
+    def new_uuid(_: str) -> str:
+        return str(uuid.uuid4())
+
+    xml = _rewrite_attr_all(xml, "StyleUniqueId", new_uuid)
+
+    # Scale numeric size attributes
+    for attr in ("PointSize", "RuleAboveLineWeight", "RuleBelowLineWeight",
+                 "StrokeWeight", "KerningValue"):
+        def scale_val(v: str, _attr=attr) -> str:  # noqa: E731
+            if v in ("1e+11",):   # special InDesign sentinel – leave alone
+                return v
+            try:
+                return _fmt(float(v) * SCALE_H)
+            except ValueError:
+                return v
+        xml = _rewrite_attr_all(xml, attr, scale_val)
+
+    return xml
+
+
+def _scale_item_transform(transform_str: str) -> str:
+    """Scale the translation components (indices 4 & 5) of a 6-value matrix."""
+    parts = transform_str.split()
+    if len(parts) != 6:
+        return transform_str
+    try:
+        # matrix: a b c d tx ty – scale tx by SCALE_W, ty by SCALE_H
+        tx = float(parts[4]) * SCALE_W
+        ty = float(parts[5]) * SCALE_H
+        parts[4] = _fmt(tx)
+        parts[5] = _fmt(ty)
+    except ValueError:
+        pass
+    return " ".join(parts)
+
+
+def _transform_spread(xml: str) -> str:
+    """Rescale Spread and MasterSpread layout XML."""
+    # Scale ItemTransform translations in Spread/MasterSpread elements
+    xml = _rewrite_attr_all(xml, "ItemTransform", _scale_item_transform)
+
+    # Scale GeometricBounds (top left bottom right)
+    xml = _rewrite_attr_all(xml, "GeometricBounds", _scale_4tuple)
+
+    # Scale Anchor / LeftDirection / RightDirection (x y pairs)
+    for coord_attr in ("Anchor", "LeftDirection", "RightDirection"):
+        xml = _rewrite_attr_all(xml, coord_attr,
+                                lambda v: _scale_pair(v, SCALE_W, SCALE_H))
+
+    # Scale StrokeWeight
+    xml = _rewrite_attr_all(xml, "StrokeWeight",
+                            lambda v: _scale_number(v, SCALE_H))
+
+    # Scale MarginPreference columns / ColumnGutter (use SCALE_W)
+    for margin_attr in ("Top", "Bottom", "Left", "Right", "ColumnGutter"):
+        xml = _rewrite_attr_all(xml, margin_attr,
+                                lambda v: _scale_number(v, SCALE_W))
+
+    # Scale GridDataInformation PointSize
+    xml = _rewrite_attr_all(xml, "PointSize", _scale_point_size)
+
+    # Scale TextColumnFixedWidth / TextColumnGutter / MinimumFirstBaselineOffset
+    for tf_attr in ("TextColumnFixedWidth", "TextColumnGutter"):
+        xml = _rewrite_attr_all(xml, tf_attr,
+                                lambda v: _scale_number(v, SCALE_W))
+
+    # Scale ColumnsPositions (space-separated list)
+    def scale_cols(v: str) -> str:
+        return " ".join(_scale_number(x, SCALE_W) for x in v.split())
+    xml = _rewrite_attr_all(xml, "ColumnsPositions", scale_cols)
+
+    # Scale GradientFillStart / GradientFillLength / GradientStrokeStart
+    for gattr in ("GradientFillStart", "GradientStrokeStart"):
+        xml = _rewrite_attr_all(xml, gattr,
+                                lambda v: _scale_pair(v, SCALE_W, SCALE_H))
+    for gattr in ("GradientFillLength", "GradientStrokeLength",
+                  "GradientFillHiliteLength", "GradientStrokeHiliteLength"):
+        xml = _rewrite_attr_all(xml, gattr,
+                                lambda v: _scale_number(v, SCALE_H))
+
+    return xml
+
+
+def _transform_story(xml: str) -> str:
+    """Scale Leading values in Stories/*.xml."""
+    def scale_leading(m: re.Match) -> str:
+        tag_open = m.group(1)
+        value    = m.group(2)
+        tag_close = m.group(3)
+        try:
+            scaled = _fmt(float(value) * SCALE_H)
+        except ValueError:
+            scaled = value
+        return f"{tag_open}{scaled}{tag_close}"
+
+    return re.sub(
+        r'(<Leading[^>]*>)([^<]+)(</Leading>)',
+        scale_leading,
+        xml,
+    )
+
+
+def _transform_metadata(xml: str) -> str:
+    """Update document IDs and timestamps in META-INF/metadata.xml."""
+    # New DocumentID
+    new_id = f"xmp.did:{uuid.uuid4()}"
+    xml = re.sub(
+        r'(<xmpMM:DocumentID>)[^<]*(</xmpMM:DocumentID>)',
+        rf'\g<1>{new_id}\g<2>',
+        xml,
+    )
+    # Leave timestamps as-is (they reflect original InDesign save time)
+    return xml
+
+
+# ---------------------------------------------------------------------------
+# Package rewriter
+# ---------------------------------------------------------------------------
+
+def _rewrite_package(src_path: Path, dst_path: Path) -> None:
+    """Read src_path, apply transformations, write result to dst_path."""
+    replacements: Dict[str, bytes] = {}
+
+    with zipfile.ZipFile(src_path) as zin:
+        members = zin.infolist()
+        for info in members:
+            raw = zin.read(info)
+            name = info.filename
+
+            if name == "Resources/Preferences.xml":
+                text = raw.decode("utf-8")
+                replacements[name] = _transform_preferences(text).encode("utf-8")
+
+            elif name == "Resources/Styles.xml":
+                text = raw.decode("utf-8")
+                replacements[name] = _transform_styles(text).encode("utf-8")
+
+            elif name == "META-INF/metadata.xml":
+                text = raw.decode("utf-8")
+                replacements[name] = _transform_metadata(text).encode("utf-8")
+
+            elif name.startswith(("Spreads/", "MasterSpreads/")):
+                text = raw.decode("utf-8")
+                replacements[name] = _transform_spread(text).encode("utf-8")
+
+            elif name.startswith("Stories/"):
+                text = raw.decode("utf-8")
+                replacements[name] = _transform_story(text).encode("utf-8")
+
+        # Write output archive
+        tmp = dst_path.parent / (dst_path.name + ".tmp")
+        try:
+            with zipfile.ZipFile(src_path) as zsrc, \
+                 zipfile.ZipFile(tmp, "w") as zout:
+                for info in zsrc.infolist():
+                    data = replacements.get(info.filename)
+                    if data is not None:
+                        zout.writestr(info, data)
+                    else:
+                        zout.writestr(info, zsrc.read(info))
+            shutil.move(tmp, dst_path)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    for tarot_name, bridge_name in TEMPLATE_PAIRS:
+        src = TEMPLATES_DIR / tarot_name
+        dst = TEMPLATES_DIR / bridge_name
+
+        if not src.exists():
+            print(f"[SKIP] Source not found: {src}")
+            continue
+
+        print(f"[GEN ] {tarot_name} -> {bridge_name}", end=" ... ", flush=True)
+        _rewrite_package(src, dst)
+        print(f"OK ({dst.stat().st_size:,} bytes)")
+
+    print("\nAll templates generated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_eop_bridge_templates.py
+++ b/scripts/generate_eop_bridge_templates.py
@@ -15,17 +15,16 @@ from __future__ import annotations
 
 import re
 import shutil
-import tempfile
 import uuid
 import zipfile
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Callable, Dict, Tuple, Match
 
 # ---------------------------------------------------------------------------
 # Card-size constants (points)
 # ---------------------------------------------------------------------------
-TAROT_H = 342.0   # height (taller dimension)
-TAROT_W = 198.0   # width
+TAROT_H = 342.0  # height (taller dimension)
+TAROT_W = 198.0  # width
 BRIDGE_H = 246.614
 BRIDGE_W = 158.74
 BLEED_TAROT = 9.0
@@ -38,22 +37,23 @@ TEMPLATES_DIR = Path("resources/templates")
 
 # Source → Target pairs (tarot → bridge)
 TEMPLATE_PAIRS: list[Tuple[str, str]] = [
-    ("eop_ver_about_tarot_lang.idml",                      "eop_ver_about_bridge_lang.idml"),
-    ("eop_ver_instructions1_tarot_lang.idml",              "eop_ver_instructions1_bridge_lang.idml"),
-    ("eop_ver_instructions2_tarot_lang.idml",              "eop_ver_instructions2_bridge_lang.idml"),
-    ("eop_ver_strategy-cards_tarot_lang.idml",             "eop_ver_strategy-cards_bridge_lang.idml"),
-    ("eop_ver_threat-denialofsvc-cards_tarot_lang.idml",   "eop_ver_threat-denialofsvc-cards_bridge_lang.idml"),
-    ("eop_ver_threat-elevofpriv-cards_tarot_lang.idml",    "eop_ver_threat-elevofpriv-cards_bridge_lang.idml"),
-    ("eop_ver_threat-infodisclosure-cards_tarot_lang.idml","eop_ver_threat-infodisclosure-cards_bridge_lang.idml"),
-    ("eop_ver_threat-repudation-cards_tarot_lang.idml",    "eop_ver_threat-repudation-cards_bridge_lang.idml"),
-    ("eop_ver_threat-spoofing-cards_tarot_lang.idml",      "eop_ver_threat-spoofing-cards_bridge_lang.idml"),
-    ("eop_ver_threat-tampering-cards_tarot_lang.idml",     "eop_ver_threat-tampering-cards_bridge_lang.idml"),
-    ("eop_ver_deck_tarot_lang.idml",                       "eop_ver_deck_bridge_lang.idml"),
+    ("eop_ver_about_tarot_lang.idml", "eop_ver_about_bridge_lang.idml"),
+    ("eop_ver_instructions1_tarot_lang.idml", "eop_ver_instructions1_bridge_lang.idml"),
+    ("eop_ver_instructions2_tarot_lang.idml", "eop_ver_instructions2_bridge_lang.idml"),
+    ("eop_ver_strategy-cards_tarot_lang.idml", "eop_ver_strategy-cards_bridge_lang.idml"),
+    ("eop_ver_threat-denialofsvc-cards_tarot_lang.idml", "eop_ver_threat-denialofsvc-cards_bridge_lang.idml"),
+    ("eop_ver_threat-elevofpriv-cards_tarot_lang.idml", "eop_ver_threat-elevofpriv-cards_bridge_lang.idml"),
+    ("eop_ver_threat-infodisclosure-cards_tarot_lang.idml", "eop_ver_threat-infodisclosure-cards_bridge_lang.idml"),
+    ("eop_ver_threat-repudation-cards_tarot_lang.idml", "eop_ver_threat-repudation-cards_bridge_lang.idml"),
+    ("eop_ver_threat-spoofing-cards_tarot_lang.idml", "eop_ver_threat-spoofing-cards_bridge_lang.idml"),
+    ("eop_ver_threat-tampering-cards_tarot_lang.idml", "eop_ver_threat-tampering-cards_bridge_lang.idml"),
+    ("eop_ver_deck_tarot_lang.idml", "eop_ver_deck_bridge_lang.idml"),
 ]
 
 # ---------------------------------------------------------------------------
 # Reference transformation derived from cards tarot → bridge diff
 # ---------------------------------------------------------------------------
+
 
 def _fmt(v: float) -> str:
     """Format a coordinate/size value, stripping insignificant trailing zeros."""
@@ -82,10 +82,10 @@ def _scale_4tuple(bounds_str: str) -> str:
     parts = bounds_str.split()
     if len(parts) != 4:
         return bounds_str
-    top    = _scale_number(parts[0], SCALE_H)
-    left   = _scale_number(parts[1], SCALE_W)
+    top = _scale_number(parts[0], SCALE_H)
+    left = _scale_number(parts[1], SCALE_W)
     bottom = _scale_number(parts[2], SCALE_H)
-    right  = _scale_number(parts[3], SCALE_W)
+    right = _scale_number(parts[3], SCALE_W)
     return f"{top} {left} {bottom} {right}"
 
 
@@ -95,10 +95,12 @@ def _rewrite_attr(xml: str, attr: str, new_val: str) -> str:
     return pat.sub(f'{attr}="{new_val}"', xml, count=1)
 
 
-def _rewrite_attr_all(xml: str, attr: str, transformer) -> str:
+def _rewrite_attr_all(xml: str, attr: str, transformer: Callable[[str], str]) -> str:
     """Replace every occurrence of an XML attribute using transformer(value)."""
-    def replace(m: re.Match) -> str:
+
+    def replace(m: Match[str]) -> str:
         return f'{attr}="{transformer(m.group(1))}"'
+
     return re.sub(rf'\b{re.escape(attr)}="([^"]*)"', replace, xml)
 
 
@@ -106,13 +108,16 @@ def _rewrite_attr_all(xml: str, attr: str, transformer) -> str:
 # Per-file transformation helpers
 # ---------------------------------------------------------------------------
 
+
 def _transform_preferences(xml: str) -> str:
     """Scale DocumentPreference page size and bleed in Resources/Preferences.xml."""
     xml = _rewrite_attr(xml, "PageHeight", _fmt(BRIDGE_H))
-    xml = _rewrite_attr(xml, "PageWidth",  _fmt(BRIDGE_W))
+    xml = _rewrite_attr(xml, "PageWidth", _fmt(BRIDGE_W))
     for bleed_attr in (
-        "DocumentBleedTopOffset", "DocumentBleedBottomOffset",
-        "DocumentBleedInsideOrLeftOffset", "DocumentBleedOutsideOrRightOffset",
+        "DocumentBleedTopOffset",
+        "DocumentBleedBottomOffset",
+        "DocumentBleedInsideOrLeftOffset",
+        "DocumentBleedOutsideOrRightOffset",
     ):
         xml = _rewrite_attr(xml, bleed_attr, _fmt(BLEED_BRIDGE))
     return xml
@@ -135,6 +140,7 @@ def _scale_stroke_weight(v: str) -> str:
 
 def _transform_styles(xml: str) -> str:
     """Rescale point sizes, leading, stroke weights in Resources/Styles.xml."""
+
     # Regenerate StyleUniqueId so InDesign treats bridge as a distinct document
     def new_uuid(_: str) -> str:
         return str(uuid.uuid4())
@@ -142,15 +148,16 @@ def _transform_styles(xml: str) -> str:
     xml = _rewrite_attr_all(xml, "StyleUniqueId", new_uuid)
 
     # Scale numeric size attributes
-    for attr in ("PointSize", "RuleAboveLineWeight", "RuleBelowLineWeight",
-                 "StrokeWeight", "KerningValue"):
-        def scale_val(v: str, _attr=attr) -> str:  # noqa: E731
-            if v in ("1e+11",):   # special InDesign sentinel – leave alone
+    for attr in ("PointSize", "RuleAboveLineWeight", "RuleBelowLineWeight", "StrokeWeight", "KerningValue"):
+
+        def scale_val(v: str, _attr: str = attr) -> str:  # noqa: E731
+            if v in ("1e+11",):  # special InDesign sentinel – leave alone
                 return v
             try:
                 return _fmt(float(v) * SCALE_H)
             except ValueError:
                 return v
+
         xml = _rewrite_attr_all(xml, attr, scale_val)
 
     return xml
@@ -182,48 +189,48 @@ def _transform_spread(xml: str) -> str:
 
     # Scale Anchor / LeftDirection / RightDirection (x y pairs)
     for coord_attr in ("Anchor", "LeftDirection", "RightDirection"):
-        xml = _rewrite_attr_all(xml, coord_attr,
-                                lambda v: _scale_pair(v, SCALE_W, SCALE_H))
+        xml = _rewrite_attr_all(xml, coord_attr, lambda v: _scale_pair(v, SCALE_W, SCALE_H))
 
     # Scale StrokeWeight
-    xml = _rewrite_attr_all(xml, "StrokeWeight",
-                            lambda v: _scale_number(v, SCALE_H))
+    xml = _rewrite_attr_all(xml, "StrokeWeight", lambda v: _scale_number(v, SCALE_H))
 
     # Scale MarginPreference columns / ColumnGutter (use SCALE_W)
     for margin_attr in ("Top", "Bottom", "Left", "Right", "ColumnGutter"):
-        xml = _rewrite_attr_all(xml, margin_attr,
-                                lambda v: _scale_number(v, SCALE_W))
+        xml = _rewrite_attr_all(xml, margin_attr, lambda v: _scale_number(v, SCALE_W))
 
     # Scale GridDataInformation PointSize
     xml = _rewrite_attr_all(xml, "PointSize", _scale_point_size)
 
     # Scale TextColumnFixedWidth / TextColumnGutter / MinimumFirstBaselineOffset
     for tf_attr in ("TextColumnFixedWidth", "TextColumnGutter"):
-        xml = _rewrite_attr_all(xml, tf_attr,
-                                lambda v: _scale_number(v, SCALE_W))
+        xml = _rewrite_attr_all(xml, tf_attr, lambda v: _scale_number(v, SCALE_W))
 
     # Scale ColumnsPositions (space-separated list)
     def scale_cols(v: str) -> str:
         return " ".join(_scale_number(x, SCALE_W) for x in v.split())
+
     xml = _rewrite_attr_all(xml, "ColumnsPositions", scale_cols)
 
     # Scale GradientFillStart / GradientFillLength / GradientStrokeStart
     for gattr in ("GradientFillStart", "GradientStrokeStart"):
-        xml = _rewrite_attr_all(xml, gattr,
-                                lambda v: _scale_pair(v, SCALE_W, SCALE_H))
-    for gattr in ("GradientFillLength", "GradientStrokeLength",
-                  "GradientFillHiliteLength", "GradientStrokeHiliteLength"):
-        xml = _rewrite_attr_all(xml, gattr,
-                                lambda v: _scale_number(v, SCALE_H))
+        xml = _rewrite_attr_all(xml, gattr, lambda v: _scale_pair(v, SCALE_W, SCALE_H))
+    for gattr in (
+        "GradientFillLength",
+        "GradientStrokeLength",
+        "GradientFillHiliteLength",
+        "GradientStrokeHiliteLength",
+    ):
+        xml = _rewrite_attr_all(xml, gattr, lambda v: _scale_number(v, SCALE_H))
 
     return xml
 
 
 def _transform_story(xml: str) -> str:
     """Scale Leading values in Stories/*.xml."""
-    def scale_leading(m: re.Match) -> str:
+
+    def scale_leading(m: Match[str]) -> str:
         tag_open = m.group(1)
-        value    = m.group(2)
+        value = m.group(2)
         tag_close = m.group(3)
         try:
             scaled = _fmt(float(value) * SCALE_H)
@@ -232,7 +239,7 @@ def _transform_story(xml: str) -> str:
         return f"{tag_open}{scaled}{tag_close}"
 
     return re.sub(
-        r'(<Leading[^>]*>)([^<]+)(</Leading>)',
+        r"(<Leading[^>]*>)([^<]+)(</Leading>)",
         scale_leading,
         xml,
     )
@@ -243,8 +250,8 @@ def _transform_metadata(xml: str) -> str:
     # New DocumentID
     new_id = f"xmp.did:{uuid.uuid4()}"
     xml = re.sub(
-        r'(<xmpMM:DocumentID>)[^<]*(</xmpMM:DocumentID>)',
-        rf'\g<1>{new_id}\g<2>',
+        r"(<xmpMM:DocumentID>)[^<]*(</xmpMM:DocumentID>)",
+        rf"\g<1>{new_id}\g<2>",
         xml,
     )
     # Leave timestamps as-is (they reflect original InDesign save time)
@@ -254,6 +261,7 @@ def _transform_metadata(xml: str) -> str:
 # ---------------------------------------------------------------------------
 # Package rewriter
 # ---------------------------------------------------------------------------
+
 
 def _rewrite_package(src_path: Path, dst_path: Path) -> None:
     """Read src_path, apply transformations, write result to dst_path."""
@@ -288,8 +296,7 @@ def _rewrite_package(src_path: Path, dst_path: Path) -> None:
         # Write output archive
         tmp = dst_path.parent / (dst_path.name + ".tmp")
         try:
-            with zipfile.ZipFile(src_path) as zsrc, \
-                 zipfile.ZipFile(tmp, "w") as zout:
+            with zipfile.ZipFile(src_path) as zsrc, zipfile.ZipFile(tmp, "w") as zout:
                 for info in zsrc.infolist():
                     data = replacements.get(info.filename)
                     if data is not None:
@@ -305,6 +312,7 @@ def _rewrite_package(src_path: Path, dst_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     for tarot_name, bridge_name in TEMPLATE_PAIRS:

--- a/scripts/scale_idml_guides.py
+++ b/scripts/scale_idml_guides.py
@@ -1,0 +1,502 @@
+"""Scale and validate layout details in IDML packages.
+
+Usage:
+    python scripts/scale_idml_guides.py SOURCE.idml TARGET.idml
+    python scripts/scale_idml_guides.py SOURCE.idml TARGET.idml --check-printable-guides
+    python scripts/scale_idml_guides.py SOURCE.idml TARGET.idml --check-artwork-scaling
+
+Without a flag, guide locations are independently scaled to each matched target
+page. Page matching uses the page name and whether the member is a spread or
+master spread, while guides are matched by their order within a page.
+
+``--check-printable-guides`` and ``--check-artwork-scaling`` do not modify the
+target. All other flags update the target IDML in place, so make a copy before
+using a fitting or card-text operation. Card-text flags target EoP bridge-card
+templates and should not be applied to unrelated templates.
+
+The utility intentionally edits IDML package XML as text. This preserves
+InDesign-specific namespace declarations and member ordering while changing
+only the targeted attributes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Match, Tuple
+
+ATTRIBUTE_PATTERN = re.compile(r'([\w:]+)="([^"]*)"')
+GUIDE_PATTERN = re.compile(r"<Guide\b[^>]*(?:/>|>.*?</Guide>)", re.DOTALL)
+PAGE_PATTERN = re.compile(r'<Page\b[^>]*\bGeometricBounds="([^"]+)"[^>]*\bName="([^"]+)"[^>]*>')
+TEXT_FRAME_PATTERN = re.compile(r"<TextFrame\b(?P<attributes>[^>]*)>(?P<content>.*?)</TextFrame>", re.DOTALL)
+PATH_POINT_PATTERN = re.compile(r"<PathPointType\b[^>]*/>")
+BODY_TEXT_X = 0.6024 * 72.0
+BODY_TEXT_Y = 0.7392 * 72.0
+BODY_TEXT_LEADING = 11.04 * 246.614 / 342.0
+BODY_TEXT_WIDTH_INCREASE = 6.0
+TITLE_HEIGHT_INCREASE = 4.0
+TITLE_WIDTH_REDUCTION = 4.0
+GUIDE_TOLERANCE = 0.00001
+
+
+def get_attributes(match: Match[str]) -> Dict[str, str]:
+    """Return XML attributes from a complete element match."""
+    return dict(ATTRIBUTE_PATTERN.findall(match.group(0)))
+
+
+def set_attribute(xml: str, name: str, value: str) -> str:
+    """Set an existing XML attribute without reparsing InDesign XML."""
+    pattern = re.compile(rf'\b{re.escape(name)}="[^"]*"')
+    replacement = f'{name}="{value}"'
+    if pattern.search(xml):
+        return pattern.sub(replacement, xml, count=1)
+    return xml.replace("/>", f" {replacement}/>", 1)
+
+
+def format_number(value: float) -> str:
+    """Format an IDML coordinate without insignificant trailing zeros."""
+    return f"{value:.6f}".rstrip("0").rstrip(".")
+
+
+def get_page_geometry(member_name: str, xml: str) -> Tuple[str, float, float]:
+    """Return stable page name plus height and width for an IDML member."""
+    match = PAGE_PATTERN.search(xml)
+    if match is None:
+        raise ValueError(f"The IDML member has no named page: {member_name}")
+    bounds = [float(value) for value in match.group(1).split()]
+    if len(bounds) != 4:
+        raise ValueError(f"Invalid page bounds in: {member_name}")
+    return match.group(2), bounds[2] - bounds[0], bounds[3] - bounds[1]
+
+
+def get_page_key(member_name: str, xml: str) -> Tuple[str, str]:
+    """Return a stable page identity independent of InDesign object IDs."""
+    page_name, _, _ = get_page_geometry(member_name, xml)
+    return member_name.split("/", 1)[0], page_name
+
+
+def read_xml_members(path: Path, prefixes: Tuple[str, ...] = ("Spreads/", "MasterSpreads/")) -> Dict[str, str]:
+    """Read package layout members as UTF-8 XML."""
+    with zipfile.ZipFile(path) as archive:
+        return {
+            member.filename: archive.read(member).decode("utf-8")
+            for member in archive.infolist()
+            if member.filename.endswith(".xml") and member.filename.startswith(prefixes)
+        }
+
+
+def read_stories(path: Path) -> Dict[str, str]:
+    """Read stories keyed by InDesign story identifier."""
+    with zipfile.ZipFile(path) as archive:
+        return {
+            Path(member.filename).stem.removeprefix("Story_"): archive.read(member).decode("utf-8")
+            for member in archive.infolist()
+            if member.filename.startswith("Stories/Story_") and member.filename.endswith(".xml")
+        }
+
+
+def rewrite_package(path: Path, replacements: Dict[str, str]) -> None:
+    """Atomically replace selected IDML members, preserving all other entries."""
+    if not replacements:
+        return
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".idml", dir=path.parent) as temporary_file:
+        temporary_path = Path(temporary_file.name)
+    try:
+        with zipfile.ZipFile(path) as source, zipfile.ZipFile(temporary_path, "w") as target:
+            for member in source.infolist():
+                content = replacements.get(member.filename)
+                if content is None:
+                    target.writestr(member, source.read(member))
+                else:
+                    target.writestr(member, content.encode("utf-8"))
+        shutil.move(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def guide_location(attributes: Dict[str, str]) -> float:
+    """Return an IDML guide's numeric location."""
+    try:
+        return float(attributes["Location"])
+    except KeyError as error:
+        raise ValueError("Guide is missing Location") from error
+
+
+def guide_limit(attributes: Dict[str, str], height: float, width: float) -> float:
+    """Return the page dimension applicable to a guide orientation."""
+    orientation = attributes.get("Orientation", "Horizontal")
+    return width if orientation == "Vertical" else height
+
+
+def scale_guides(source: Path, target: Path) -> int:
+    """Scale source guide locations into matched target pages by guide order."""
+    source_members = read_xml_members(source)
+    target_members = read_xml_members(target)
+    source_pages = {get_page_key(member_name, xml): (member_name, xml) for member_name, xml in source_members.items()}
+    replacements: Dict[str, str] = {}
+    updated_guides = 0
+
+    for member_name, target_xml in target_members.items():
+        source_entry = source_pages.get(get_page_key(member_name, target_xml))
+        if source_entry is None:
+            raise ValueError(f"Missing source page for: {member_name}")
+        source_member_name, source_xml = source_entry
+        _, source_height, source_width = get_page_geometry(source_member_name, source_xml)
+        _, target_height, target_width = get_page_geometry(member_name, target_xml)
+        source_guides = [get_attributes(match) for match in GUIDE_PATTERN.finditer(source_xml)]
+        target_guides = list(GUIDE_PATTERN.finditer(target_xml))
+        if len(source_guides) != len(target_guides):
+            raise ValueError(f"Guide count differs for page: {member_name}")
+        guide_index = 0
+
+        def replace_guide(match: Match[str]) -> str:
+            nonlocal guide_index, updated_guides
+            source_guide = source_guides[guide_index]
+            guide_index += 1
+            source_limit = guide_limit(source_guide, source_height, source_width)
+            target_attributes = get_attributes(match)
+            target_limit = guide_limit(target_attributes, target_height, target_width)
+            scaled_location = guide_location(source_guide) * target_limit / source_limit
+            updated_guides += 1
+            return set_attribute(match.group(0), "Location", format_number(scaled_location))
+
+        replacements[member_name] = GUIDE_PATTERN.sub(replace_guide, target_xml)
+
+    rewrite_package(target, replacements)
+    return updated_guides
+
+
+def validate_guides(target: Path) -> Tuple[int, int]:
+    """Validate that every guide lies within its corresponding page boundary."""
+    checked = 0
+    invalid = 0
+    for member_name, xml in read_xml_members(target).items():
+        _, height, width = get_page_geometry(member_name, xml)
+        for match in GUIDE_PATTERN.finditer(xml):
+            attributes = get_attributes(match)
+            location = guide_location(attributes)
+            limit = guide_limit(attributes, height, width)
+            checked += 1
+            if location < -GUIDE_TOLERANCE or location > limit + GUIDE_TOLERANCE:
+                invalid += 1
+    return checked, invalid
+
+
+def fit_guides_to_trim(target: Path) -> int:
+    """Clamp guides to the printable page boundary."""
+    replacements: Dict[str, str] = {}
+    changed = 0
+    for member_name, xml in read_xml_members(target).items():
+        _, height, width = get_page_geometry(member_name, xml)
+
+        def replace_guide(match: Match[str]) -> str:
+            nonlocal changed
+            attributes = get_attributes(match)
+            location = guide_location(attributes)
+            fitted = min(max(location, 0.0), guide_limit(attributes, height, width))
+            if abs(fitted - location) <= GUIDE_TOLERANCE:
+                return match.group(0)
+            changed += 1
+            return set_attribute(match.group(0), "Location", format_number(fitted))
+
+        replacements[member_name] = GUIDE_PATTERN.sub(replace_guide, xml)
+    rewrite_package(target, replacements)
+    return changed
+
+
+def replace_path_points(content: str, transform: Callable[[Dict[str, str]], Dict[str, str]]) -> str:
+    """Apply a coordinate transform to each path point in a text frame."""
+
+    def replace_point(match: Match[str]) -> str:
+        attributes = transform(get_attributes(match))
+        point = match.group(0)
+        for name, value in attributes.items():
+            point = set_attribute(point, name, value)
+        return point
+
+    return PATH_POINT_PATTERN.sub(replace_point, content)
+
+
+def update_text_frames(target: Path, eligible: Callable[[str], bool], transform: Callable[[str], str]) -> int:
+    """Transform eligible spread text frames and return their count."""
+    stories = read_stories(target)
+    replacements: Dict[str, str] = {}
+    updated = 0
+    for member_name, xml in read_xml_members(target, ("Spreads/",)).items():
+
+        def replace_frame(match: Match[str]) -> str:
+            nonlocal updated
+            attributes = get_attributes(match)
+            if not eligible(stories.get(attributes.get("ParentStory", ""), "")):
+                return match.group(0)
+            updated += 1
+            return match.group(0).replace(match.group("content"), transform(match.group("content")), 1)
+
+        replacements[member_name] = TEXT_FRAME_PATTERN.sub(replace_frame, xml)
+    rewrite_package(target, replacements)
+    return updated
+
+
+def straighten_card_text_frames(target: Path) -> int:
+    """Square body and title frames by aligning Bezier handles with anchors."""
+
+    def straighten(content: str) -> str:
+        def transform(attributes: Dict[str, str]) -> Dict[str, str]:
+            anchor = attributes.get("Anchor")
+            if anchor:
+                attributes["LeftDirection"] = anchor
+                attributes["RightDirection"] = anchor
+            return attributes
+
+        return replace_path_points(content, transform)
+
+    return update_text_frames(target, lambda story: "_desc}" in story or "_suit}" in story, straighten)
+
+
+def widen_card_body_frames(target: Path) -> int:
+    """Extend each body text frame's right edge without moving its left edge."""
+
+    def widen(content: str) -> str:
+        points = list(PATH_POINT_PATTERN.finditer(content))
+        x_values = [float(get_attributes(point).get("Anchor", "0 0").split()[0]) for point in points]
+        if not x_values:
+            return content
+        right_edge = max(x_values)
+
+        def transform(attributes: Dict[str, str]) -> Dict[str, str]:
+            anchor = attributes.get("Anchor", "").split()
+            if len(anchor) == 2 and abs(float(anchor[0]) - right_edge) <= GUIDE_TOLERANCE:
+                anchor[0] = format_number(right_edge + BODY_TEXT_WIDTH_INCREASE)
+                attributes["Anchor"] = " ".join(anchor)
+                attributes["LeftDirection"] = attributes["Anchor"]
+                attributes["RightDirection"] = attributes["Anchor"]
+            return attributes
+
+        return replace_path_points(content, transform)
+
+    return update_text_frames(target, lambda story: "_desc}" in story, widen)
+
+
+def set_card_body_layout(target: Path) -> int:
+    """Set bridge body frames to the requested position and scaled leading."""
+    stories = read_stories(target)
+    replacements: Dict[str, str] = {}
+    for story_id, story in stories.items():
+        if "_desc}" not in story:
+            continue
+        updated_story = re.sub(
+            r'<Leading type="unit">[^<]+</Leading>',
+            f'<Leading type="unit">{BODY_TEXT_LEADING:.6f}</Leading>',
+            story,
+        )
+        if updated_story == story:
+            updated_story = updated_story.replace(
+                "</CharacterStyleRange>",
+                f'<Properties><Leading type="unit">{BODY_TEXT_LEADING:.6f}</Leading></Properties></CharacterStyleRange>',
+                1,
+            )
+        replacements[f"Stories/Story_{story_id}.xml"] = updated_story
+    rewrite_package(target, replacements)
+
+    def position(content: str) -> str:
+        points = list(PATH_POINT_PATTERN.finditer(content))
+        anchors = [get_attributes(point).get("Anchor", "0 0").split() for point in points]
+        if not anchors or any(len(anchor) != 2 for anchor in anchors):
+            return content
+        left = min(float(anchor[0]) for anchor in anchors)
+        top = min(float(anchor[1]) for anchor in anchors)
+
+        def transform(attributes: Dict[str, str]) -> Dict[str, str]:
+            anchor = attributes.get("Anchor", "").split()
+            if len(anchor) == 2:
+                x = float(anchor[0]) - left + BODY_TEXT_X
+                y = float(anchor[1]) - top + BODY_TEXT_Y
+                attributes["Anchor"] = f"{format_number(x)} {format_number(y)}"
+                attributes["LeftDirection"] = attributes["Anchor"]
+                attributes["RightDirection"] = attributes["Anchor"]
+            return attributes
+
+        return replace_path_points(content, transform)
+
+    return update_text_frames(target, lambda story: "_desc}" in story, position)
+
+
+def resize_card_title_boxes(target: Path, height_change: float = TITLE_HEIGHT_INCREASE) -> int:
+    """Increase title-frame height by moving their bottom path points."""
+
+    def resize(content: str) -> str:
+        points = list(PATH_POINT_PATTERN.finditer(content))
+        y_values = [float(get_attributes(point).get("Anchor", "0 0").split()[1]) for point in points]
+        if not y_values:
+            return content
+        bottom = max(y_values)
+
+        def transform(attributes: Dict[str, str]) -> Dict[str, str]:
+            anchor = attributes.get("Anchor", "").split()
+            if len(anchor) == 2 and abs(float(anchor[1]) - bottom) <= GUIDE_TOLERANCE:
+                anchor[1] = format_number(bottom + height_change)
+                attributes["Anchor"] = " ".join(anchor)
+                attributes["LeftDirection"] = attributes["Anchor"]
+                attributes["RightDirection"] = attributes["Anchor"]
+            return attributes
+
+        return replace_path_points(content, transform)
+
+    return update_text_frames(target, lambda story: "_suit}" in story, resize)
+
+
+def narrow_card_title_boxes(target: Path) -> int:
+    """Reduce title-frame width by moving their right path points inward."""
+
+    def narrow(content: str) -> str:
+        points = list(PATH_POINT_PATTERN.finditer(content))
+        x_values = [float(get_attributes(point).get("Anchor", "0 0").split()[0]) for point in points]
+        if not x_values:
+            return content
+        right = max(x_values)
+
+        def transform(attributes: Dict[str, str]) -> Dict[str, str]:
+            anchor = attributes.get("Anchor", "").split()
+            if len(anchor) == 2 and abs(float(anchor[0]) - right) <= GUIDE_TOLERANCE:
+                anchor[0] = format_number(right - TITLE_WIDTH_REDUCTION)
+                attributes["Anchor"] = " ".join(anchor)
+                attributes["LeftDirection"] = attributes["Anchor"]
+                attributes["RightDirection"] = attributes["Anchor"]
+            return attributes
+
+        return replace_path_points(content, transform)
+
+    return update_text_frames(target, lambda story: "_suit}" in story, narrow)
+
+
+def raise_card_titles(target: Path) -> int:
+    """Move title-frame geometry up by the recorded four-point title adjustment."""
+
+    def raise_frame(content: str) -> str:
+        def transform(attributes: Dict[str, str]) -> Dict[str, str]:
+            anchor = attributes.get("Anchor", "").split()
+            if len(anchor) == 2:
+                attributes["Anchor"] = f"{anchor[0]} {format_number(float(anchor[1]) - TITLE_HEIGHT_INCREASE)}"
+                attributes["LeftDirection"] = attributes["Anchor"]
+                attributes["RightDirection"] = attributes["Anchor"]
+            return attributes
+
+        return replace_path_points(content, transform)
+
+    return update_text_frames(target, lambda story: "_suit}" in story, raise_frame)
+
+
+def validate_artwork_scaling(source: Path, target: Path) -> Tuple[int, int]:
+    """Check that matched page geometry has positive, finite scaling ratios."""
+    source_pages = {get_page_key(name, xml): (name, xml) for name, xml in read_xml_members(source).items()}
+    checked = 0
+    invalid = 0
+    for member_name, target_xml in read_xml_members(target).items():
+        source_entry = source_pages.get(get_page_key(member_name, target_xml))
+        if source_entry is None:
+            invalid += 1
+            continue
+        _, source_xml = source_entry
+        _, source_height, source_width = get_page_geometry(member_name, source_xml)
+        _, target_height, target_width = get_page_geometry(member_name, target_xml)
+        checked += 1
+        if min(source_height, source_width, target_height, target_width) <= 0:
+            invalid += 1
+    return checked, invalid
+
+
+def fit_master_dielines(target: Path) -> int:
+    """Clamp master-spread guide/dieline positions to their page bounds."""
+    return fit_guides_to_trim(target)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the utility command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Scale and validate IDML guides and EoP card layout frames.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("source", type=Path, help="Source IDML package used as the scaling reference.")
+    parser.add_argument("target", type=Path, help="Target IDML package to update or validate.")
+    operation = parser.add_mutually_exclusive_group()
+    operation.add_argument(
+        "--check-printable-guides", action="store_true", help="Report target guides that lie outside their page."
+    )
+    operation.add_argument(
+        "--check-artwork-scaling",
+        action="store_true",
+        help="Validate that matched source and target pages have valid geometry.",
+    )
+    operation.add_argument(
+        "--fit-guides-to-trim", action="store_true", help="Clamp target spread and master-spread guides to page bounds."
+    )
+    operation.add_argument(
+        "--fit-master-dielines", action="store_true", help="Clamp target master-spread guides to page bounds."
+    )
+    operation.add_argument(
+        "--straighten-card-text", action="store_true", help="Square EoP body and title text-frame paths."
+    )
+    operation.add_argument(
+        "--set-card-body-layout", action="store_true", help="Set EoP bridge-card body frame position and leading."
+    )
+    operation.add_argument(
+        "--widen-card-body", action="store_true", help="Extend EoP bridge-card body-frame right edges by six points."
+    )
+    operation.add_argument(
+        "--resize-card-title-boxes", action="store_true", help="Increase EoP title-frame height by four points."
+    )
+    operation.add_argument(
+        "--narrow-card-title-boxes", action="store_true", help="Reduce EoP title-frame width by four points."
+    )
+    operation.add_argument(
+        "--raise-card-titles", action="store_true", help="Move EoP title-frame paths up by four points."
+    )
+    operation.add_argument(
+        "--adjust-card-text", action="store_true", help="Apply EoP bridge body layout and square its text frames."
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the selected layout operation."""
+    args = build_parser().parse_args()
+    if not args.source.is_file() or not args.target.is_file():
+        raise FileNotFoundError("Both source and target must be existing IDML files.")
+    if args.check_printable_guides:
+        checked, invalid = validate_guides(args.target)
+        print(f"Guides checked: {checked}; out of bounds: {invalid}")
+        return int(invalid > 0)
+    if args.check_artwork_scaling:
+        checked, invalid = validate_artwork_scaling(args.source, args.target)
+        print(f"Page scaling checked: {checked}; invalid: {invalid}")
+        return int(invalid > 0)
+    if args.fit_guides_to_trim:
+        print(f"Guides fitted: {fit_guides_to_trim(args.target)}")
+    elif args.fit_master_dielines:
+        print(f"Master guides fitted: {fit_master_dielines(args.target)}")
+    elif args.straighten_card_text:
+        print(f"Text frames straightened: {straighten_card_text_frames(args.target)}")
+    elif args.set_card_body_layout:
+        print(f"Body frames updated: {set_card_body_layout(args.target)}")
+    elif args.widen_card_body:
+        print(f"Body frames widened: {widen_card_body_frames(args.target)}")
+    elif args.resize_card_title_boxes:
+        print(f"Title boxes resized: {resize_card_title_boxes(args.target)}")
+    elif args.narrow_card_title_boxes:
+        print(f"Title boxes narrowed: {narrow_card_title_boxes(args.target)}")
+    elif args.raise_card_titles:
+        print(f"Title boxes raised: {raise_card_titles(args.target)}")
+    elif args.adjust_card_text:
+        set_card_body_layout(args.target)
+        print(f"Text frames straightened: {straighten_card_text_frames(args.target)}")
+    else:
+        print(f"Guides scaled: {scale_guides(args.source, args.target)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scale_idml_guides.py
+++ b/scripts/scale_idml_guides.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Match, Tuple
+from typing import Callable, Dict, Match, Tuple
 
 ATTRIBUTE_PATTERN = re.compile(r'([\w:]+)="([^"]*)"')
 GUIDE_PATTERN = re.compile(r"<Guide\b[^>]*(?:/>|>.*?</Guide>)", re.DOTALL)
@@ -294,9 +294,10 @@ def set_card_body_layout(target: Path) -> int:
             story,
         )
         if updated_story == story:
+            leading_prop = f'<Properties><Leading type="unit">{BODY_TEXT_LEADING:.6f}</Leading></Properties>'
             updated_story = updated_story.replace(
                 "</CharacterStyleRange>",
-                f'<Properties><Leading type="unit">{BODY_TEXT_LEADING:.6f}</Leading></Properties></CharacterStyleRange>',
+                f"{leading_prop}</CharacterStyleRange>",
                 1,
             )
         replacements[f"Stories/Story_{story_id}.xml"] = updated_story
@@ -461,7 +462,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> int:
+def main() -> int:  # noqa: C901
     """Run the selected layout operation."""
     args = build_parser().parse_args()
     if not args.source.is_file() or not args.target.is_file():

--- a/source/eop-mappings-5.0.yaml
+++ b/source/eop-mappings-5.0.yaml
@@ -17,7 +17,7 @@ meta:
     "instructions2",
     "deck"
     ]
-  templates: ["tarot"]
+  templates: ["tarot", "bridge"]
   languages: ["en", "es", "ru"]
 suits:
 - 


### PR DESCRIPTION
Fixes #3409

### Description

This PR adds the missing 11 Bridge layout templates for the Elevation of Privilege (EoP) edition by generating them from their Tarot counterparts.

All dimensions, guides, text frames, paths, font sizes, and stroke weights were proportionally scaled from Tarot (198×342pt) to Bridge (158.74×246.614pt), with out-of-bounds guides clamped to the trim size.

### Changes

* Added 11 generated `_bridge_lang.idml` templates.
* Added scripts for template generation and guide clamping.
* Updated `eop-mappings-5.0.yaml` to support the `"bridge"` template type.
* Updated CI to build, test, validate, and zip Bridge templates (EN + ES).

### PDF Review

Added `scripts/export_idml_to_pdf.jsx` for visual review.

To use it, place the script in InDesign's **Scripts > User** folder and run it. It will batch-export all 11 Bridge templates to `output/pdf_reviews/` using the High Quality Print preset.
