### PR TITLE
Fix: Replace Segoe with Selawik in EoP tarot IDML templates

### DIFF
--- a/resources/templates/eop_ver_instructions2_tarot_lang.idml
+++ b/resources/templates/eop_ver_instructions2_tarot_lang.idml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26300d8fe9b3848d7238094ca1d5bbe40b09fb186d23fa839b23bd9ed13211f8
-size 62382
+oid sha256:a250af28e11b2b51c4a56e14584fa514a44ab5cd213726a42a42356a9af9dfcb
+size 62951

--- a/resources/templates/eop_ver_strategy-cards_tarot_lang.idml
+++ b/resources/templates/eop_ver_strategy-cards_tarot_lang.idml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbca489a59a7850019b3d2b8182d2e49252d22851af962ff4a61c9b62960cee0
-size 81788
+oid sha256:16791c01a40126a1e288b8dadc39cc52a9d9f565cece15331a92148238cba82d
+size 82362


### PR DESCRIPTION
## Summary

Fixes #3425 — Font inconsistencies on EoP tarot layouts where **Segoe** was used instead of **Selawik**.

Two IDML template files had lingering Segoe font references in their style definitions, breaking visual consistency with the rest of the EoP tarot deck (e.g., `eop_ver_cards_tarot_lang.idml`, which correctly uses Selawik throughout).

## What changed

### `resources/templates/eop_ver_instructions2_tarot_lang.idml`
- **Styles.xml** — Replaced 9 `<AppliedFont>` references from `Segoe` → `Selawik`:
  - `ParagraphStyle/LIST` (the **list discs** called out in the issue)
  - `CharacterStyle/Titles`, `CharacterStyle/Identifier`, `CharacterStyle/RulesCopy`
  - `ParagraphStyle/Threat spacing` and 4 tabbed paragraph styles
- **Preferences.xml** — Replaced the default document font from `Segoe` → `Selawik`

### `resources/templates/eop_ver_strategy-cards_tarot_lang.idml`
- **Styles.xml** — Replaced 4 `<AppliedFont>` references from `Segoe` → `Selawik`:
  - `CharacterStyle/Titles`, `CharacterStyle/Identifier`, `CharacterStyle/RulesCopy` (the **guide labels** called out in the issue)
  - `ParagraphStyle/Threat spacing`
- **Preferences.xml** — Replaced the default document font from `Segoe` → `Selawik`
- **Fonts.xml** — Added `Selawik` font family declaration (Light, Semilight, Regular, Semibold, Bold) — this file previously had **no Selawik declaration at all**, which would have caused InDesign to flag a missing font

## How it was verified

- Extracted the repackaged IDML archives and confirmed:
  - **Zero** `Segoe` `AppliedFont` references remain in `Styles.xml` and `Preferences.xml` for both files
  - All style definitions (LIST, Titles, Identifier, RulesCopy, Threat spacing) now resolve to `Selawik`
  - `Selawik` font family is declared in `Fonts.xml` for both templates
  - IDML ZIP structure is valid (`mimetype` as the first uncompressed entry)
- Cross-checked against `eop_ver_cards_tarot_lang.idml` (the reference template) — both fixed files now match its Selawik-only pattern in style definitions

## Notes

- **Metadata-only** Segoe references (in `META-INF/metadata.xml`, `Spreads/*.xml` XMP blocks) were intentionally left unchanged — these are historical font-usage records written by InDesign and do not affect rendering. The reference `cards` template also retains these.
- The `Segoe` font family declaration in `Fonts.xml` was kept intact (it only declares font availability, not usage) — same pattern as the reference template.